### PR TITLE
ipsec-ike-vpn-pentesting - Fix typo

### DIFF
--- a/pentesting/ipsec-ike-vpn-pentesting.md
+++ b/pentesting/ipsec-ike-vpn-pentesting.md
@@ -28,7 +28,7 @@ MAC Address: 00:1B:D5:54:4D:E4 (Cisco Systems)
 
 The IPSec configuration can be prepared only to accept one or a few transformations. A transformation is a combination of values. **Each transform** contains a number of attributes like DES or 3DES as the **encryption algorithm**, SHA or MD5 as the **integrity algorithm**, a pre-shared key as the **authentication type**, Diffie-Hellman 1 or 2 as the key **distribution algorithm** and 28800 seconds as the **lifetime**. 
 
-Then, the first thing that you have to do is** find a valid transformation**, so the server will talk to you. To do so, you can use the tool **ike-scan**. By default, Ike-scan works in main mode, and sends a packet to the gateway with an ISAKMP header and a single proposal with **eight transforms inside it**.
+Then, the first thing that you have to do is to **find a valid transformation**, so the server will talk to you. To do so, you can use the tool **ike-scan**. By default, Ike-scan works in main mode, and sends a packet to the gateway with an ISAKMP header and a single proposal with **eight transforms inside it**.
 
 Depending on the response you can obtain some information about the endpoint:
 
@@ -47,7 +47,7 @@ As you can see in the previous response, there is a field called **AUTH** with t
 **The value of the last line is also very important:**
 
 *  _0 returned handshake; 0 returned notify:_ This means the target is **not an IPsec gateway**.
-* _**1 returned handshake; 0 returned notify**_**: **This means the **target is configured for IPsec and is willing to perform IKE negotiation, and either one or more of the transforms you proposed are acceptable** (a valid transform will be shown in the output)
+* _**1 returned handshake; 0 returned notify:**_ This means the **target is configured for IPsec and is willing to perform IKE negotiation, and either one or more of the transforms you proposed are acceptable** (a valid transform will be shown in the output).
 * _0 returned handshake; 1 returned notify:_ VPN gateways respond with a notify message when **none of the transforms are acceptable** (though some gateways do not, in which case further analysis and a revised proposal should be tried).
 
 Then, in this case we already have a valid transformation but if you are in the 3rd case, then you need to **brute-force a little bit to find a valid transformation:**
