### PR TITLE
Fix broken images

### DIFF
--- a/pentesting-web/deserialization/exploiting-__viewstate-parameter.md
+++ b/pentesting-web/deserialization/exploiting-__viewstate-parameter.md
@@ -28,7 +28,7 @@ HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework\v{VersionHere}
 
 You can try to identify if ViewState is MAC protected by capturing a request containing this parameter with BrupSuite:
 
-![](https://www.notsosecure.com/wp-content/uploads/2019/06/1.0.png)
+![](https://notsosecure.com/sites/all/assets/group/nss_uploads/2019/06/1.0.png)
 
 If Mac is not used to protect the parameter you can exploit it using [**YSoSerial.Net**](https://github.com/pwntester/ysoserial.net).
 
@@ -65,7 +65,7 @@ We can also do it for **overall** application by setting it on the **web.config*
 
 As the parameter is MAC protected this time to successfully execute the attack we first need the key used. In this case, BurpSuite will let us know that the parameter is MAC protected:
 
-![](https://www.notsosecure.com/wp-content/uploads/2019/06/2.0.png)
+![](https://notsosecure.com/sites/all/assets/group/nss_uploads/2019/06/2.0.png)
 
 You can try to use [**Blacklist3r(AspDotNetWrapper.exe)** ](https://github.com/NotSoSecure/Blacklist3r/tree/master/MachineKey/AspDotNetWrapper)to find the key used.
 
@@ -76,7 +76,7 @@ AspDotNetWrapper.exe --keypath MachineKeys.txt --encrypteddata /wEPDwUKLTkyMTY0M
 --modifier : __VIWESTATEGENERATOR parameter value
 ```
 
-![](https://www.notsosecure.com/wp-content/uploads/2019/06/2.1.png)
+![](https://notsosecure.com/sites/all/assets/group/nss_uploads/2019/06/2.1.png)
 
 If you are lucky and the key is found,you can proceed with the attack using [**YSoSerial.Net**](https://github.com/pwntester/ysoserial.net)**:**
 
@@ -96,7 +96,7 @@ In cases where `_VIEWSTATEGENERATOR` parameter **isn't sent** by the server you 
 
 In this case Burp doesn't find if the parameter is protected with MAC because it doesn't recognise the values. Then, the value is probably encrypted and you will **need the Machine Key to encrypt your payload** to exploit the vulnerability.
 
-![](https://www.notsosecure.com/wp-content/uploads/2019/06/3.0.png)
+![](https://notsosecure.com/sites/all/assets/group/nss_uploads/2019/06/3.0.png)
 
 **In this case the** [**Blacklist3r**](https://github.com/NotSoSecure/Blacklist3r/tree/master/MachineKey/AspDotNetWrapper) **module is under development...**
 
@@ -106,7 +106,7 @@ Threfore, if the Machinekey is known (e.g. via a directory traversal issue), [**
 
 * Remove `__VIEWSTATEENCRYPTED` parameter from the request in order to exploit the ViewState deserialization vulnerability, else it will return a Viewstate MAC validation error and exploit will fail as shown in Figure:
 
-![](https://www.notsosecure.com/wp-content/uploads/2019/06/3.1.png)
+![](https://notsosecure.com/sites/all/assets/group/nss_uploads/2019/06/3.1.png)
 
 ### Test Case: 4 – .Net >= 4.5 and EnableViewStateMac=true/false and ViewStateEncryptionMode=true/false except both attribute to false
 
@@ -124,7 +124,7 @@ compatibilityMode="Framework45"
 
 As in the previous case Burp doesn't identify if the request is MAC protected because the **value is encrypted.** Then, to send a **valid payload the attacker need the key**.
 
-![](https://www.notsosecure.com/wp-content/uploads/2019/06/4.0.png)
+![](https://notsosecure.com/sites/all/assets/group/nss_uploads/2019/06/4.0.png)
 
 You can try to use [**Blacklist3r(AspDotNetWrapper.exe)** ](https://github.com/NotSoSecure/Blacklist3r/tree/master/MachineKey/AspDotNetWrapper)to find the key being used:
 
@@ -138,7 +138,7 @@ AspDotNetWrapper.exe --keypath MachineKeys.txt --encrypteddata bcZW2sn9CbYxU47Lw
 
 For a more detailed description for IISDirPath and TargetPagePath [refer here](https://soroush.secproject.com/blog/2019/04/exploiting-deserialisation-in-asp-net-via-viewstate/)
 
-![](https://www.notsosecure.com/wp-content/uploads/2019/06/4.1.png)
+![](https://notsosecure.com/sites/all/assets/group/nss_uploads/2019/06/4.1.png)
 
 Once a valid Machine key is identified, **the next step is to generate a serialized payload using** [**YSoSerial.Net**](https://github.com/pwntester/ysoserial.net)
 
@@ -148,7 +148,7 @@ ysoserial.exe -p ViewState  -g TextFormattingRunProperties -c "powershell.exe In
 
 If you have the value of `__VIEWSTATEGENERATOR` you can try to **use** the `--generator` parameter with that value and **omit** the parameters `--path` and `--apppath`
 
-![](https://www.notsosecure.com/wp-content/uploads/2019/06/4.2.png)
+![](https://notsosecure.com/sites/all/assets/group/nss_uploads/2019/06/4.2.png)
 
 If the ViewState deserialization vulnerability is successfully exploited, an attacker-controlled server will receive an out of band request containing the username.  [PoC of Successful Exploitation](https://www.notsosecure.com/exploiting-viewstate-deserialization-using-blacklist3r-and-ysoserial-net/#PoC)
 
@@ -165,11 +165,11 @@ You need to use one more parameter in order to create correctly the payload:
 
 For all the test cases, if the ViewState YSoSerial.Net payload works **successfully** then the server responds with “**500 Internal server error**” having response content “**The state information is invalid for this page and might be corrupted**” and we get the OOB request as shown in Figures below:
 
-![](https://www.notsosecure.com/wp-content/uploads/2019/06/5.0POC-of-Seccuessful-exploitation.png)
+![](https://notsosecure.com/sites/all/assets/group/nss_uploads/2019/06/5.0POC-of-Seccuessful-exploitation.png)
 
 out of band request with the current username
 
-![](https://www.notsosecure.com/wp-content/uploads/2019/06/5.1POC-of-Seccuessful-exploitation.png)
+![](https://notsosecure.com/sites/all/assets/group/nss_uploads/2019/06/5.1POC-of-Seccuessful-exploitation.png)
 
 ## References
 


### PR DESCRIPTION
It seems that the path to the images changed, resulting in 301/404.
New paths taken from
https://notsosecure.com/exploiting-viewstate-deserialization-using-blacklist3r-and-ysoserial-net