### PR TITLE
Changing SameSite table for comprehensiveness

### DIFF
--- a/pentesting-web/hacking-with-cookies/README.md
+++ b/pentesting-web/hacking-with-cookies/README.md
@@ -144,20 +144,20 @@ This will indicate to the browser if the **cookie** can be sent **from other dom
 * **Lax**: The cookie will be sent along with the GET request initiated by third party websites.
 * **None**: The cookie is sent from any third party domain
 
-| **Request Type** | **Example Code**                   | **Cookies sent** |
-| ---------------- | ---------------------------------- | ---------------- |
-| Link             | \<a href="...">\</a>               | Normal, Lax      |
-| Perender         | \<link rel="prerender" href=".."/> | Normal, Lax      |
-| Form GET         | \<form method="GET" action="...">  | Normal, Lax      |
-| Form POST        | \<form method="POST" action="..."> | Normal           |
-| iframe           | \<iframe src="...">\</iframe>      | Normal           |
-| AJAX             | $.get("...")                       | Normal           |
-| Image            | \<img src="...">                   | Normal           |
+| **Request Type** | **Example Code**                   | **Cookies Sent When** |
+| ---------------- | ---------------------------------- | --------------------- |
+| Link             | \<a href="...">\</a>               | NotSet*, Lax, None    |
+| Prerender        | \<link rel="prerender" href=".."/> | NotSet*, Lax, None    |
+| Form GET         | \<form method="GET" action="...">  | NotSet*, Lax, None    |
+| Form POST        | \<form method="POST" action="..."> | NotSet*, None         |
+| iframe           | \<iframe src="...">\</iframe>      | NotSet*, None         |
+| AJAX             | $.get("...")                       | NotSet*, None         |
+| Image            | \<img src="...">                   | NetSet*, None         |
 
-Table from [here](https://www.netsparker.com/blog/web-security/same-site-cookie-attribute-prevent-cross-site-request-forgery/)\
+Table from [Invicti](https://www.netsparker.com/blog/web-security/same-site-cookie-attribute-prevent-cross-site-request-forgery/) and slightly modified.\
 A cookie with _**SameSite**_ attribute will **mitigate CSRF attacks** where a logged session is needed.
 
-**Notice that from Chrome80 (feb/2019) the default behaviour of a cookie without a cookie samesite** **attribute will be lax** ([https://www.troyhunt.com/promiscuous-cookies-and-their-impending-death-via-the-samesite-policy/](https://www.troyhunt.com/promiscuous-cookies-and-their-impending-death-via-the-samesite-policy/)).\
+**\*Notice that from Chrome80 (feb/2019) the default behaviour of a cookie without a cookie samesite** **attribute will be lax** ([https://www.troyhunt.com/promiscuous-cookies-and-their-impending-death-via-the-samesite-policy/](https://www.troyhunt.com/promiscuous-cookies-and-their-impending-death-via-the-samesite-policy/)).\
 Notice that temporary, after applying this change, the **cookies without a SameSite** **policy** in Chrome will be **treated as None** during the **first 2 minutes and then as Lax for top-level cross-site POST request.**
 
 ## Cookies Flags


### PR DESCRIPTION
The table of the SameSite cookie flag used the term `Normal`, which is taken from the Invicti website, but could be misleading . Changing it in favor of `NotSet`. Further, adding `None` to the table for comprehensiveness. Finally, adding a hint to `NotSet` in the table, because of the changing default behavior of browsers. Also fixing a typo in a keyword.