### PR TITLE
Fix broken Impacket link in pentesting-smb

### DIFF
--- a/src/network-services-pentesting/pentesting-smb/README.md
+++ b/src/network-services-pentesting/pentesting-smb/README.md
@@ -564,7 +564,7 @@ In **kali** it is located on /usr/share/doc/python3-impacket/examples/
 
 ## Impacket reference
 
-[https://www.hackingarticles.in/beginners-guide-to-impacket-tool-kit-part-1/](https://www.hackingarticles.in/beginners-guide-to-impacket-tool-kit-part-1/)
+[https://www.hackingarticles.in/impacket-guide-smb-msrpc/](https://www.hackingarticles.in/impacket-guide-smb-msrpc/)
 
 ### ksmbd attack surface and SMB2/SMB3 protocol fuzzing (syzkaller)
 


### PR DESCRIPTION
The previous link was dead, so i replaced it with a working one that covers the same content.