### PR TITLE
Added in IRC Server Authentication via Netcat

### DIFF
--- a/network-services-pentesting/pentesting-irc.md
+++ b/network-services-pentesting/pentesting-irc.md
@@ -77,6 +77,14 @@ JOIN <CHANNEL_NAME>   #Connect to a channel
 OPER <USERNAME> <PASSWORD>
 ```
 
+You can, also, atttempt to login to the server with a password. The default password for ngIRCd is 'wealllikedebian'.
+
+```bash
+PASS wealllikedebian
+NICK patrick
+USER test1 test2 <IP> :test3
+```
+
 ### **Find and scan IRC services**
 
 ```bash


### PR DESCRIPTION
I added in IRC server authentication via Netcat. I, also, mentioned that ngIRCd has a default password which should be tried.