### PR TITLE
Update werkzeug.md

### DIFF
--- a/pentesting/pentesting-web/werkzeug.md
+++ b/pentesting/pentesting-web/werkzeug.md
@@ -133,7 +133,7 @@ private_bits = [
 * `username` is the user who started this Flask
 * `modname` is flask.app
 * `getattr(app, '__name__', getattr (app .__ class__, '__name__'))` is Flask
-* `getattr(mod, '__file__', None)` is the absolute path of an app.py in the flask directory
+* `getattr(mod, '__file__', None)` is the absolute path of `app.py` in the flask directory (e.g. `/usr/local/lib/python3.5/dist-packages/flask/app.py`). If `app.py` doesn't work, try `app.pyc`
 * `uuid.getnode()` is the MAC address of the current computer, `str (uuid.getnode ())` is the decimal expression of the mac address
 * `get_machine_id()` read the value in `/etc/machine-id` or `/proc/sys/kernel/random/boot_id` and return directly if there is, sometimes it might be required to append a piece of information within `/proc/self/cgroup` that you find at the end of the first line \(after the third slash\)
 


### PR DESCRIPTION
Recently I solved a challenge involving werkzeug console. The server for that challenge restarts every 5 min, so from the second run onwards `app.pyc` is used instead of `app.py`. It took me a long time to notice that. I hope this can help someone else avoid my mistake.