### PR TITLE
Add special character to bypass file upload restrictions

### DIFF
--- a/pentesting-web/file-upload/README.md
+++ b/pentesting-web/file-upload/README.md
@@ -50,7 +50,7 @@ Other useful extensions:
 4. Try to bypass the protections **tricking the extension parser** of the server-side with techniques like **doubling** the **extension** or **adding junk** data (**null** bytes) between extensions. _You can also use the **previous extensions** to prepare a better payload._
    * _file.png.php_
    * _file.png.pHp5_
-   * _file.php#.png
+   * _file.php#.png_
    * _file.php%00.png_
    * _file.php\x00.png_
    * _file.php%0a.png_

--- a/pentesting-web/file-upload/README.md
+++ b/pentesting-web/file-upload/README.md
@@ -50,6 +50,7 @@ Other useful extensions:
 4. Try to bypass the protections **tricking the extension parser** of the server-side with techniques like **doubling** the **extension** or **adding junk** data (**null** bytes) between extensions. _You can also use the **previous extensions** to prepare a better payload._
    * _file.png.php_
    * _file.png.pHp5_
+   * _file.php#.png
    * _file.php%00.png_
    * _file.php\x00.png_
    * _file.php%0a.png_


### PR DESCRIPTION
Adding a "#" character before a legitimate file extension might allow the attacker to upload a file (for instance, file.php#.png), which the server does think it is a png file, but when the file is checked on the browser - after upload - (i.e.: http://www.example.com/uploads/file.php#.png), since the "#" exists, it works as a "named anchor" or "fragment" and not as a file extension, so the PHP file gets executed.