### PR TITLE
Corrected error in redis sandbox escape via dofile

### DIFF
--- a/pentesting/6379-pentesting-redis.md
+++ b/pentesting/6379-pentesting-redis.md
@@ -187,7 +187,7 @@ This method can also be used to earn bitcoin ：[yam](https://www.v2ex.com/t/286
 
 ### LUA sandbox bypass
 
-[**Here**](https://www.agarri.fr/blog/archives/2014/09/11/trying_to_hack_redis_via_http_requests/index.html) you can see that Redis uses the command **EVAL** to execute **Lua code sandboxed**. In the linked post you can see **how to abuse it** using the **dotfile** function, but [apparently](https://stackoverflow.com/questions/43502696/redis-cli-code-execution-using-eval) this isn't no longer possible. Anyway, if you can **bypass the Lua** sandbox you could **execute arbitrary** commas on the system. Also, from the same post you can see some **options to cause DoS**.
+[**Here**](https://www.agarri.fr/blog/archives/2014/09/11/trying_to_hack_redis_via_http_requests/index.html) you can see that Redis uses the command **EVAL** to execute **Lua code sandboxed**. In the linked post you can see **how to abuse it** using the **dofile** function, but [apparently](https://stackoverflow.com/questions/43502696/redis-cli-code-execution-using-eval) this isn't no longer possible. Anyway, if you can **bypass the Lua** sandbox you could **execute arbitrary** commas on the system. Also, from the same post you can see some **options to cause DoS**.
 
 ### Master-Slave Module
 


### PR DESCRIPTION
There was a spelling mistake within the redis page for LUA sandbox bypass. This has been corrected within this pull.