### PR TITLE
Fixed broken link in the section on to bypass HttpOnly flag during XSS exploitation.

### DIFF
--- a/pentesting-web/hacking-with-cookies/README.md
+++ b/pentesting-web/hacking-with-cookies/README.md
@@ -78,7 +78,7 @@ This avoids the **client** to access the cookie (Via **Javascript** for example:
 
 #### **Bypasses**
 
-* If the page is **sending the cookies as the response** of a requests (for example in a **PHPinfo** page), it's possible to abuse the XSS to send a request to this page and **steal the cookies** from the response (check an example in [https://hackcommander.github.io/pentesting-article-1/)](https://hackcommander.github.io/pentesting-article-1/)
+* If the page is **sending the cookies as the response** of a requests (for example in a **PHPinfo** page), it's possible to abuse the XSS to send a request to this page and **steal the cookies** from the response (check an example in [https://hackcommander.github.io/posts/2022/11/12/bypass-httponly-via-php-info-page/](https://hackcommander.github.io/posts/2022/11/12/bypass-httponly-via-php-info-page/).
 * This could be Bypassed with **TRACE** **HTTP** requests as the response from the server (if this HTTP method is available) will reflect the cookies sent. This technique is called **Cross-Site Tracking**.
   * This technique is avoided by **modern browsers by not permitting sending a TRACE** request from JS. However, some bypasses to this have been found in specific software like sending `\r\nTRACE` instead of `TRACE` to IE6.0 SP2.
 * Another way is the exploitation of zero/day vulnerabilities of the browsers.


### PR DESCRIPTION
I renamed the posts of my blog to make them a little more descriptive and changed the link https://hackcommander.github.io/pentesting-article-1/ to https://hackcommander.github.io/posts/2022/11/12/bypass-httponly-via-php-info-page/.