### PR TITLE
Fix incorrect illustration in "cors-bypass.md"

### DIFF
--- a/src/pentesting-web/cors-bypass.md
+++ b/src/pentesting-web/cors-bypass.md
@@ -78,8 +78,8 @@ OPTIONS /info HTTP/1.1
 Host: example2.com
 ...
 Origin: https://example.com
-Access-Control-Request-Method: POST
-Access-Control-Request-Headers: Authorization
+Access-Control-Request-Method: PUT
+Access-Control-Request-Headers: Special-Request-Header
 ```
 
 In response, the server might return headers indicating the accepted methods, the allowed origin, and other CORS policy details, as shown below:


### PR DESCRIPTION
**Existing text description:**
`Consider the following illustration of a pre-flight request aimed at employing the PUT method along with a custom header named Special-Request-Header:`

**Existing illustration:**
```
OPTIONS /info HTTP/1.1
Host: example2.com
...
Origin: https://example.com
Access-Control-Request-Method: POST
Access-Control-Request-Headers: Authorization
```


The description mentions the `PUT` method and the `Special-Request-Header` header, but the illustration uses `POST` and `Authorization` instead. This inconsistency is likely to confuse readers.