### PR TITLE
add a note about SQL truncation no longer working in latest MySQL versions

### DIFF
--- a/pentesting-web/sql-injection/README.md
+++ b/pentesting-web/sql-injection/README.md
@@ -342,11 +342,14 @@ To do so you should try to **create a new object named as the "master object"** 
 
 #### SQL Truncation Attack
 
+
 If the database is vulnerable and the max number of chars for username is for example 30 and you want to impersonate the user **admin**, try to create a username called: "_admin \[30 spaces] a_" and any password.
 
 The database will **check** if the introduced **username** **exists** inside the database. If **not**, it will **cut** the **username** to the **max allowed number of characters** (in this case to: "_admin \[25 spaces]_") and the it will **automatically remove all the spaces at the end updating** inside the database the user "**admin**" with the **new password** (some error could appear but it doesn't means that this hasn't worked).
 
 More info: [https://blog.lucideus.com/2018/03/sql-truncation-attack-2018-lucideus.html](https://blog.lucideus.com/2018/03/sql-truncation-attack-2018-lucideus.html) & [https://resources.infosecinstitute.com/sql-truncation-attack/#gref](https://resources.infosecinstitute.com/sql-truncation-attack/#gref)
+
+_Note: This attack will no longer work in latest MySQL installations. While comparisons still ignore trailing whitespace by default, attempting to insert a string that is longer than the length of a field will result in an error, and the insertion will fail._
 
 ### MySQL Insert time based checking
 

--- a/pentesting-web/sql-injection/README.md
+++ b/pentesting-web/sql-injection/README.md
@@ -349,7 +349,7 @@ The database will **check** if the introduced **username** **exists** inside the
 
 More info: [https://blog.lucideus.com/2018/03/sql-truncation-attack-2018-lucideus.html](https://blog.lucideus.com/2018/03/sql-truncation-attack-2018-lucideus.html) & [https://resources.infosecinstitute.com/sql-truncation-attack/#gref](https://resources.infosecinstitute.com/sql-truncation-attack/#gref)
 
-_Note: This attack will no longer work in latest MySQL installations. While comparisons still ignore trailing whitespace by default, attempting to insert a string that is longer than the length of a field will result in an error, and the insertion will fail._
+_Note: This attack will no longer work as described above in latest MySQL installations. While comparisons still ignore trailing whitespace by default, attempting to insert a string that is longer than the length of a field will result in an error, and the insertion will fail._
 
 ### MySQL Insert time based checking
 


### PR DESCRIPTION
The specified attack no longer works as described because MySQL throws an error instead of truncating these days.

Proof with the latest MySQL version from the apt repo:

```
mysql> insert into test2(name, password) values ("admin                    asd", "test");
ERROR 1406 (22001): Data too long for column 'name' at row 1
mysql> select * from test2;
+----+-------+----------+
| id | name  | password |
+----+-------+----------+
|  1 | admin | asd      |
+----+-------+----------+
1 row in set (0.00 sec)
```

As you can see, the field was not truncated and it was not added.