### PR TITLE
small typo fix

### DIFF
--- a/pentesting/1521-1522-1529-pentesting-oracle-listener/README.md
+++ b/pentesting/1521-1522-1529-pentesting-oracle-listener/README.md
@@ -160,7 +160,7 @@ If an **account has system database priviledges \(sysdba\) or system operator \(
 ```bash
 sqlplus <username>/<password>@<ip_address>/<SID> 'as sysdba';
 #Example:
-sqplus SYSTEM/MANAGER@192.168.0.2/ORCL 'as sysdba'
+sqlplus SYSTEM/MANAGER@192.168.0.2/ORCL 'as sysdba'
 ```
 
 ## **All in One**


### PR DESCRIPTION
on file pentesting/1521-1522-1529-pentesting-oracle-listener/

`sqplus` should be `sqlplus`