### PR TITLE
Encode request string before sending RTSP command

### DIFF
--- a/src/network-services-pentesting/554-8554-pentesting-rtsp.md
+++ b/src/network-services-pentesting/554-8554-pentesting-rtsp.md
@@ -40,7 +40,7 @@ import socket
 req = "DESCRIBE rtsp://<ip>:<port> RTSP/1.0\r\nCSeq: 2\r\nAuthorization: Basic YWRtaW46MTIzNA==\r\n\r\n"
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 s.connect(("192.168.1.1", 554))
-s.sendall(req)
+s.sendall(req.encode())
 data = s.recv(1024)
 print(data)
 ```


### PR DESCRIPTION
Fixing:
TypeError: a bytes-like object is required, not 'str'
    s.sendall(req)

Added request encoding before socket sendall as req is a string.