### PR TITLE
Update airbus ioxid article links

### DIFF
--- a/network-services-pentesting/135-pentesting-msrpc.md
+++ b/network-services-pentesting/135-pentesting-msrpc.md
@@ -90,14 +90,14 @@ _Note that from the mentioned options all except of **`tcp_dcerpc_auditor`** can
 
 ### Identifying IP addresses
 
-Using [https://github.com/mubix/IOXIDResolver](https://github.com/mubix/IOXIDResolver), comes from [Airbus research](https://airbus-cyber-security.com/the-oxid-resolver-part-1-remote-enumeration-of-network-interfaces-without-any-authentication/) is possible to abuse the _**ServerAlive2**_ method inside the _**IOXIDResolver**_ interface.
+Using [https://github.com/mubix/IOXIDResolver](https://github.com/mubix/IOXIDResolver), comes from [Airbus research](https://www.cyber.airbus.com/the-oxid-resolver-part-1-remote-enumeration-of-network-interfaces-without-any-authentication/) is possible to abuse the _**ServerAlive2**_ method inside the _**IOXIDResolver**_ interface.
 
 This method has been used to get interface information as **IPv6** address from the HTB box _APT_. See [here](https://0xdf.gitlab.io/2021/04/10/htb-apt.html) for 0xdf APT writeup, it includes an alternative method using rpcmap.py from [Impacket](https://github.com/SecureAuthCorp/impacket/) with _stringbinding_ (see above).
 
 References:
 
-* [https://airbus-cyber-security.com/the-oxid-resolver-part-1-remote-enumeration-of-network-interfaces-without-any-authentication/](https://airbus-cyber-security.com/the-oxid-resolver-part-1-remote-enumeration-of-network-interfaces-without-any-authentication/)
-* [https://airbus-cyber-security.com/the-oxid-resolver-part-2-accessing-a-remote-object-inside-dcom/](https://airbus-cyber-security.com/the-oxid-resolver-part-2-accessing-a-remote-object-inside-dcom/)
+* [https://www.cyber.airbus.com/the-oxid-resolver-part-1-remote-enumeration-of-network-interfaces-without-any-authentication/](https://www.cyber.airbus.com/the-oxid-resolver-part-1-remote-enumeration-of-network-interfaces-without-any-authentication/)
+* [https://www.cyber.airbus.com/the-oxid-resolver-part-2-accessing-a-remote-object-inside-dcom/](https://www.cyber.airbus.com/the-oxid-resolver-part-2-accessing-a-remote-object-inside-dcom/)
 
 ## Port 593
 


### PR DESCRIPTION
Just a small update for the links to the articles about IOXIDResolver from airbus. I noticed the links were dead, so I fetched the new ones :)