### PR TITLE
Fix typo in shells page

### DIFF
--- a/generic-methodologies-and-resources/shells/linux.md
+++ b/generic-methodologies-and-resources/shells/linux.md
@@ -217,7 +217,7 @@ or
 https://gitlab.com/0x4ndr3/blog/blob/master/JSgen/JSgen.py
 ```
 
-## OpenSSH
+## OpenSSL
 
 The Attacker (Kali)
 


### PR DESCRIPTION
Looks like there was a typo in `OpenSSL` on this page.