### PR TITLE
fix typo

### DIFF
--- a/network-services-pentesting/pentesting-dns.md
+++ b/network-services-pentesting/pentesting-dns.md
@@ -19,7 +19,7 @@ Get the [**official PEASS & HackTricks swag**](https://peass.creator-spring.com)
 
 # **Basic Information**
 
-The Domain Name Systems (DNS) is the phonebook of the Internet. Humans access information online through domain names, like nytimes.com or espn.com. Web browsers interact through Internet Protocol (IP) addresses. DN S translates domain names to [IP addresses](https://www.cloudflare.com/learning/dns/glossary/what-is-my-ip-address/) so browsers can load Internet resources.\
+The Domain Name Systems (DNS) is the phonebook of the Internet. Humans access information online through domain names, like nytimes.com or espn.com. Web browsers interact through Internet Protocol (IP) addresses. DNS translates domain names to [IP addresses](https://www.cloudflare.com/learning/dns/glossary/what-is-my-ip-address/) so browsers can load Internet resources.\
 From [here](https://www.cloudflare.com/learning/dns/what-is-dns/).
 
 **Default port:** 53


### PR DESCRIPTION
typo in `network-services-pentesting/pentesting-dns.md`.
line 22: `DN S` should be `DNS`