### PR TITLE
Fixed netsh command for spaces in SSIDs

### DIFF
--- a/windows-hardening/windows-local-privilege-escalation/README.md
+++ b/windows-hardening/windows-local-privilege-escalation/README.md
@@ -912,7 +912,7 @@ netsh wlan show profile
 #To get the clear-text password use
 netsh wlan show profile <SSID> key=clear
 #Oneliner to extract all wifi passwords
-cls & echo. & for /f "tokens=4 delims=: " %a in ('netsh wlan show profiles ^| find "Profile "') do @echo off > nul & (netsh wlan show profiles name=%a key=clear | findstr "SSID Cipher Content" | find /v "Number" & echo.) & @echo on
+cls & echo. & for /f "tokens=3,* delims=: " %a in ('netsh wlan show profiles ^| find "Profile "') do @echo off > nul & (netsh wlan show profiles name="%b" key=clear | findstr "SSID Cipher Content" | find /v "Number" & echo.) & @echo on*
 ```
 
 ### Saved RDP Connections


### PR DESCRIPTION
Fixed netsh wlan commands for SSIDs that have spaces in their names like "This is my wifi".