### PR TITLE
Fix broken link and default number of ports scanned

### DIFF
--- a/pentesting/pentesting-network/README.md
+++ b/pentesting/pentesting-network/README.md
@@ -1,7 +1,7 @@
 # Pentesting Network
 
 If you want to **know** about my **latest modifications**/**additions** or you have **any suggestion for HackTricks or PEASS**, **join the** [**💬**](https://emojipedia.org/speech-balloon/) [**Discord group**](https://discord.gg/hRep4RUj7f) or the [**telegram group**](https://t.me/peass), or **follow me on Twitter** [🐦](https://emojipedia.org/bird/)[**@carlospolopm**](https://twitter.com/carlospolopm)**.**\
-If you want to **share some tricks with the community** you can also submit **pull requests** to [**https://github.com/carlospolop/hacktricks**](https://github.com/carlospolop/hacktricks\*\*]\(https://github.com/carlospolop/hacktricks) **that will be reflected in this book.**\
+If you want to **share some tricks with the community** you can also submit **pull requests** to [**https://github.com/carlospolop/hacktricks**](https://github.com/carlospolop/hacktricks) **that will be reflected in this book.**\
 **Don't forget to** give ⭐ on the github to motivate me to continue developing this book.
 
 ## Discovering hosts from the outside
@@ -51,7 +51,7 @@ nmap -sU -sV --version-intensity 0 -F -n 199.66.11.53/24
 # The "--version-intensity 0" will make nmap only test the most probable
 ```
 
-The nmap line proposed before will test the **top 100 UDP ports** in every host inside the **/24** range but even only this will take **>20min**. If need **fastest results** you can use [**udp-proto-scanner**](https://github.com/portcullislabs/udp-proto-scanner): `./udp-proto-scanner.pl 199.66.11.53/24` This will send these **UDP probes** to their **expected port** (for a /24 range this will just take 1 min): _DNSStatusRequest, DNSVersionBindReq, NBTStat, NTPRequest, RPCCheck, SNMPv3GetRequest, chargen, citrix, daytime, db2, echo, gtpv1, ike,ms-sql, ms-sql-slam, netop, ntp, rpc, snmp-public, systat, tftp, time, xdmcp._
+The nmap line proposed before will test the **top 1000 UDP ports** in every host inside the **/24** range but even only this will take **>20min**. If need **fastest results** you can use [**udp-proto-scanner**](https://github.com/portcullislabs/udp-proto-scanner): `./udp-proto-scanner.pl 199.66.11.53/24` This will send these **UDP probes** to their **expected port** (for a /24 range this will just take 1 min): _DNSStatusRequest, DNSVersionBindReq, NBTStat, NTPRequest, RPCCheck, SNMPv3GetRequest, chargen, citrix, daytime, db2, echo, gtpv1, ike,ms-sql, ms-sql-slam, netop, ntp, rpc, snmp-public, systat, tftp, time, xdmcp._
 
 ### SCTP Port Discovery
 


### PR DESCRIPTION
From nmap man page (and tested with `nmap -sU 127.0.0.1`), nmap scans the top 1000 ports by default, and not the top 100.

The link was broken so I also fixed it.