### PR TITLE
Update Pentesting Network - Bettercap Sections

### DIFF
--- a/generic-methodologies-and-resources/pentesting-network/README.md
+++ b/generic-methodologies-and-resources/pentesting-network/README.md
@@ -92,8 +92,8 @@ You can use these tools to passively discover hosts inside a connected network:
 ```bash
 netdiscover -p
 p0f -i eth0 -p -o /tmp/p0f.log
-# Bettercap2
-net.recon on/off
+# Bettercap
+net.recon on/off #Read local ARP cache periodically
 net.show
 set net.show.meta true #more info
 ```
@@ -111,13 +111,13 @@ netdiscover -r <Network> #ARP requests (Discover IPs)
 #NBT discovery
 nbtscan -r 192.168.0.1/24 #Search in Domain
 
-# Bettercap2 (By default ARP requests are sent) 
-net.probe on/off #Activate all service discover and ARP
-net.probe.mdns #Search local mDNS services (Discover local)
-net.probe.nbns #Ask for NetBios name (Discover local)
-net.probe.upnp # Search services (Discover local)
-net.probe.wsd # Search Web Services Discovery (Discover local)
-net.probe.throttle 10 #10ms between requests sent (Discover local)
+# Bettercap
+net.probe on/off #Discover hosts on current subnet by probing with ARP, mDNS, NBNS, UPNP, and/or WSD
+set net.probe.mdns true/false #Enable mDNS discovery probes (default=true)
+set net.probe.nbns true/false #Enable NetBIOS name service discovery probes (default=true)
+set net.probe.upnp true/false #Enable UPNP discovery probes (default=true)
+set net.probe.wsd true/false #Enable WSD discovery probes (default=true)
+set net.probe.throttle 10 #10ms between probes sent (default=10)
 
 #IPv6
 alive6 <IFACE> # Send a pingv6 to multicast.
@@ -139,10 +139,9 @@ Then this kind of packets are usually sent in an **ethernet 0x0842** or in a **U
 If **no \[MAC]** is provided, the packet is sent to **broadcast ethernet** (and the broadcast MAC will be the one being repeated).
 
 ```bash
-#WOL (without MAC is used ff:...:ff)
+# Bettercap (if no [MAC] is specificed ff:ff:ff:ff:ff:ff will be used/entire broadcast domain)
 wol.eth [MAC] #Send a WOL as a raw ethernet packet of type 0x0847
 wol.udp [MAC] #Send a WOL as an IPv4 broadcast packet to UDP port 9
-# Bettercap2 can also be used for this purpose
 ```
 
 ## Scanning Hosts
@@ -164,7 +163,7 @@ nmap -sV -sC -O -T4 -n -Pn -p- -oA fullfastscan <IP>
 # Nmap fast scan for all the ports slower to avoid failures due to -T4
 nmap -sV -sC -O -p- -n -Pn -oA fullscan <IP>
 
-#Bettercap2 Scan
+#Bettercap Scan
 syn.scan 192.168.1.0/24 1 10000 #Ports 1-10000
 ```
 
@@ -247,15 +246,15 @@ ssh user@<TARGET IP> tcpdump -i ens160 -U -s0 -w - | sudo wireshark -k -i -
 ssh <USERNAME>@<TARGET IP> tcpdump -i <INTERFACE> -U -s0 -w - 'port not 22' | sudo wireshark -k -i - # Exclude SSH traffic
 ```
 
-### Bettercap2
+### Bettercap
 
 ```bash
 net.sniff on
 net.sniff stats
-net.sniff.output #Output file
-net.sniff.local #Accept packets from this machine
-net.sniff.filter
-net.sniff.regexp
+set net.sniff.output sniffed.pcap #Write captured packets to file
+set net.sniff.local  #If true it will consider packets from/to this computer, otherwise it will skip them (default=false)
+set net.sniff.filter #BPF filter for the sniffer (default=not arp)
+set net.sniff.regexp #If set only packets matching this regex will be considered
 ```
 
 ### Wireshark
@@ -272,14 +271,14 @@ You can us tools like [https://github.com/lgandx/PCredz](https://github.com/lgan
 
 ARP Spoofing consist on sending gratuitous ARPResponses to indicate that the IP of a machine has the MAC of our device. Then, the victim will change the ARP table and will contact our machine every time it wants to contact the IP spoofed.
 
-#### **Bettercap2**
+#### **Bettercap**
 
 ```bash
 arp.spoof on
-arp.ban on # No ipv4-redirect
-arp.spoof.targets
-arp.spoof.whitelist
-arp.spoof.internal #Spoofed local connections (by default only Victim <--> Gateway
+set arp.spoof.targets <IP> #Specific targets to ARP spoof (default=<entire subnet>)
+set arp.spoof.whitelist #Specific targets to skip while spoofing
+set arp.spoof.fullduplex true #If true, both the targets and the gateway will be attacked, otherwise only the target (default=false)
+set arp.spoof.internal true #If true, local connections among computers of the network will be spoofed, otherwise only connections going to and coming from the Internet (default=false)
 ```
 
 #### **Arpspoof**
@@ -820,7 +819,7 @@ Another interesting test, is to serve a c**ertificate of the requested hostname 
 
 Other things to test is to try to sign the certificate with a valid certificate that it is not a valid CA. Or to use the valid public key, force to use an algorithm as diffie hellman (one that do not need to decrypt anything with the real private key) and when the client request a probe of the real private key (like a hash) send a fake probe and expect that the client does not check this.
 
-## Bettercap 2
+## Bettercap
 
 ```bash
 # Events


### PR DESCRIPTION
Fixing up some of the Bettercap commands and comments using documentation from https://www.bettercap.org/modules/ and double-checking syntax in the Bettercap interface. Removed '2' from Bettercap2 because they're the same tool now.