### PR TITLE
Added docker-compose and fixed Dockerfile LANG collision

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM ghcr.io/hacktricks-wiki/hacktricks-cloud/translator-image:latest
 
 # Variable de idioma (cambia "master" a "es" si lo quieres en español, etc.)
-ARG LANG=master
-ENV LANG=${LANG}
+ARG HT_LANG=master
+ENV HT_LANG=${HT_LANG}
 
 # Configuración de git y preparación
 RUN mkdir -p ~/.ssh && \
@@ -14,7 +14,7 @@ WORKDIR /app
 COPY . /app
 
 # Selecciona idioma y construye la documentación
-RUN git checkout ${LANG} && git pull
+RUN git checkout ${HT_LANG} && git pull
 
 # Exponemos el puerto que usará mdbook
 EXPOSE 3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+# Run locally:  docker compose up   (or: podman compose up)  ->  http://localhost:3337
+services:
+  hacktricks:
+    image: ghcr.io/hacktricks-wiki/hacktricks-cloud/translator-image:latest
+    platform: linux/amd64  # published image is amd64-only
+    container_name: hacktricks
+    ports:
+      - "3337:3000"
+    volumes:
+      - .:/app
+    working_dir: /app
+    environment:
+      MDBOOK_PREPROCESSOR__HACKTRICKS__ENV: dev
+    command:
+      - bash
+      - -c
+      - >
+        git config --global --add safe.directory /app &&
+        mdbook serve --hostname 0.0.0.0 --port 3000

--- a/src/README.md
+++ b/src/README.md
@@ -35,6 +35,14 @@ docker run -d --rm --platform linux/amd64 -p 3337:3000 --name hacktricks -v $(pw
 
 Your local copy of HackTricks will be **available at [http://localhost:3337](http://localhost:3337)** after <5 minutes (it needs to build the book, be patient).
 
+Alternatively, if you have Docker Compose you can just run the following from the repo root:
+
+```bash
+docker compose up
+```
+
+This uses the bundled `docker-compose.yml` to serve your local checkout at [http://localhost:3337](http://localhost:3337) with live reload.
+
 ## HackTricks Partners
 
 ---


### PR DESCRIPTION
Adds a docker-compose.yml file as I'd had issues booting the container with the run command provided. The README also has an additional line to accommodate this change. Also added a fix to the Dockerfile which reused LANG (colliding with the base image's LANG=C.UTF-8, making 'git checkout ${LANG}' run 'git checkout C.UTF-8' and fail); renamed the build arg to HT_LANG.