### PR TITLE
Improve confusing explanation in race-condition page

### DIFF
--- a/pentesting-web/race-condition.md
+++ b/pentesting-web/race-condition.md
@@ -38,7 +38,7 @@ But, using HTTP/1.1 '**last-byte sync**' technique it's possible to pre-send the
 To **pre-send the bulk of each request**:
 
 * If the request has no body, send all the headers, but don't set the END\_STREAM flag. Withhold an empty data frame with END\_STREAM set.
-* If the request has a body, send the headers and all the body data except the final byte. Withhold a data frame containing the final byte.
+* If the request has a body, send the headers and all the body data except the final byte and the END\_STREAM flag. Withhold a data frame containing the final byte.
 
 Next, **prepare to send the final frames**:
 


### PR DESCRIPTION
I was recently learning about Single packet attacks using your site (and others). I was very confused and assumed, that when the request has a body, ONLY the last byte will be removed(not stripping the END_STREAM flag). This doesnt make any sense as the server wouldn't wait for more data as the request wouldn't be  incomplete.

Reference: https://infosecwriteups.com/dive-into-single-packet-attack-3d3849ffe1d2 

Greetings 