### PR TITLE
Badsecrets

### DIFF
--- a/pentesting-web/deserialization/exploiting-__viewstate-parameter.md
+++ b/pentesting-web/deserialization/exploiting-__viewstate-parameter.md
@@ -96,6 +96,36 @@ AspDotNetWrapper.exe --keypath MachineKeys.txt --encrypteddata /wEPDwUKLTkyMTY0M
 
 ![](https://notsosecure.com/sites/all/assets/group/nss\_uploads/2019/06/2.1.png)
 
+[**Badsecrets**](https://github.com/blacklanternsecurity/badsecrets) is another tool which can identify known machineKeys. It is written in Python, so unlock Blacklist3r, there is no Windows dependency. For .NET viewstates, there is a "python blacklist3r" utility, which is the quickest way to use it.
+
+It can either be supplied with the viewstate and generator directly:
+```
+pip install badsecrets
+git clone https://github.com/blacklanternsecurity/badsecrets
+cd badsecrets
+python examples/blacklist3r.py --viewstate /wEPDwUJODExMDE5NzY5ZGQMKS6jehX5HkJgXxrPh09vumNTKQ== --generator EDD8C9AE
+```
+
+![](https://user-images.githubusercontent.com/24899338/227034640-662b6aad-f8b9-49e4-9a6b-62a5f6ae2d60.png)
+
+Or, it can connect directly to the target URL and try to carve the viewstate out of the HTML:
+```
+pip install badsecrets
+git clone https://github.com/blacklanternsecurity/badsecrets
+cd badsecrets
+python examples/blacklist3r.py --url http://vulnerablesite/vulnerablepage.aspx
+```
+
+![](https://user-images.githubusercontent.com/24899338/227034654-e8ad9648-6c0e-47cb-a873-bf97623a0089.png)
+
+To search for vulnerable viewstates at scale, in conjunction with subdomain enumeration, the `badsecrets` [**BBOT**]() module can be used:
+
+```
+bbot -f subdomain-enum -m badsecrets -t evil.corp
+```
+
+![](https://user-images.githubusercontent.com/24899338/227028780-950d067a-4a01-481f-8e11-41fabed1943a.png)
+
 If you are lucky and the key is found,you can proceed with the attack using [**YSoSerial.Net**](https://github.com/pwntester/ysoserial.net)**:**
 
 ```
@@ -158,6 +188,15 @@ For a more detailed description for IISDirPath and TargetPagePath [refer here](h
 
 ![](https://notsosecure.com/sites/all/assets/group/nss\_uploads/2019/06/4.1.png)
 
+
+Or, with [**Badsecrets**](https://github.com/blacklanternsecurity/badsecrets) (with a generator value):
+
+```
+cd badsecrets
+python examples/blacklist3r.py --viewstate JLFYOOegbdXmPjQou22oT2IxUwCAzSA9EAxD6+305e/4MQG7G1v5GI3wL7D94W2OGpVGrI2LCqEwDoS/8JkE0rR4ak0= --generator B2774415
+```
+![](https://user-images.githubusercontent.com/24899338/227043316-13f0488f-5326-46cc-9604-404b908ebd7b.png)
+
 Once a valid Machine key is identified, **the next step is to generate a serialized payload using** [**YSoSerial.Net**](https://github.com/pwntester/ysoserial.net)
 
 ```
@@ -194,6 +233,7 @@ out of band request with the current username
 * [**https://www.notsosecure.com/exploiting-viewstate-deserialization-using-blacklist3r-and-ysoserial-net/**](https://www.notsosecure.com/exploiting-viewstate-deserialization-using-blacklist3r-and-ysoserial-net/)
 * [**https://medium.com/@swapneildash/deep-dive-into-net-viewstate-deserialization-and-its-exploitation-54bf5b788817**](https://medium.com/@swapneildash/deep-dive-into-net-viewstate-deserialization-and-its-exploitation-54bf5b788817)\\
 * [**https://soroush.secproject.com/blog/2019/04/exploiting-deserialisation-in-asp-net-via-viewstate/**](https://soroush.secproject.com/blog/2019/04/exploiting-deserialisation-in-asp-net-via-viewstate/)
+* [**https://blog.blacklanternsecurity.com/p/introducing-badsecrets**](https://blog.blacklanternsecurity.com/p/introducing-badsecrets)
 
 <img src="../../.gitbook/assets/image (1) (1) (1) (1).png" alt="" data-size="original">
 

--- a/pentesting-web/deserialization/exploiting-__viewstate-parameter.md
+++ b/pentesting-web/deserialization/exploiting-__viewstate-parameter.md
@@ -96,7 +96,7 @@ AspDotNetWrapper.exe --keypath MachineKeys.txt --encrypteddata /wEPDwUKLTkyMTY0M
 
 ![](https://notsosecure.com/sites/all/assets/group/nss\_uploads/2019/06/2.1.png)
 
-[**Badsecrets**](https://github.com/blacklanternsecurity/badsecrets) is another tool which can identify known machineKeys. It is written in Python, so unlock Blacklist3r, there is no Windows dependency. For .NET viewstates, there is a "python blacklist3r" utility, which is the quickest way to use it.
+[**Badsecrets**](https://github.com/blacklanternsecurity/badsecrets) is another tool which can identify known machineKeys. It is written in Python, so unlike Blacklist3r, there is no Windows dependency. For .NET viewstates, there is a "python blacklist3r" utility, which is the quickest way to use it.
 
 It can either be supplied with the viewstate and generator directly:
 ```

--- a/pentesting-web/deserialization/java-jsf-viewstate-.faces-deserialization.md
+++ b/pentesting-web/deserialization/java-jsf-viewstate-.faces-deserialization.md
@@ -209,6 +209,32 @@ else:
 	print(GREEN + "[*] Saved to : {}".format(sys.argv[2]))
 ```
 
+# Detection with Badsecrets
+
+![Badsecrets](https://github.com/blacklanternsecurity/badsecrets) is a library capable of detecting the use of known cryptographic keys by looking at the products they produce, and checking against a list of known or weak keys. Its `Jsf_viewstate` module is capable of detecting Java Server Faces ViewStates created with known keys on both Mojarra and MyFaces, in addition to unprotected or compressed ViewStates. 
+
+The quickest way to use it is with the `cli.py` example tool as follows:
+
+```
+pip install badsecrets
+git clone https://github.com/blacklanternsecurity/badsecrets
+cd badsecrets
+python examples/cli.py Ly8gp+FZKt9XsaxT5gZu41DDxO74k029z88gNBOru2jXW0g1Og+RUPdf2d8hGNTiofkD1VvmQTZAfeV+5qijOoD+SPzw6K72Y1H0sxfx5mFcfFtmqX7iN6Gq0fwLM+9PKQz88f+e7KImJqG1cz5KYhcrgT87c5Ayl03wEHvWwktTq9TcBJc4f1VnNHXVZgALGqQuETU8hYwZ1VilDmQ7J4pZbv+pvPUvzk+/e2oNeybso6TXqUrbT2Mz3k7yfe92q3pRjdxRlGxmkO9bPqNOtETlLPE5dDiZYo1U9gr8BBQ=
+```
+
+![](https://user-images.githubusercontent.com/24899338/227623883-f760570d-796e-459d-87b0-b87ad33999ae.png)
+
+If it finds a match, it will also list the platform (Mojarra or MyFaces), the encryption algorithm in use, and whether compression was used or not, which are all essential for exploitation.
+
+To search for vulnerable viewstates at scale, in conjunction with subdomain enumeration, the `badsecrets` [**BBOT**]() module can be used:
+
+```
+bbot -f subdomain-enum -m badsecrets -t evil.corp
+```
+
+![](https://user-images.githubusercontent.com/24899338/227626488-e45e99b2-0f6d-451e-8a43-7d6db75098de.png)
+
+
 # Final thoughts
 
 Most facts about JSF ViewStates and their dangers presented in this blog post are not exactly new but it seems they were never presented in such a condensed way. It showed [once more](https://www.alphabot.com/security/blog/2017/net/How-to-configure-Json.NET-to-create-a-vulnerable-web-API.html) that seemingly harmless configuration changes can lead to serious vulnerabilities.

--- a/pentesting-web/deserialization/java-jsf-viewstate-.faces-deserialization.md
+++ b/pentesting-web/deserialization/java-jsf-viewstate-.faces-deserialization.md
@@ -76,7 +76,7 @@ Everything happened before the JSF implementation could have a look at the ViewS
 
 Now, what are the ingredients for a disaster?
 
-* unencrypted ViewState
+* unencrypted ViewState (or, possession of the encryption key)
 * Gadget on the classpath of the server
 * In case of Mojarra: ViewState configured to reside on the `client`
 * In case of MyFaces: ViewState configured to reside on the `client` **or** the `server`
@@ -209,7 +209,7 @@ else:
 	print(GREEN + "[*] Saved to : {}".format(sys.argv[2]))
 ```
 
-# Detection with Badsecrets
+# Known Key Detection with Badsecrets
 
 ![Badsecrets](https://github.com/blacklanternsecurity/badsecrets) is a library capable of detecting the use of known cryptographic keys by looking at the products they produce, and checking against a list of known or weak keys. Its `Jsf_viewstate` module is capable of detecting Java Server Faces ViewStates created with known keys on both Mojarra and MyFaces, in addition to unprotected or compressed ViewStates. 
 


### PR DESCRIPTION
Badsecrets is a new library for detecting the use of known secrets by examining the cryptographic products they produce and comparing them against its repository of known keys. Two of the most important Badsecrets modules (ASPNET_viewstate and Jsf_viewstate) provide new and more effective ways to attack these platforms.

For example, for asp.net viewstates, Badsecrets allows for detecting known keys without requiring a C# program as it currently does, so it can be done in Linux, and done much faster.

For javaserver-faces viewstates, existing tooling is lacking in terms detection of known keys across all versions, which have significant differences in their crypto implementations

My changes add references to Badsecrets for those two use cases.