### PR TITLE
SMB/SMB2 139/445 consolesless mfs enumeration

### DIFF
--- a/pentesting/pentesting-smb.md
+++ b/pentesting/pentesting-smb.md
@@ -504,4 +504,11 @@ Entry_5:
   Name: Hydra Brute Force
   Description: Need User
   Command: hydra -t 1 -V -f -l {Username} -P {Big_Passwordlist} {IP} smb
+  
+Entry_6:
+  	Name: SMB/SMB2 139/445 consolesless mfs enumeration
+  	Description: SMB/SMB2 139/445  enumeration without the need to run msfconsole
+  	Note: sourced from https://github.com/carlospolop/legion
+  	Command: msfconsole -q -x 'use auxiliary/scanner/smb/smb_version; set RHOSTS {IP}; set RPORT 139; run; exit' && msfconsole -q -x 'use auxiliary/scanner/smb/smb2; set RHOSTS {IP}; set RPORT 139; run; exit' && msfconsole -q -x 'use auxiliary/scanner/smb/smb_version; set RHOSTS {IP}; set RPORT 445; run; exit' && msfconsole -q -x 'use auxiliary/scanner/smb/smb2; set RHOSTS {IP}; set RPORT 445; run; exit' 
+    
 ```


### PR DESCRIPTION
  	Description: SMB/SMB2 139/445  enumeration without the need to run msfconsole
  	Note: sourced from https://github.com/carlospolop/legion