### PR TITLE
Update nosql-injection.md: clarify aggregate() requirement

### DIFF
--- a/pentesting-web/nosql-injection.md
+++ b/pentesting-web/nosql-injection.md
@@ -125,6 +125,8 @@ Using the **$func** operator of the [MongoLite](https://github.com/agentejo/cock
 
 It's possible to use [**$lookup**](https://www.mongodb.com/docs/manual/reference/operator/aggregation/lookup/) to get info from a different collection. In the following example, we are reading from a **different collection** called **`users`** and getting the **results of all the entries** with a password matching a wildcard.
 
+**NOTE:** `$lookup` and other aggregation functions are only available if the `aggregate()` function was used to perform the search instead of the more common `find()` or `findOne()` functions.
+
 ```json
 [
   {


### PR DESCRIPTION
It should be clarified that `$lookup` and other such functions are only available if the `aggregate()` function was used in the backend.