### PR TITLE
Fix a link to hackingthe.cloud

### DIFF
--- a/cloud-security/cloud-security-review.md
+++ b/cloud-security/cloud-security-review.md
@@ -1,6 +1,6 @@
 # Cloud Security Review
 
-**Check for nice cloud hacking tricks in** [**https://hackingthe.cloud/aws/general-knowledge/connection-tracking/**](https://hackingthe.cloud/aws/general-knowledge/connection-tracking/)
+**Check for nice cloud hacking tricks in** [**https://hackingthe.cloud**](https://hackingthe.cloud)
 
 ## Generic tools
 


### PR DESCRIPTION
Originally this link navigated to a specific page. I think the intention was to link to hackingthe.cloud in general.