### PR TITLE
Remove `X-ProxyUser-Ip: 127.0.0.1` duplicate in `network-services-pentesting/pentesting-web/special-http-headers`

### DIFF
--- a/network-services-pentesting/pentesting-web/special-http-headers.md
+++ b/network-services-pentesting/pentesting-web/special-http-headers.md
@@ -35,7 +35,6 @@ Rewrite **IP source**:
 * `X-Host: 127.0.0.1`
 * `True-Client-IP: 127.0.0.1`
 * `Cluster-Client-IP: 127.0.0.1`
-* `X-ProxyUser-Ip: 127.0.0.1`
 * `Via: 1.0 fred, 1.1 127.0.0.1`
 * `Connection: close, X-Forwarded-For` (Check hop-by-hop headers)
 


### PR DESCRIPTION
I see duplicate entry `X-ProxyUser-Ip: 127.0.0.1` in https://book.hacktricks.xyz/network-services-pentesting/pentesting-web/special-http-headers and I propose to remove it.