### PR TITLE
Fix wording issue in tomcat.md 

### DIFF
--- a/pentesting/pentesting-web/tomcat.md
+++ b/pentesting/pentesting-web/tomcat.md
@@ -85,7 +85,7 @@ The following example scripts that come with Apache Tomcat v4.x - v7.x and can b
 
 ### Path Traversal (..;/)
 
-In some **vulnerable versions of Tomcat** you can access to protected directories in Tomcat using the path: `/..;/`
+In some **[vulnerable configurations of Tomcat](https://www.acunetix.com/vulnerabilities/web/tomcat-path-traversal-via-reverse-proxy-mapping/)** you can access to protected directories in Tomcat using the path: `/..;/`
 
 So, for example, you might be able to **access the Tomcat manager** page accessing: `www.vulnerable.com/lalala/..;/manager/html`
 


### PR DESCRIPTION
It's not the tomcat version that's vulnerable. It's a path normalization inconsistency issue where the reverse proxy and tomcat parse the string /..;/ differently.