### PR TITLE
Fix golang SSTI description

### DIFF
--- a/pentesting-web/ssti-server-side-template-injection/README.md
+++ b/pentesting-web/ssti-server-side-template-injection/README.md
@@ -921,7 +921,7 @@ However, Go allows to **DEFINE** a whole **template** and then **later call it**
 
 The documentation for both the html/template module can be found [here](https://golang.org/pkg/html/template/), and the documentation for the text/template module can be found [here](https://golang.org/pkg/text/template/), and yes, they do vary, a lot. For example, in **text/templat**e, you can **directly call any public function with the “call” value**, this however, is not the case with html/template.
 
-If you want to find a RCE in go via SSTI, you should know that as you can access the given object to the template with `{{ . }}`, you can also **call the objects methods**. So, imagine that the **passed object has a method called System** that executes the given command, you could abuse it with: `{{ .System("ls") }}`\
+If you want to find a RCE in go via SSTI, you should know that as you can access the given object to the template with `{{ . }}`, you can also **call the objects methods**. So, imagine that the **passed object has a method called System** that executes the given command, you could abuse it with: `{{ .System "ls" }}`\
 Therefore, you will probably **need the source code**. A potential source code for something like that will look like:
 
 ```go


### PR DESCRIPTION
Hey there! While reading the description for golang SSTI on hacktricks, I noticed that the payload for executing functions is incorrect. Using parentheses to call functions does not work with golang's html/template (as described [here](https://stackoverflow.com/questions/10200178/call-a-method-from-a-go-template)).