### PR TITLE
Update scanner instructions to latest nuclei version

### DIFF
--- a/network-services-pentesting/pentesting-web/README.md
+++ b/network-services-pentesting/pentesting-web/README.md
@@ -150,7 +150,7 @@ whatweb -a 4 <URL>
 wapiti -u <URL>
 W3af
 zaproxy #You can use an API
-nuclei -t nuclei-templates
+nuclei -ut && nuclei -target <URL>
 ```
 
 #### CMS scanners


### PR DESCRIPTION
Tiny update as Nuclei 2.7.5 now automatically pulls templates and updates them.