### PR TITLE
Fix dead link and add resource to pentesting-web

### DIFF
--- a/network-services-pentesting/pentesting-web/README.md
+++ b/network-services-pentesting/pentesting-web/README.md
@@ -328,7 +328,7 @@ _Note that anytime a new directory is discovered during brute-forcing or spideri
   * **Javascript Beautifier:** [http://jsbeautifier.org/](https://beautifier.io), [http://jsnice.org/](http://jsnice.org)
   * **JsFuck deobfuscation** (javascript with chars:"\[]!+" [https://enkhee-osiris.github.io/Decoder-JSFuck/](https://enkhee-osiris.github.io/Decoder-JSFuck/))
   * [**TrainFuck**](https://github.com/taco-c/trainfuck)**:** `+72.+29.+7..+3.-67.-12.+55.+24.+3.-6.-8.-67.-23.`
-  * In several occasions you will need to **understand regular expressions** used, this will be useful: [https://regex101.com/](https://regex101.com) or [https://pythonium.net/regex](https://pythonium.net/regex)
+  * On several occasions, you will need to **understand the regular expressions** used. This will be useful: [https://regex101.com/](https://regex101.com) or [https://pythonium.net/regex](https://pythonium.net/regex)
 * You could also **monitor the files were forms were detected**, as a change in the parameter or the apearance f a new form may indicate a potential new vulnerable functionality.
 
 **403 Forbidden/Basic Authentication/401 Unauthorized (bypass)**


### PR DESCRIPTION
Fix dead link:
Replace https://ooze.ninja/javascript/poisonjs/ with https://enkhee-osiris.github.io/Decoder-JSFuck/

Add regex resource: 
https://pythonium.net/regex  (Visual regex tester)