### PR TITLE
Fix SharpHound CollectionMethod param

### DIFF
--- a/windows-hardening/active-directory-methodology/bloodhound.md
+++ b/windows-hardening/active-directory-methodology/bloodhound.md
@@ -119,7 +119,7 @@ And bloodhound will be ready to ingest data.
 They have several options but if you want to run SharpHound from a PC joined to the domain, using your current user and extract all the information you can do:
 
 ```
-./SharpHound.exe --CollectionMethod All
+./SharpHound.exe --CollectionMethods All
 Invoke-BloodHound -CollectionMethod All
 ```
 


### PR DESCRIPTION
Hey!

The Sharphound.exe param is called `CollectionMethods`. See [the docs](https://github.com/BloodHoundAD/BloodHound/blob/master/docs/data-collection/sharphound.rst).

The param for Invoke-BloodHound seems to stay the same. See [this](https://github.com/BloodHoundAD/BloodHound/blob/master/Collectors/SharpHound.ps1#L15).