### PR TITLE
Added a link to 8 subdomain finders

### DIFF
--- a/todo/more-tools.md
+++ b/todo/more-tools.md
@@ -27,6 +27,7 @@
 * [https://builtwith.com/](https://builtwith.com/)
 * [https://www.spiderfoot.net/](https://www.spiderfoot.net/)
 * [https://github.com/zricethezav/gitleaks](https://github.com/zricethezav/gitleaks)
+* [https://www.nmmapper.com/sys/tools/subdomainfinder/](https://www.nmmapper.com/sys/tools/subdomainfinder/) : 8 Subdomain finder tools, sublist3r, amass and more
 
 ## **WEB**
 


### PR DESCRIPTION
Added a link to 8 subdomain finders which include(sublist3r, amass, anubis subdomain finder, nmap dns-brute, findomain, lepus) and more.