### PR TITLE
fix typo+consistent description in automatic tools

### DIFF
--- a/pentesting/pentesting-smtp/README.md
+++ b/pentesting/pentesting-smtp/README.md
@@ -143,6 +143,7 @@ Extracted from: [https://www.nccgroup.trust/uk/about-us/newsroom-and-events/blog
 
 ```text
 Metasploit: auxiliary/scanner/smtp/smtp_enum
+smtp-user-enum: smtp-user-enum -M <MODE> -u <USER> -t <IP>
 Nmap: nmap --script smtp-enum-users <IP>
 ```
 

--- a/pentesting/pentesting-smtp/README.md
+++ b/pentesting/pentesting-smtp/README.md
@@ -143,8 +143,7 @@ Extracted from: [https://www.nccgroup.trust/uk/about-us/newsroom-and-events/blog
 
 ```text
 Metasploit: auxiliary/scanner/smtp/smtp_enum
-smtp-user-enum
-nmap –script smtp-enum-users.nse <IP>
+Nmap: nmap --script smtp-enum-users <IP>
 ```
 
 ## DSN Reports


### PR DESCRIPTION
fixed a syntax error in nmap command of automatic tools section remove nse and add -- instead of - for better compatibility.
more consistend description