### PR TITLE
Fix small typo in the tip for adding a user to a localgroup

### DIFF
--- a/windows/basic-cmd-for-pentesters.md
+++ b/windows/basic-cmd-for-pentesters.md
@@ -130,7 +130,7 @@ logonsessions64.exe
 #Local
 net localgroup #All available groups
 net localgroup Administrators #Info about a group (admins)
-new localgroup administrators [username] /add #Add user to administrators
+net localgroup administrators [username] /add #Add user to administrators
 
 #Domain
 net group /domain #Info about domain groups


### PR DESCRIPTION
This is a one character typo fix for `new` -> `net` in the following line 

```
net localgroup administrators [username] /add 
```