### PR TITLE
Add new multicast DNS spoofing tool: Dementor

### DIFF
--- a/src/generic-methodologies-and-resources/pentesting-network/spoofing-llmnr-nbt-ns-mdns-dns-and-wpad-and-relay-attacks.md
+++ b/src/generic-methodologies-and-resources/pentesting-network/spoofing-llmnr-nbt-ns-mdns-dns-and-wpad-and-relay-attacks.md
@@ -9,7 +9,7 @@
 - **LLMNR, NBT-NS, and mDNS**:
   - Microsoft and other operating systems use LLMNR and NBT-NS for local name resolution when DNS fails. Similarly, Apple and Linux systems use mDNS.
   - These protocols are susceptible to interception and spoofing due to their unauthenticated, broadcast nature over UDP.
-  - [Responder](https://github.com/lgandx/Responder) can be used to impersonate services by sending forged responses to hosts querying these protocols.
+  - [Responder](https://github.com/lgandx/Responder) and [Dementor](https://github.com/MatrixEditor/Dementor) can be used to impersonate services by sending forged responses to hosts querying these protocols.
   - Further information on service impersonation using Responder can be found [here](spoofing-llmnr-nbt-ns-mdns-dns-and-wpad-and-relay-attacks.md).
 
 ### Web Proxy Auto-Discovery Protocol (WPAD)
@@ -18,13 +18,19 @@
 - Discovery is facilitated via DHCP, DNS, or fallback to LLMNR and NBT-NS if DNS fails.
 - Responder can automate WPAD attacks, directing clients to malicious WPAD servers.
 
-### Responder for Protocol Poisoning
+### Responder/Dementor for Protocol Poisoning
 
 - **Responder** is a tool used for poisoning LLMNR, NBT-NS, and mDNS queries, selectively responding based on query types, primarily targeting SMB services.
 - It comes pre-installed in Kali Linux, configurable at `/etc/responder/Responder.conf`.
 - Responder displays captured hashes on the screen and saves them in the `/usr/share/responder/logs` directory.
 - It supports both IPv4 and IPv6.
 - Windows version of Responder is available [here](https://github.com/lgandx/Responder-Windows).
+
+- **Dementor** expands on the topics of multicast poisoning and additionally acts as a rogue service provider (including CUPS RCE support)
+- Overall structure is similar to **Responder** with more granular configuration. (default is here: [Dementor.toml](https://github.com/MatrixEditor/dementor/blob/master/dementor/assets/Dementor.toml))
+- Compatibility between **Dementor** and **Responder** is given here: [Compatibility Matrix](https://matrixeditor.github.io/dementor/compat.html)
+- Intro and Documentation here: [Dementor - Docs](https://matrixeditor.github.io/dementor/intro.html)
+- Fixes capture issues introduced by Responder on certain protocols
 
 #### Running Responder
 
@@ -34,6 +40,13 @@
 - WPAD impersonation can be activated with: `responder -I <Interface> --wpad`
 - NetBIOS requests can be resolved to the attacker's IP, and an authentication proxy can be set up: `responder.py -I <interface> -Pv`
 
+#### Running Dementor
+
+- With detault settings applied: `Dementor -I <interface>`
+- With default settings in analysis mode: `Dementor -I <interface> -A`
+- Automatic NTLM session downgrade (ESS): `Dementor -I <interface> -O NTLM.ExtendedSessionSecurity=Off`
+- Run current session with custom config: `Dementor -I <interface> --config <file.toml>`
+
 ### DHCP Poisoning with Responder
 
 - Spoofing DHCP responses can permanently poison a victim's routing information, offering a stealthier alternative to ARP poisoning.
@@ -41,9 +54,9 @@
 - Running the attack: `./Responder.py -I eth0 -Pdv`
 - This method can effectively capture NTLMv1/2 hashes, but it requires careful handling to avoid network disruption.
 
-### Capturing Credentials with Responder
+### Capturing Credentials with Responder/Dementor
 
-- Responder will impersonate services using the above-mentioned protocols, capturing credentials (usually NTLMv2 Challenge/Response) when a user attempts to authenticate against the spoofed services.
+- Responder/Dementor will impersonate services using the above-mentioned protocols, capturing credentials (usually NTLMv2 Challenge/Response) when a user attempts to authenticate against the spoofed services.
 - Attempts can be made to downgrade to NetNTLMv1 or disable ESS for easier credential cracking.
 
 It's crucial to note that employing these techniques should be done legally and ethically, ensuring proper authorization and avoiding disruption or unauthorized access.
@@ -204,15 +217,15 @@ For detailed info about this attack check:
 | **Service ticket / TGS-REQ ↔ REP** | Bound to one **SPN**; encrypted with the SPN owner’s key | interchangeable if SPNs share account |
 | **AP-REQ** | Client sends `TGS` to the service | **what we steal & replay** |
 
-* Tickets are encrypted with the **password-derived key of the account that owns the SPN**.  
-* The **Authenticator** inside the AP-REQ has a 5-minute timestamp; replay inside that window is valid until the service cache sees a duplicate.  
+* Tickets are encrypted with the **password-derived key of the account that owns the SPN**.
+* The **Authenticator** inside the AP-REQ has a 5-minute timestamp; replay inside that window is valid until the service cache sees a duplicate.
 * Windows rarely checks if the SPN string in the ticket matches the service you hit, so a ticket for `CIFS/HOST` normally decrypts fine on `LDAP/HOST`.
 
 - 2. **What must be true to relay Kerberos**
 
-1. **Shared key:** source and target SPNs belong to the same computer account (default on Windows servers).  
-2. **No channel protection:** SMB/LDAP signing off and EPA off for HTTP/LDAPS.  
-3. **You can intercept or coerce authentication:** LLMNR/NBNS poison, DNS spoof, **PetitPotam / DFSCoerce RPC**, fake AuthIP, rogue DCOM, etc..  
+1. **Shared key:** source and target SPNs belong to the same computer account (default on Windows servers).
+2. **No channel protection:** SMB/LDAP signing off and EPA off for HTTP/LDAPS.
+3. **You can intercept or coerce authentication:** LLMNR/NBNS poison, DNS spoof, **PetitPotam / DFSCoerce RPC**, fake AuthIP, rogue DCOM, etc..
 4. **Ticket source not already used:** you win the race before the real packet hits or block it entirely; otherwise the server’s replay cache fires Event 4649.
 5. You need to somehow be able to perform a **MitM in the communication** maybe being part of the DNSAmins group to modify the DNS of the domain or being able to change the HOST file of the victim.
 
@@ -282,17 +295,17 @@ You now own **NT AUTHORITY\SYSTEM**.
 
 ### **Detection**
 
-* Surge in **Event 4769** for `CIFS/`, `HTTP/`, `LDAP/` from the same source within seconds.  
-* **Event 4649** on the service indicates replay detected.  
-* Kerberos logon from **127.0.0.1** (relay to local SCM) is highly suspicious—map via Sigma rule in KrbRelayUp docs.  
+* Surge in **Event 4769** for `CIFS/`, `HTTP/`, `LDAP/` from the same source within seconds.
+* **Event 4649** on the service indicates replay detected.
+* Kerberos logon from **127.0.0.1** (relay to local SCM) is highly suspicious—map via Sigma rule in KrbRelayUp docs.
 * Watch changes to `msDS-AllowedToActOnBehalfOfOtherIdentity` or `msDS-KeyCredentialLink` attributes.
 
 ## **Hardening**
 
-1. **Enforce LDAP & SMB signing + EPA** on every server.  
-2. **Split SPNs** so HTTP isn’t on the same account as CIFS/LDAP.  
-3. Patch coercion vectors (PetitPotam KB5005413, DFS, AuthIP).  
-4. Set **`ms-DS-MachineAccountQuota = 0`** to stop rogue computer joins.  
+1. **Enforce LDAP & SMB signing + EPA** on every server.
+2. **Split SPNs** so HTTP isn’t on the same account as CIFS/LDAP.
+3. Patch coercion vectors (PetitPotam KB5005413, DFS, AuthIP).
+4. Set **`ms-DS-MachineAccountQuota = 0`** to stop rogue computer joins.
 5. Alert on **Event 4649** and unexpected loopback Kerberos logons.
 
 


### PR DESCRIPTION
This pull request adds information of a new multicast poisoning tool and links to its reference:
- Dementor Github: https://github.com/MatrixEditor/dementor
- Dementor Docs: https://matrixeditor.github.io/dementor/intro.html



