### PR TITLE
Fixed missing return characters in RTSP samples

### DIFF
--- a/network-services-pentesting/554-8554-pentesting-rtsp.md
+++ b/network-services-pentesting/554-8554-pentesting-rtsp.md
@@ -39,7 +39,7 @@ First and foremost RTSP is an HTTP like protocol. It has different structure and
 
 RTSP can be accessed unauthenticated (common in off-the-shelf devices) or authenticated. Authenticated access mirrors HTTP in that you have Basic and Digest authentication, both nearly identical to HTTP. To find out whether your device is authenticated or unauthenticated, simply send a “DESCRIBE” request. A simple DESCRIBE request looks like:
 
-`DESCRIBE rtsp://<ip>:<port> RTSP/1.0\r\nCSeq: 2`
+`DESCRIBE rtsp://<ip>:<port> RTSP/1.0\r\nCSeq: 2\r\n\r\n`
 
 Note: the additional “\r\n” is required for reliable response. Some systems will accept the single “\r\n” but most won’t.
 
@@ -53,7 +53,7 @@ Basic authentication is the way to go, hopefully the response received indicates
 
 To formulate a Basic authentication element, one simple has to base 64 encode \<username> “:” \<password> and add it to the request. So a new request would look like:
 
-`DESCRIBE rtsp://<ip>:<port> RTSP/1.0\r\nCSeq: 2\r\nAuthorization: Basic YWRtaW46MTIzNA==`
+`DESCRIBE rtsp://<ip>:<port> RTSP/1.0\r\nCSeq: 2\r\nAuthorization: Basic YWRtaW46MTIzNA==\r\n\r\n`
 
 Again note the request is terminated with the double “\r\n”.
 


### PR DESCRIPTION
The DESCRIBE examples were missing the required \r\n\r\n's - I added them back in.