### PR TITLE
minor cmsmap is not on pypi, so it can be installed from github

### DIFF
--- a/network-services-pentesting/pentesting-web/moodle.md
+++ b/network-services-pentesting/pentesting-web/moodle.md
@@ -78,7 +78,7 @@ Scan completed.
 ### CMSMap
 
 ```bash
-pip3 install cmsmap
+pip3 install git+https://github.com/dionach/CMSmap.git
 cmsmap http://moodle.example.com/<moodle_path>
 ```
 


### PR DESCRIPTION
install  `cmsmap` command from github instead of  pypi.org because its not available on pypi 