### PR TITLE
Avoid redundant robots CloudFront invalidations

### DIFF
--- a/.github/workflows/translate_all.yml
+++ b/.github/workflows/translate_all.yml
@@ -281,4 +281,4 @@ jobs:
         run: |
           aws cloudfront create-invalidation \
             --distribution-id "${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}" \
-            --paths "/$BRANCH/*" "/robots.txt" "/sitemap.xml" "/$BRANCH/sitemap.xml"
+            --paths "/$BRANCH/*" "/sitemap.xml" "/$BRANCH/sitemap.xml"


### PR DESCRIPTION
Created by Hermes.

## Summary
- Removes `/robots.txt` from the translation workflow CloudFront invalidation paths.
- The translation workflow does not upload root robots.txt, so invalidating it on every translated branch deploy is redundant.
- Keeps the branch content, root sitemap, and branch sitemap invalidations.

## Evidence
AWS CloudFront invalidation history showed hundreds of recent main-wiki invalidations with `/robots.txt` repeated for each language deploy.

## Validation
- Inspected `.github/workflows/translate_all.yml` only; no runtime validation needed for this path-only workflow change.