### PR TITLE
add missing semicolons in nginx conf flie

### DIFF
--- a/network-services-pentesting/pentesting-web/nginx.md
+++ b/network-services-pentesting/pentesting-web/nginx.md
@@ -39,7 +39,7 @@ Inside the Nginx configuration look the "location" statements, if someone looks 
 
 ```
 location /imgs { 
-    alias /path/images/ 
+    alias /path/images/;
 }
 ```
 
@@ -59,7 +59,7 @@ The correct configuration will be:
 
 ```
 location /imgs/ { 
-    alias /path/images/ 
+    alias /path/images/;
 }
 ```
 


### PR DESCRIPTION
without semicolon after the line, the result would be
```
Job for nginx.service failed because the control process exited with error code.
See "systemctl status nginx.service" and "journalctl -xeu nginx.service" for details.
```