### PR TITLE
Fix nmap example in pentesting-network's README

### DIFF
--- a/generic-methodologies-and-resources/pentesting-network/README.md
+++ b/generic-methodologies-and-resources/pentesting-network/README.md
@@ -31,7 +31,7 @@ You could also use **nmap** to send other types of ICMP packets (this will avoid
 ```bash
 ping -c 1 199.66.11.4    # 1 echo request to a host
 fping -g 199.66.11.0/24  # Send echo requests to ranges
-nmap -PEPM -sP -n 199.66.11.0/24 #Send echo, timestamp requests and subnet mask requests
+nmap -PE -PM -PP -sn -n 199.66.11.0/24 #Send echo, timestamp requests and subnet mask requests
 ```
 
 ### TCP Port Discovery
@@ -130,7 +130,7 @@ But, as you are in the **same network** as the other hosts, you can do **more th
 
 * If you **ping** a **subnet broadcast address** the ping should be arrive to **each host** and they could **respond** to **you**: `ping -b 10.10.5.255`
 * Pinging the **network broadcast address** you could even find hosts inside **other subnets**: `ping -b 255.255.255.255`
-* Use the `-PEPM` flag of `nmap`to perform host discovery sending **ICMPv4 echo**, **timestamp**, and **subnet mask requests:** `nmap -PEPM -sP –vvv -n 10.12.5.0/24`
+* Use the `-PE`, `-PP`, `-PM` flags of `nmap`to perform host discovery sending respectively **ICMPv4 echo**, **timestamp**, and **subnet mask requests:** `nmap -PE -PM -PP -sn -vvv -n 10.12.5.0/24`
 
 ### **Wake On Lan**
 


### PR DESCRIPTION
Hi!

Some nmap syntax in the network discovery file seems to be outdated. `-PEPM` doesn't work, but `-PE -PM -PP` does, and `-sP` has been replaced by `-sn`.

Cheers!