### PR TITLE
change "gRPC Pentest" title to "gRPC-Web Pentest"

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -597,7 +597,7 @@
 * [File Upload](pentesting-web/file-upload/README.md)
   * [PDF Upload - XXE and CORS bypass](pentesting-web/file-upload/pdf-upload-xxe-and-cors-bypass.md)
 * [Formula/CSV/Doc/LaTeX/GhostScript Injection](pentesting-web/formula-csv-doc-latex-ghostscript-injection.md)
-* [gRPC Pentest](pentesting-web/grpc-web-pentest.md)
+* [gRPC-Web Pentest](pentesting-web/grpc-web-pentest.md)
 * [HTTP Connection Contamination](pentesting-web/http-connection-contamination.md)
 * [HTTP Connection Request Smuggling](pentesting-web/http-connection-request-smuggling.md)
 * [HTTP Request Smuggling / HTTP Desync Attack](pentesting-web/http-request-smuggling/README.md)


### PR DESCRIPTION
After I added gRPC-Web Pentest to Hacktricks (https://github.com/carlospolop/hacktricks/commit/c8a6851ba27854618abd981f3495219af806da78), the title in the summary was added wrongly by maintainers. The right title is gRPC-Web Pentest not gRPC Pentest. Because gRPC and gRPC-Web are not same.