### PR TITLE
Fix typo in the MSSql version query

### DIFF
--- a/pentesting/pentesting-mssql-microsoft-sql-server.md
+++ b/pentesting/pentesting-mssql-microsoft-sql-server.md
@@ -176,7 +176,7 @@ You can login into the service using **impacket mssqlclient.py**
 mssqlclient.py  -db volume -windows-auth <DOMAIN>/<USERNAME>:<PASSWORD>@<IP> #Recommended -windows-auth when you are going to use a domain. use as domain the netBIOS name of the machine
 
 #Once logged in you can run queries:
-SQL> select @@ version;
+SQL> select @@version;
 
 #Steal NTLM hash
 sudo responder -I <interface> #Run that in other console


### PR DESCRIPTION
Fix typo in the MSSQL version query
https://docs.microsoft.com/en-us/sql/t-sql/functions/version-transact-sql-configuration-functions?view=sql-server-ver15#syntax