### PR TITLE
Adding SQL Server Linked Servers Passwords Attack

### DIFF
--- a/network-services-pentesting/pentesting-mssql-microsoft-sql-server/README.md
+++ b/network-services-pentesting/pentesting-mssql-microsoft-sql-server/README.md
@@ -495,6 +495,26 @@ Invoke-SqlServer-Escalate-ExecuteAs -SqlServerInstance 10.2.9.101 -SqlUser myuse
 
 [https://blog.netspi.com/sql-server-persistence-part-1-startup-stored-procedures/](https://blog.netspi.com/sql-server-persistence-part-1-startup-stored-procedures/)
 
+## Extracting passwords from SQL Server Linked Servers
+An attacker can extract SQL Server Linked Servers passwords from the SQL Instances and get them in clear text, granting the attacker passwords that can be used to acquire a greater foothold on the target.
+The script to extract and decrypt the passwords stored for the Linked Servers can be found [here](https://www.richardswinbank.net/admin/extract_linked_server_passwords)
+
+Some requirements, and configurations must be done in order for this exploit to work.
+First of all, you must have Administrator rights on the machine, or the ability to manage the SQL Server Configurations.
+
+After validating your permissions, you need to configure three things, which are the following:
+1. Enable TCP/IP on the SQL Server instances;
+2. Add a Start Up parameter, in this case, a trace flag will be added, which is -T7806.
+3. Enable remote admin connection.
+
+To automate these configurations, [this repository ](https://github.com/IamLeandrooooo/SQLServerLinkedServersPasswords/) has the needed scripts.
+Besides having a powershell script for each step of the configuration, the repository also has a full script which combines the configuration scripts and the extraction and decryption of the passwords.
+
+For further information, refer to the following links regarding this attack:
+[Decrypting MSSQL Database Link Server Passwords](https://www.netspi.com/blog/technical/adversary-simulation/decrypting-mssql-database-link-server-passwords/)
+
+[Troubleshooting the SQL Server Dedicated Administrator Connection](https://www.mssqltips.com/sqlservertip/5364/troubleshooting-the-sql-server-dedicated-administrator-connection/)
+
 ## Local Privilege Escalation
 
 The user running MSSQL server will have enabled the privilege token **SeImpersonatePrivilege.**\


### PR DESCRIPTION
Adding a section to the pentesting-mssql-microsoft-sql-server playbook where SQL Server Linked Servers Passwords Attack is detailed with information and scripts to handle the needed configurations. Also a script for the extraction and decryption of the passwords is added. Furthermore, additional information is provided to better understand the attack.