### PR TITLE
Update stego-tricks.md - append to section "Some other image tools wo…

### DIFF
--- a/stego/stego-tricks.md
+++ b/stego/stego-tricks.md
@@ -164,6 +164,9 @@ Get details on a PNG file (or even find out it's actually something else!).\
 
 * [http://magiceye.ecksdee.co.uk/](http://magiceye.ecksdee.co.uk/)
 * [https://29a.ch/sandbox/2012/imageerrorlevelanalysis/](https://29a.ch/sandbox/2012/imageerrorlevelanalysis/)
+* [https://github.com/resurrecting-open-source-projects/outguess](https://github.com/resurrecting-open-source-projects/outguess)
+* [https://www.openstego.com/](https://www.openstego.com/)
+* [https://diit.sourceforge.net/](https://diit.sourceforge.net/)
 
 ## Extracting data from audios
 


### PR DESCRIPTION
Added links for OpenStego, OutGuess (a legacy/classic), and DIIT (also legacy, favorite of some CTFs)  under the "some other image tools..." section--plan to flesh out proper descriptions later, but felt important to include (as files produced by one set of stego tools are often not compatible with another--an incomplete list of resources can be...torment.)  