### PR TITLE
Correct spelling in Android README.md.

### DIFF
--- a/mobile-pentesting/android-app-pentesting/README.md
+++ b/mobile-pentesting/android-app-pentesting/README.md
@@ -292,7 +292,7 @@ You need to activate the **debugging** options and it will be cool if you can **
 5. Go back and you will find the **Developer options**.
 
 > Once you have installed the application, the first thing you should do is to try it and investigate what does it do, how does it work and get comfortable with it.\
-> I will suggest to **perform this initial dynamic analysis using MobSF dynamic analysis + pidcat**, so will will be able to **learn how the application works** while MobSF **capture** a lot of **interesting** **data** you can review later on.
+> I will suggest to **perform this initial dynamic analysis using MobSF dynamic analysis + pidcat**, so we will be able to **learn how the application works** while MobSF **captures** a lot of **interesting** **data** you can review later on.
 
 ### Unintended Data Leakage
 


### PR DESCRIPTION
The Android App Pentesting guide features some spelling mistakes, which this pull request corrects.