### PR TITLE
typo fix

### DIFF
--- a/network-services-pentesting/ipsec-ike-vpn-pentesting.md
+++ b/network-services-pentesting/ipsec-ike-vpn-pentesting.md
@@ -104,7 +104,7 @@ Cisco recommends avoidance of DH groups 1 and 2 in particular. The paper’s aut
 
 ## Server fingerprinting
 
-Then, you can use ike-scan to try to **discover the vendor** of the device. The tool send an initial proposal and stops replaying. Then, it will **analyze** the **time** difference **between** the received **messages** from the server and the matching response pattern, the pe tester can successfully fingerprint the VPN gateway vendor. More over, some VPN servers will use the optional **Vendor ID (VID) payload** with IKE.
+Then, you can use ike-scan to try to **discover the vendor** of the device. The tool send an initial proposal and stops replaying. Then, it will **analyze** the **time** difference **between** the received **messages** from the server and the matching response pattern, the pentester can successfully fingerprint the VPN gateway vendor. More over, some VPN servers will use the optional **Vendor ID (VID) payload** with IKE.
 
 **Specify the valid transformation if needed** (using --trans)
 


### PR DESCRIPTION
typo in `/network-services-pentesting/ipsec-ike-vpn-pentesting.md`. `pe tester` should be `pentester`