### PR TITLE
Add another option for SeDebugPrivilege Code Execution

### DIFF
--- a/windows-hardening/windows-local-privilege-escalation/privilege-escalation-abusing-tokens/README.md
+++ b/windows-hardening/windows-local-privilege-escalation/privilege-escalation-abusing-tokens/README.md
@@ -141,8 +141,9 @@ mimikatz # sekurlsa::logonpasswords
 
 If you want to get a `NT SYSTEM` shell you could use:
 
-* ****[**SeDebugPrivilegePoC**](https://github.com/daem0nc0re/PrivFu/tree/main/PrivilegedOperations/SeDebugPrivilegePoC)****
-* ****[**psgetsys.ps1**](https://raw.githubusercontent.com/decoder-it/psgetsystem/master/psgetsys.ps1)****
+* ****[**SeDebugPrivilege-Exploit (C++)**](https://github.com/bruno-1337/SeDebugPrivilege-Exploit)****
+* ****[**SeDebugPrivilegePoC (C#)**](https://github.com/daem0nc0re/PrivFu/tree/main/PrivilegedOperations/SeDebugPrivilegePoC)****
+* ****[**psgetsys.ps1 (Powershell Script)**](https://raw.githubusercontent.com/decoder-it/psgetsystem/master/psgetsys.ps1)****
 
 ```powershell
 # Get the PID of a process running as NT SYSTEM


### PR DESCRIPTION
Added another option of code execution on the SeDebugPrivilege Token, this one is made in C++ and should be useful in machines that don't have .NET installed.

