### PR TITLE
Correct sandboxing info in iframes-in-xss-and-csp.md

### DIFF
--- a/pentesting-web/xss-cross-site-scripting/iframes-in-xss-and-csp.md
+++ b/pentesting-web/xss-cross-site-scripting/iframes-in-xss-and-csp.md
@@ -123,7 +123,7 @@ if __name__ == "__main__":
 
 ### Iframe sandbox
 
-The `sandbox` attribute enables an extra set of restrictions for the content in the iframe. **By default, no restriction is applied.**
+The `sandbox` attribute enables an extra set of restrictions for the content in the iframe. **By default, all restrictions are applied.**
 
 When the `sandbox` attribute is present, and it will:
 


### PR DESCRIPTION
Small error in sandboxing info here. When setting the `sandbox` attribute, a value of `sandbox=""` enforces all restrictions by default (as mentioned lower down on the same page).