### PR TITLE
Open redirect page is redirecting to example.com

### DIFF
--- a/src/pentesting-web/open-redirect.md
+++ b/src/pentesting-web/open-redirect.md
@@ -96,7 +96,6 @@ https://evil.example/trusted.example
 /\\evil.example
 /..//evil.example
 ```
-```
 </details>
 
 ## Open Redirect uploading svg files
@@ -113,7 +112,7 @@ xmlns="http://www.w3.org/2000/svg">
 
 ## Common injection parameters
 
-```
+```text
 /{payload}
 ?next={payload}
 ?url={payload}
@@ -239,7 +238,6 @@ cat candidates.txt | openredirex -p payloads.txt -k FUZZ -c 50 > results.txt
 
 # 4) Manually verify interesting hits
 awk '/30[1237]|Location:/I' results.txt
-```
 ```
 </details>
 


### PR DESCRIPTION
The open redirect page is redirection to example.com because an HTML example of open redirection vulnerability is being interpreted as HTML inside the page. I think that the issue is about the ``` fields. I reorganized the fields to fix the issue. However, the project wasn't run in local to check my fix.




