### PR TITLE
Fix typo "Procol" to "Protocol"

### DIFF
--- a/network-services-pentesting/pentesting-web/403-and-401-bypasses.md
+++ b/network-services-pentesting/pentesting-web/403-and-401-bypasses.md
@@ -80,7 +80,7 @@ If _/path_ is blocked:
   * {"user\_id":"\<legit\_id>","user\_id":"\<victims\_id>"} (JSON Parameter Pollution)
   * user\_id=ATTACKER\_ID\&user\_id=VICTIM\_ID (Parameter Pollution)
 
-## **Procol version**
+## **Protocol version**
 
 If using HTTP/1.1 **try to use 1.0** or even test if it **supports 2.0**.
 


### PR DESCRIPTION
Found a typo error in the procol-version section and changed the word "procol" to "protocol".