### PR TITLE
Reduce redundant CloudFront invalidation paths

### DIFF
--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -202,7 +202,9 @@ jobs:
 
       - name: Invalidate CloudFront HTML and SEO assets
         run: |
+          # /en/* covers /en/robots.txt and /en/sitemap.xml; only invalidate
+          # root SEO files separately.
           aws cloudfront create-invalidation \
             --distribution-id "${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}" \
-            --paths "/en/*" "/robots.txt" "/en/robots.txt" "/sitemap.xml" "/en/sitemap.xml"
+            --paths "/en/*" "/robots.txt" "/sitemap.xml"
       

--- a/.github/workflows/translate_all.yml
+++ b/.github/workflows/translate_all.yml
@@ -290,7 +290,9 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          paths=("/$BRANCH/*" "/$BRANCH/sitemap.xml")
+          # The wildcard already invalidates the language sitemap, so avoid
+          # paying for a redundant explicit /$BRANCH/sitemap.xml path.
+          paths=("/$BRANCH/*")
           if [ "${{ steps.root_sitemap.outputs.changed }}" = "true" ]; then
             paths+=("/sitemap.xml")
           fi


### PR DESCRIPTION
Created by Hermes.

## Problem
The wiki CloudFront distribution is paying for redundant invalidation paths. Recent live metrics showed 1,329 invalidation batches in the last 15 days for E17AYUMK3JFXZQ (`hacktricks.wiki`/`book.hacktricks.wiki`), and sampled translation invalidations included both `/<lang>/*` and `/<lang>/sitemap.xml`. The wildcard already covers the sitemap path.

## Change
- Remove explicit `/$BRANCH/sitemap.xml` from translation invalidations.
- Remove explicit `/en/robots.txt` and `/en/sitemap.xml` from master invalidations because `/en/*` already covers them.
- Keep root `/robots.txt` and `/sitemap.xml` invalidations unchanged.

## Validation
- Verified with a local Python assertion that the old redundant invalidation command/path array is gone and the reduced paths are present.
- Ran `git diff --check` successfully.
