### PR TITLE
Update werkzeug.md | Replaced md5 with sha1

### DIFF
--- a/network-services-pentesting/pentesting-web/werkzeug.md
+++ b/network-services-pentesting/pentesting-web/werkzeug.md
@@ -176,7 +176,7 @@ print(rv)
 ```
 
 {% hint style="success" %}
-If you are on an **old version** of Werkzeug, try changing the **hashing algorithm to md5** instead of md5.
+If you are on an **old version** of Werkzeug, try changing the **hashing algorithm to md5** instead of sha1.
 {% endhint %}
 
 ## References


### PR DESCRIPTION
Corrected sentence 

`If you are on an **old version** of Werkzeug, try changing the **hashing algorithm to md5** instead of md5.` 

To

`If you are on an **old version** of Werkzeug, try changing the **hashing algorithm to md5** instead of sha1.`