### PR TITLE
Fix incorrect ipv6 link-local address

### DIFF
--- a/generic-methodologies-and-resources/pentesting-network/pentesting-ipv6.md
+++ b/generic-methodologies-and-resources/pentesting-network/pentesting-ipv6.md
@@ -43,8 +43,8 @@ Suppose the **MAC address** is **`12:34:56:78:9a:bc`**
 
 1. To IPv6 notation: **`1234:5678:9abc`**
 2. Append `fe80::` at the begging and Insert `fffe` in the middle: **`fe80::`**`1234:56`**`ff:fe`**`78:9abc`
-3. Invert seventh bit from the left, from 0001 0010 to 0001 0000: `fe80::1`**`0`**`34:5678:9abc`
-4. `fe80::1034:5678:9abc`
+3. Invert seventh bit from the left, from 0001 0010 to 0001 0000: `fe80::1`**`0`**`34:56ff:fe78:9abc`
+4. `fe80::1034:56ff:fe78:9abc`
 
 **Unique local  address:**  This type of ipv6 address also  not intended to be routed on the public internet. Unique local is a replacement of site-local address, that allows communication within a site while being routable to a multiple local networks.\
 **FEC00::/7**  – The unique local address range.


### PR DESCRIPTION
in the second step the guide tells you to insert `fffe` in the middle, but then omits it which results in an incorrect link-local address.