### PR TITLE
Link to English kubectl install documentation

### DIFF
--- a/pentesting/pentesting-kubernetes/enumeration-from-a-pod.md
+++ b/pentesting/pentesting-kubernetes/enumeration-from-a-pod.md
@@ -39,7 +39,7 @@ If you don't know what is **RBAC**, [**read this section**](./#cluster-hardening
 
 ## Enumeration CheatSheet
 
-To enumerate the environment you can upload the [**kubectl**](https://kubernetes.io/es/docs/tasks/tools/install-kubectl/) binary and use it. Also, using the **service** **token** obtained before you can manually access some endpoints of the **API Server**.  
+To enumerate the environment you can upload the [**kubectl**](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-kubectl-binary-with-curl-on-linux) binary and use it. Also, using the **service** **token** obtained before you can manually access some endpoints of the **API Server**.  
 In order to find the the IP of the API service check the environment for a variable called `KUBERNETES_SERVICE_HOST`.
 
 ### Differences between `list` and `get` verbs


### PR DESCRIPTION
The Kubernetes "enumeration from a pod" documentation links to Spanish instructions to install kubectl. This commit changes the URL to the English documentation.