### PR TITLE
Fixes typo in the wfuzz proxy command HTML -> HTTP

### DIFF
--- a/pentesting-web/web-tool-wfuzz.md
+++ b/pentesting-web/web-tool-wfuzz.md
@@ -72,7 +72,7 @@ wfuzz.py -c -z file,users.txt -z file,pass.txt --sc 200 h"name=FUZZ&password=FUZ
 #### **GET, 2 lists, filter string \(show\), proxy, cookies**
 
 ```text
-wfuzz -c -w users.txt -w pass.txt --ss "Welcome " -p 127.0.0.1:8080:HTML -b "PHPSESSIONID=1234567890abcdef;customcookie=hey" "http://example.com/index.php?username=FUZZ&password=FUZ2Z&action=sign+in"
+wfuzz -c -w users.txt -w pass.txt --ss "Welcome " -p 127.0.0.1:8080:HTTP -b "PHPSESSIONID=1234567890abcdef;customcookie=hey" "http://example.com/index.php?username=FUZZ&password=FUZ2Z&action=sign+in"
 ```
 
 ### Bruteforce Dicrectory/RESTful bruteforce
@@ -88,13 +88,13 @@ wfuzz -c -w /tmp/tmp/params.txt --hc 404 https://domain.com/api/FUZZ
 #### **Basic, 2 lists, filter string \(show\), proxy**
 
 ```text
-wfuzz -c -w users.txt -w pass.txt -p 127.0.0.1:8080:HTML --ss "Welcome" --basic FUZZ:FUZ2Z "http://example.com/index.php"
+wfuzz -c -w users.txt -w pass.txt -p 127.0.0.1:8080:HTTP --ss "Welcome" --basic FUZZ:FUZ2Z "http://example.com/index.php"
 ```
 
 #### **NTLM, 2 lists, filter string \(show\), proxy**
 
 ```text
-wfuzz -c -w users.txt -w pass.txt -p 127.0.0.1:8080:HTML --ss "Welcome" --ntlm 'domain\FUZZ:FUZ2Z' "http://example.com/index.php"
+wfuzz -c -w users.txt -w pass.txt -p 127.0.0.1:8080:HTTP --ss "Welcome" --ntlm 'domain\FUZZ:FUZ2Z' "http://example.com/index.php"
 ```
 
 ### Cookie/Header bruteforce \(vhost brute\)
@@ -102,13 +102,13 @@ wfuzz -c -w users.txt -w pass.txt -p 127.0.0.1:8080:HTML --ss "Welcome" --ntlm '
 #### **Cookie, filter code \(show\), proxy**
 
 ```text
-wfuzz -c -w users.txt -p 127.0.0.1:8080:HTML --ss "Welcome " -H "Cookie:id=1312321&user=FUZZ"  "http://example.com/index.php"
+wfuzz -c -w users.txt -p 127.0.0.1:8080:HTTP --ss "Welcome " -H "Cookie:id=1312321&user=FUZZ"  "http://example.com/index.php"
 ```
 
 #### **User-Agent, filter code \(hide\), proxy**
 
 ```text
-wfuzz -c -w user-agents.txt -p 127.0.0.1:8080:HTML --ss "Welcome " -H "User-Agent: FUZZ"  "http://example.com/index.php"
+wfuzz -c -w user-agents.txt -p 127.0.0.1:8080:HTTP --ss "Welcome " -H "User-Agent: FUZZ"  "http://example.com/index.php"
 ```
 
 #### **Host**
@@ -124,7 +124,7 @@ http://example.com -t 100
 #### **Using file**
 
 ```text
-wfuzz -c -w methods.txt -p 127.0.0.1:8080:HTML --sc 200 -X FUZZ "http://example.com/index.php"
+wfuzz -c -w methods.txt -p 127.0.0.1:8080:HTTP --sc 200 -X FUZZ "http://example.com/index.php"
 ```
 
 #### **Using inline list**


### PR DESCRIPTION
This PR corrects a typo in the `-p` parameter examples for wfuzz. These parameters incorrectly specify the proxy type as `HTML` rather than `HTTP`.