### PR TITLE
Fix ldapsearch command syntax

### DIFF
--- a/network-services-pentesting/pentesting-ldap.md
+++ b/network-services-pentesting/pentesting-ldap.md
@@ -174,8 +174,8 @@ ldapdomaindump <IP> [-r <IP>] -u '<domain>\<username>' -p '<password>' [--authty
 Check null credentials or if your credentials are valid:
 
 ```bash
-ldapsearch -x -h <IP> -D '' -w '' -b "DC=<1_SUBDOMAIN>,DC=<TDL>"
-ldapsearch -x -h <IP> -D '<DOMAIN>\<username>' -w '<password>' -b "DC=<1_SUBDOMAIN>,DC=<TDL>"
+ldapsearch -x -H ldap://<IP> -D '' -w '' -b "DC=<1_SUBDOMAIN>,DC=<TLD>"
+ldapsearch -x -H ldap://<IP> -D '<DOMAIN>\<username>' -w '<password>' -b "DC=<1_SUBDOMAIN>,DC=<TLD>"
 ```
 
 ```bash
@@ -191,9 +191,9 @@ If you find something saying that the "_bind must be completed_" means that the 
 You can extract **everything from a domain** using:
 
 ```bash
-ldapsearch -x -h <IP> -D '<DOMAIN>\<username>' -w '<password>' -b "DC=<1_SUBDOMAIN>,DC=<TDL>"
+ldapsearch -x -H ldap://<IP> -D '<DOMAIN>\<username>' -w '<password>' -b "DC=<1_SUBDOMAIN>,DC=<TLD>"
 -x Simple Authentication
--h LDAP Server
+-H LDAP Server
 -D My User
 -w My password
 -b Base site, all data from here will be given
@@ -202,50 +202,50 @@ ldapsearch -x -h <IP> -D '<DOMAIN>\<username>' -w '<password>' -b "DC=<1_SUBDOMA
 Extract **users**:
 
 ```bash
-ldapsearch -x -h <IP> -D '<DOMAIN>\<username>' -w '<password>' -b "CN=Users,DC=<1_SUBDOMAIN>,DC=<TDL>"
-#Example: ldapsearch -x -h <IP> -D 'MYDOM\john' -w 'johnpassw' -b "CN=Users,DC=mydom,DC=local"
+ldapsearch -x -H ldap://<IP> -D '<DOMAIN>\<username>' -w '<password>' -b "CN=Users,DC=<1_SUBDOMAIN>,DC=<TLD>"
+#Example: ldapsearch -x -H ldap://<IP> -D 'MYDOM\john' -w 'johnpassw' -b "CN=Users,DC=mydom,DC=local"
 ```
 
 Extract **computers**:
 
 ```bash
-ldapsearch -x -h <IP> -D '<DOMAIN>\<username>' -w '<password>' -b "CN=Computers,DC=<1_SUBDOMAIN>,DC=<TDL>"
+ldapsearch -x -H ldap://<IP> -D '<DOMAIN>\<username>' -w '<password>' -b "CN=Computers,DC=<1_SUBDOMAIN>,DC=<TLD>"
 ```
 
 Extract **my info**:
 
 ```bash
-ldapsearch -x -h <IP> -D '<DOMAIN>\<username>' -w '<password>' -b "CN=<MY NAME>,CN=Users,DC=<1_SUBDOMAIN>,DC=<TDL>"
+ldapsearch -x -H ldap://<IP> -D '<DOMAIN>\<username>' -w '<password>' -b "CN=<MY NAME>,CN=Users,DC=<1_SUBDOMAIN>,DC=<TLD>"
 ```
 
 Extract **Domain Admins**:
 
 ```bash
-ldapsearch -x -h <IP> -D '<DOMAIN>\<username>' -w '<password>' -b "CN=Domain Admins,CN=Users,DC=<1_SUBDOMAIN>,DC=<TDL>"
+ldapsearch -x -H ldap://<IP> -D '<DOMAIN>\<username>' -w '<password>' -b "CN=Domain Admins,CN=Users,DC=<1_SUBDOMAIN>,DC=<TLD>"
 ```
 
 Extract **Domain Users**:
 
 ```bash
-ldapsearch -x -h <IP> -D '<DOMAIN>\<username>' -w '<password>' -b "CN=Domain Users,CN=Users,DC=<1_SUBDOMAIN>,DC=<TDL>"
+ldapsearch -x -H ldap://<IP> -D '<DOMAIN>\<username>' -w '<password>' -b "CN=Domain Users,CN=Users,DC=<1_SUBDOMAIN>,DC=<TLD>"
 ```
 
 Extract **Enterprise Admins**:
 
 ```bash
-ldapsearch -x -h <IP> -D '<DOMAIN>\<username>' -w '<password>' -b "CN=Enterprise Admins,CN=Users,DC=<1_SUBDOMAIN>,DC=<TDL>"
+ldapsearch -x -H ldap://<IP> -D '<DOMAIN>\<username>' -w '<password>' -b "CN=Enterprise Admins,CN=Users,DC=<1_SUBDOMAIN>,DC=<TLD>"
 ```
 
 Extract **Administrators**:
 
 ```bash
-ldapsearch -x -h <IP> -D '<DOMAIN>\<username>' -w '<password>' -b "CN=Administrators,CN=Builtin,DC=<1_SUBDOMAIN>,DC=<TDL>"
+ldapsearch -x -H ldap://<IP> -D '<DOMAIN>\<username>' -w '<password>' -b "CN=Administrators,CN=Builtin,DC=<1_SUBDOMAIN>,DC=<TLD>"
 ```
 
 Extract **Remote Desktop Group**:
 
 ```bash
-ldapsearch -x -h <IP> -D '<DOMAIN>\<username>' -w '<password>' -b "CN=Remote Desktop Users,CN=Builtin,DC=<1_SUBDOMAIN>,DC=<TDL>"
+ldapsearch -x -H ldap://<IP> -D '<DOMAIN>\<username>' -w '<password>' -b "CN=Remote Desktop Users,CN=Builtin,DC=<1_SUBDOMAIN>,DC=<TLD>"
 ```
 
 To see if you have access to any password you can use grep after executing one of the queries:
@@ -379,17 +379,17 @@ Entry_2:
 Entry_3:
   Name: LdapSearch
   Description: Base LdapSearch
-  Command: ldapsearch -h {IP} -x
+  Command: ldapsearch -H ldap://{IP} -x
 
 Entry_4:
   Name: LdapSearch Naming Context Dump
   Description: Attempt to get LDAP Naming Context
-  Command: ldapsearch -h {IP} -x -s base namingcontexts
+  Command: ldapsearch -H ldap://{IP} -x -s base namingcontexts
 
 Entry_5:
   Name: LdapSearch Big Dump
   Description: Need Naming Context to do big dump
-  Command: ldapsearch -h {IP} -x -b "{Naming_Context}"
+  Command: ldapsearch -H ldap://{IP} -x -b "{Naming_Context}"
 
 Entry_6:
   Name: Hydra Brute Force


### PR DESCRIPTION
The parameter that specifies the LDAP server host (*LDAP Uniform Resource Identifiers(s)*) is  `-H` and not `-h`. Option `-h` does not exists and results in an error.