### PR TITLE
Fix typo, text bolding and text linking

### DIFF
--- a/pentesting-web/xxe-xee-xml-external-entity.md
+++ b/pentesting-web/xxe-xee-xml-external-entity.md
@@ -64,7 +64,7 @@ This XXE payload declares an XML parameter entity called `xxe` and then uses the
 
 ## Main attacks
 
-[Most of these attacks were tasted using the awesome Portswiggers XEE labs: https://portswigger.net/web-security/xxe](https://portswigger.net/web-security/xxe)
+[Most of these attacks were tested using the awesome Portswiggers XEE labs: https://portswigger.net/web-security/xxe](https://portswigger.net/web-security/xxe)
 
 ### New Entity test
 
@@ -305,7 +305,7 @@ jar:https://download.host.com/myarchive.zip!/file.txt
 ```
 
 {% hint style="danger" %}
-To be able to access files inside PKZIP files is s**uper useful to abuse XXE via system DTD files.** Check t[his section to learn how to abuse system DTD files](xxe-xee-xml-external-entity.md#error-based-system-dtd).
+To be able to access files inside PKZIP files is **super useful to abuse XXE via system DTD files.** Check [this section to learn how to abuse system DTD files](xxe-xee-xml-external-entity.md#error-based-system-dtd).
 {% endhint %}
 
 #### Behind the scenes
@@ -323,7 +323,7 @@ Once the server has downloaded your file, you need to find its location by brows
 ![Jar](https://gosecure.github.io/xxe-workshop/img//74fac3155d455980.png)
 
 {% hint style="danger" %}
-Writing files in a temporary directory can help to e**scalate another vulnerability that involves a path traversal** \(such as local file include, template injection, XSLT RCE, deserialization, etc\).
+Writing files in a temporary directory can help to **escalate another vulnerability that involves a path traversal** \(such as local file include, template injection, XSLT RCE, deserialization, etc\).
 {% endhint %}
 
 ### XSS


### PR DESCRIPTION
Changed typo tasted to tested.

Changed text bolding from
  - s\*\*uper useful to abuse XXE via system DTD files.\*\* to \*\*super useful to abuse XXE via system DTD files.\*\*
  - e\*\*scalate another vulnerability that involves a path traversal\*\* to \*\*escalate another vulnerability that involves a path traversal\*\*

Changed text linking from t[his section to learn how to abuse system DTD files] to [this section to learn how to abuse system DTD files].