### PR TITLE
Fixing Cache Deception Typo

### DIFF
--- a/pentesting-web/cache-deception.md
+++ b/pentesting-web/cache-deception.md
@@ -205,7 +205,8 @@ Sending a header containing an illegal character, `\` would cause a cacheable 40
 
 The goal of Cache Deception is to make clients **load resources that are going to be saved by the cache with their sensitive information**.
 
-First of all note that **extensions** such as `.css`, `.js`, `.png` etc are usually **configured** to be **saved** in the **cache.** Therefore, if you access `www.example.com/profile.php/nonexistent.js` the cache will probably store the response because it sees the `.js` **extension**. But, if the **application** is **replaying** with the **sensitive** user contents stored in _www.example.com/profile.php_, you can **steal** those contents from other users.\
+First of all note that **extensions** such as `.css`, `.js`, `.png` etc are usually **configured** to be **saved** in the **cache.** Therefore, if you access `www.example.com/profile.php/nonexistent.js` the cache will probably store the response because it sees the `.js` **extension**. But, if the **application** is **replaying** with the **sensitive** user contents stored in _www.example.com/profile.php_, you can **steal** those contents from other users.
+
 Other things to test:
 
 * _www.example.com/profile.php/.js_
@@ -213,11 +214,11 @@ Other things to test:
 * _www.example.com/profile.php/test.js_
 * _www.example.com/profile.php/../test.js_
 * _www.example.com/profile.php/%2e%2e/test.js_
-* _Use less known extensions such as_ `.avif`
+* _Use lesser known extensions such as_ `.avif`
 
 Another very clear example can be found in this write-up: [https://hackerone.com/reports/593712](https://hackerone.com/reports/593712).\
 In the example, it is explained that if you load a non-existent page like _http://www.example.com/home.php/non-existent.css_ the content of _http://www.example.com/home.php_ (**with the user's sensitive information**) is going to be returned and the cache server is going to save the result.\
-Then, the **attacker** can access _http://www.example.com/home.php_ and see the **confidential information** of the users that accessed before.
+Then, the **attacker** can access _http://www.example.com/home.php/non-existent.css_ in their own browser and observe the **confidential information** of the users that accessed before.
 
 Note that the **cache proxy** should be **configured** to **cache** files **based** on the **extension** of the file (_.css_) and not base on the content-type. In the example _http://www.example.com/home.php/non-existent.css_ will have a `text/html` content-type instead of a `text/css` mime type (which is the expected for a _.css_ file).
 


### PR DESCRIPTION
Fixing a small typo as it confused my understanding while revising Web Cache Deception attacks. Namely, where an attacker would observe the sensitive cached information after social engineering a user.