### PR TITLE
Update /pentesting-web/hacking-with-cookies/README.md.

### DIFF
--- a/pentesting-web/hacking-with-cookies/README.md
+++ b/pentesting-web/hacking-with-cookies/README.md
@@ -168,6 +168,10 @@ This avoids the **client** to access the cookie (Via **Javascript** for example:
 
 #### **Bypasses**
 
+* Through the PHP info page if this is disclosed:
+
+  [https://hackcommander.github.io/pentesting-article-1/](https://hackcommander.github.io/pentesting-article-1/)
+  
 * This could be Bypassed with **TRACE** **HTTP** requests as the response from the server (if this HTTP method is available) will reflect the cookies sent. This technique is called **Cross-Site Tracking**.
   * This technique is avoided by **modern browsers by not permitting sending a TRACE** request from JS. However, some bypasses to this have been found in specific software like sending `\r\nTRACE` instead of `TRACE` to IE6.0 SP2.
 * Another way is the exploitation of zero/day vulnerabilities of the browsers.


### PR DESCRIPTION
Added the PHP info page as a method to bypass the HttpOnly flag of the cookies during the exploitation of an XSS.