@@ -71,8 +71,8 @@ while read line; do (echo "Valid trans found: $line" && ike-scan -M --aggressive
 ```
 
 Hopefully **a valid transformation is echoed back**.\
-You can try the** same attack** using[** iker.py**](https://github.com/isaudits/scripts/blob/master/iker.py).\
-You could also try to brute force transformations with **ikeforce**:
+You can try the **same attack** using [**iker.py**](https://github.com/isaudits/scripts/blob/master/iker.py).\
+You could also try to brute force transformations with [**ikeforce**](https://github.com/SpiderLabs/ikeforce):
 
 ```bash
 ./ikeforce.py <IP> # No parameters are required for scan -h for additional help
@@ -80,10 +80,10 @@ You could also try to brute force transformations with **ikeforce**:
 
 ![](<../.gitbook/assets/image (109).png>)
 
-In **DH Group **also**: 14 = 2048-bit MODP **and **15 = 3072-bit**\
+In **DH Group: 14 = 2048-bit MODP** and **15 = 3072-bit**\
 **2 = HMAC-SHA = SHA1 (in this case). The --trans format is $Enc,$Hash,$Auth,$DH**
 
-Cisco recommends avoidance of DH groups 1 and 2 in particular. The paper’s authors describe how it is likely that **nation states **can **decrypt** **IPsec **sessions negotiated using **weak groups **via discrete log **precomputation**. The hundreds of millions of dollars spent performing precomputation are amortised through the real-time decryption of any session using a weak group (1,024-bit or smaller).
+Cisco recommends avoidance of DH groups 1 and 2 in particular. The paper’s authors describe how it is likely that **nation states can decrypt IPsec sessions negotiated using weak groups via discrete log precomputation**. The hundreds of millions of dollars spent performing precomputation are amortised through the real-time decryption of any session using a weak group (1,024-bit or smaller).
 
 ### Server fingerprinting
 
@@ -117,8 +117,7 @@ This can be also achieve with nmap script _**ike-version**_
 
 ## Finding the correct ID (group name)
 
-For being allowed to capture the hash you need a valid transformation supporting Aggressive mode and the correct ID (group name)._** **_\
-_****_You probably won't know the valid group name, so you will have to brute-force it.\
+For being allowed to capture the hash you need a valid transformation supporting Aggressive mode and the correct ID (group name). You probably won't know the valid group name, so you will have to brute-force it.\
 To do so, I would recommend you 2 methods:
 
 ### Bruteforcing ID with ike-scan
@@ -129,7 +128,7 @@ First of all try to make a request with a fake ID trying to gather the hash ("-P
 ike-scan -P -M -A -n fakeID <IP>
 ```
 
-If **no hash is returned**, then probably this method of brute forcing** will work**. If **some** **hash **is returned, this means that a **fake hash is going to be sent** back for a fake ID, so **this method won't be reliable** to brute-force the ID. For example, a fake hash could be returned (this happens in modern versions):
+If **no hash is returned**, then probably this method of brute forcing will work. **If some hash is returned, this means that a fake hash is going to be sent back for a fake ID, so this method won't be reliable** to brute-force the ID. For example, a fake hash could be returned (this happens in modern versions):
 
 ![](<../.gitbook/assets/image (110).png>)
 
@@ -151,19 +150,19 @@ Or use this dict (is a combination of the other 2 dicts without repetitions):
 
 ### Bruteforcing ID with Iker
 
-[** iker.py**](https://github.com/isaudits/scripts/blob/master/iker.py)** **also uses **ike-scan** to bruteforce possible group names. It follows it's own method to **find a valid ID based on the output of ike-scan**.
+[**iker.py**](https://github.com/isaudits/scripts/blob/master/iker.py) also uses **ike-scan** to bruteforce possible group names. It follows it's own method to **find a valid ID based on the output of ike-scan**.
 
 ### Bruteforcing ID with ikeforce
 
-[ikeforce.py](https://github.com/SpiderLabs/ikeforce) is a tool that can be used to **brute force IDs also**. This tool will **try to exploit different vulnerabilities** that could be used to **distinguish **between a **valid **and a** non-valid ID** (could have false positives and false negatives, that is why I prefer to use the ike-scan method if possible).
+[**ikeforce.py**](https://github.com/SpiderLabs/ikeforce) is a tool that can be used to **brute force IDs also**. This tool will **try to exploit different vulnerabilities** that could be used to **distinguish between a valid and a non-valid ID** (could have false positives and false negatives, that is why I prefer to use the ike-scan method if possible).
 
 By default **ikeforce** will send at the beginning some random ids to check the behaviour of the server and determinate the tactic to use.
 
-* The **first method** is to brute-force the group names by **searching** for the information **Dead Peer Detection DPD** of Cisco systems (this info is only replayed by the server if the group name is correct).\
+* The **first method** is to brute-force the group names by **searching** for the information **Dead Peer Detection DPD** of Cisco systems (this info is only replayed by the server if the group name is correct).
 
-* The **second method** available is to **checks the number of responses sent to each try** because sometimes more packets are sent when the correct id is used.\
+* The **second method** available is to **checks the number of responses sent to each try** because sometimes more packets are sent when the correct id is used.
 
-* The **third method** consist on **searching for "INVALID-ID-INFORMATION" in response to incorrect ID**.\
+* The **third method** consist on **searching for "INVALID-ID-INFORMATION" in response to incorrect ID**.
 
 * Finally, if the server does not replay anything to the checks, **ikeforce** will try to brute force the server and check if when the correct id is sent the server replay with some packet.\
   Obviously, the goal of brute forcing the id is to get the **PSK** when you have a valid id. Then, with the **id** and **PSK** you will have to bruteforce the XAUTH (if it is enabled).
@@ -187,26 +186,23 @@ It is also possible to obtain valid usernames by sniffing the connection between
 
 ## Capturing & cracking the hash
 
-Finally, If you have find a **valid transformation** and the** group name** and the **aggressive mode is allowed**, then you can very easily grab the crackable hash:
+Finally, If you have found a **valid transformation**  and the **group name** and if the **aggressive mode is allowed**, then you can very easily grab the crackable hash:
 
 ```bash
 ike-scan -M -A -n <ID> --pskcrack=hash.txt <IP> #If aggressive mode is supported and you know the id, you can get the hash of the passwor
 ```
 
-The hash will be saved inside _hash.txt_
+The hash will be saved inside _hash.txt_.
 
-You can use **psk-crack** to **crack** the password
+You can use **psk-crack**, **john** (using [**ikescan2john.py**](https://github.com/truongkma/ctf-tools/blob/master/John/run/ikescan2john.py)) and **hashcat** to **crack** the hash:
 
 ```bash
-psk-crack -d <Wordlist_path> psk.txt #To crack the hash
-#You can also crack it using john (using ikescan2john.py) and hashcat.
+psk-crack -d <Wordlist_path> psk.txt
 ```
-
-[ikescan2john.py](https://github.com/truongkma/ctf-tools/blob/master/John/run/ikescan2john.py)
 
 ## **XAuth**
 
-Most implementations use** aggressive mode IKE with a PSK to perform group authentication**, and **XAUTH **to provide additional** user authentication** (via Microsoft Active Directory, RADIUS, or similar). Within **IKEv2**, **EAP replaces XAUTH** to authenticate users.
+Most implementations use **aggressive mode IKE with a PSK to perform group authentication**, and **XAUTH to provide additional user authentication** (via Microsoft Active Directory, RADIUS, or similar). Within **IKEv2**, **EAP replaces XAUTH** to authenticate users.
 
 ### Local network MitM to capture credentials
 
@@ -232,8 +228,8 @@ If you found one or several valid transforms just use them like in the previous 
 
 ## Authentication with an IPSEC VPN
 
-In Kali **VPNC **is used to establish IPsec tunnels. The **profiles **have to be located in _**/etc/vpnc/**_** **and you can use the tool _**vpnc **_to call them.\
-Example taken from book **Network Security Assessment 3rd Edition**.
+In Kali **VPNC** is used to establish IPsec tunnels. **Profiles** have to be located in **_/etc/vpnc/_** and you can use the tool _**vpnc**_ to call them.\
+Example taken from the book **Network Security Assessment 3rd Edition**:
 
 ```
 root@kali:~# cat > /etc/vpnc/vpntest.conf << STOP


### PR DESCRIPTION
* Fix many trailing `*` and `\` 
* Fix some minor typos