### PR TITLE
add dockerized version of nginx proxy with ajp

### DIFF
--- a/network-services-pentesting/8009-pentesting-apache-jserv-protocol-ajp.md
+++ b/network-services-pentesting/8009-pentesting-apache-jserv-protocol-ajp.md
@@ -108,6 +108,8 @@ Module options (exploit/multi/http/tomcat_mgr_deploy):
 
 ### Nginx Reverse Proxy & AJP
 
+[Checkout the Dockerized version](#Dockerized-version)
+
 When we come across an open AJP proxy port (8009 TCP), we can use Nginx with the `ajp_module` to access the "hidden" Tomcat Manager. This can be done by compiling the Nginx source code and adding the required module, as follows:
 
 * Download the Nginx source code
@@ -181,6 +183,19 @@ curl http://127.0.0.1:80
                     <h2>If you're seeing this, you've successfully installed Tomcat. Congratulations!</h2>
 <SNIP>
 ```
+
+### Dockerized-version
+
+```bash
+git clone https://github.com/ScribblerCoder/nginx-ajp-docker
+cd nginx-ajp-docker
+```
+Replace `TARGET-IP` in `nginx.conf` witg AJP IP then build and run
+``` bash
+docker build . -t nginx-ajp-proxy
+docker run -it --rm -p 80:80 nginx-ajp-proxy
+```
+
 
 ## References
 


### PR DESCRIPTION
I added a dockerized version of nginx reverse proxy with ajp modules to make it easier to setup/run without having to install and compile any dependencies on your host machine