### PR TITLE
Add missing hyphen

### DIFF
--- a/pentesting/pentesting-kubernetes/enumeration-from-a-pod.md
+++ b/pentesting/pentesting-kubernetes/enumeration-from-a-pod.md
@@ -319,7 +319,7 @@ As you are inside the Kubernetes environment, if you cannot escalate privileges 
 **For this purpose, you can try to get all the services of the kubernetes environment:**
 
 ```text
-kubectl get svc –all-namespaces
+kubectl get svc --all-namespaces
 ```
 
 ![](../../.gitbook/assets/image%20%28471%29.png)


### PR DESCRIPTION
The "enumeration from a pod" command example to get all services is missing a hyphen.