### PR TITLE
PSByPassCLM direct bypass command error fix

### DIFF
--- a/windows/basic-powershell-for-pentesters/README.md
+++ b/windows/basic-powershell-for-pentesters/README.md
@@ -118,7 +118,7 @@ In current Windows that Bypass won't work but you can use[ **PSByPassCLM**](http
 #### Direct bypass:
 
 ```bash
-C:\Windows\Microsoft.NET\Framework64\v4.0.30319\InstallUtil.exe /logfile= /LogToConsole=true /revshell=true /U c:\temp\psby.exe
+C:\Windows\Microsoft.NET\Framework64\v4.0.30319\InstallUtil.exe /logfile= /LogToConsole=true /U c:\temp\psby.exe
 ```
 
 #### Reverse shell:


### PR DESCRIPTION
Previously, "/revshell=true" was included for direct bypass. Including this would cause an error and would not spawn a powershell instance. It has been fixed and verified to work successfully. 

