### PR TITLE
Change: machine_id explanation

### DIFF
--- a/network-services-pentesting/pentesting-web/werkzeug.md
+++ b/network-services-pentesting/pentesting-web/werkzeug.md
@@ -86,7 +86,7 @@ private_bits = [
     >>> print(0x5600027a23ac)
     94558041547692
     ```
-* `get_machine_id()` concatenate the **values in `/etc/machine-id`** , **`/proc/sys/kernel/random/boot_id`** and **first line of `/proc/self/cgroup`** after the last slash (`/`).
+* `get_machine_id()` concatenate the **values in `/etc/machine-id`** or **`/proc/sys/kernel/random/boot_id`** with the **first line of `/proc/self/cgroup`** after the last slash (`/`).
 
 <details>
 


### PR DESCRIPTION
The current commentary apparently tells to the user concatenate the three values, machine_id, boot_id and the cgroup name. Causing a confusion in exploiting process.