### PR TITLE
Update pentesting-smb.md - Adding additional technique for rpcclient (authenticated)

### DIFF
--- a/network-services-pentesting/pentesting-smb.md
+++ b/network-services-pentesting/pentesting-smb.md
@@ -121,6 +121,7 @@ nmap --script "safe or smb-enum-*" -p 445 <IP>
 #Connect to the rpc
 rpcclient -U "" -N <IP> #No creds
 rpcclient //machine.htb -U domain.local/USERNAME%754d87d42adabcca32bdb34a876cbffb  --pw-nt-hash
+rpcclient -U "username%passwd" <IP> #With creds
 #You can use querydispinfo and enumdomusers to query user information
 
 #Dump user information


### PR DESCRIPTION
There is a lack of information for authenticated connection via rpcclient. This is one of the ways I used to connect with rpcclient. I hope the format is okay, the point is clear if nothing. 

In quotation marks first goes the username then (%) symbol, which is quite important as it serves as a delimiter for password which comes after it. Full command:
rpcclient -U "username%password" 10.10.10.3