### PR TITLE
Add disclaimer to MacOS memory dump tool

### DIFF
--- a/macos-hardening/macos-security-and-privilege-escalation/README.md
+++ b/macos-hardening/macos-security-and-privilege-escalation/README.md
@@ -806,6 +806,10 @@ ls -Rl /Library/Managed\ Preferences/
 
 In order to dump the memory in a MacOS machine you can use [**osxpmem**](https://github.com/google/rekall/releases/download/v1.5.1/osxpmem-2.1.post4.zip).
 
+**Note**: The following instructions will only work for Macs with Intel architecture. This tool is now archived and the last release was in 2017. 
+The binary downloaded using the instructions below targets Intel chips as Apple Silicon wasn't around in 2017. It may be possible to compile
+the binary for arm64 architecture but you'll have to try for yourself.
+
 ```bash
 #Dump raw format
 sudo osxpmem.app/osxpmem --format raw -o /tmp/dump_mem


### PR DESCRIPTION
These instructions don't work on Macs using M1 or M2 chips as the binary in the release has been compiled to target Intel architecture.

Link to most recent release of the project:
https://github.com/google/rekall/releases/tag/v1.7.1

And this is the error message I got when running the bash commands in this section of the bool

```
> kextload osxpmem.app/MacPmem.kext                                                                                                                                                             
Executing: /usr/bin/kmutil load -p /private/tmp/osxpmem.app/MacPmem.kext
Error Domain=KMErrorDomain Code=71 "Incompatible architecture: Binary is for x86_64, but needed arch arm64e
...
```