### PR TITLE
Add information relevant to the Xamarin AssemblyStore

### DIFF
--- a/mobile-pentesting/xamarin-apps.md
+++ b/mobile-pentesting/xamarin-apps.md
@@ -80,6 +80,12 @@ In case of Android **APKs these dll files are compressed** and cannot be directl
 python3 xamarin-decompress.py -o /path/to/decompressed/apk
 ```
 
+It is possible instead of dll files you will see `assemblies.blob` and `assemblies.manifest` in the assemblies directory. This is a Xamarin AssemblyStore and the currently recommended way to pack dlls in an Android application. The `assemblies.manifest` is a text file describing the contents of the binary file `assemblies.blob`. To unpack these you will need use [pyxamstore](https://github.com/jakev/pyxamstore).
+
+```
+pyxamstore unpack -d /path/to/decompressed/apk/assemblies/
+```
+
 In the case of the iOS, **dll files inside the IPA files can be directly loaded** into a decompiler (no need to uncompress anything).
 
 **Most of the application code can be found when we decompile the dll files.**  Also note that Xamarin Framework based apps contain 90% of common code in the builds of all platforms like iOS and Android etc.&#x20;
@@ -105,6 +111,7 @@ Try to check if the application has any kind of SSL pinning in place. If not, us
 ## References
 
 * [https://www.appknox.com/security/xamarin-reverse-engineering-a-guide-for-penetration-testers](https://www.appknox.com/security/xamarin-reverse-engineering-a-guide-for-penetration-testers)
+* [https://thecobraden.com/posts/unpacking_xamarin_assembly_stores/](https://thecobraden.com/posts/unpacking_xamarin_assembly_stores/)
 
 <details>
 


### PR DESCRIPTION
The Xamarin AssemblyStore is the currently recommended way of packing Xamarin DLLs in Android applications. pyxstore will unpack the DLLs found in the assemblies.blob to perform further analysis. This commit describes that process in some detail.