### PR TITLE
References: fix heading level and citation on python-yaml-deserialization

### DIFF
--- a/src/pentesting-web/deserialization/python-yaml-deserialization.md
+++ b/src/pentesting-web/deserialization/python-yaml-deserialization.md
@@ -50,7 +50,7 @@ print(yaml.full_load(data))    # ConstructorError in modern PyYAML
 print(yaml.unsafe_load(data))  # range(1, 10)
 ```
 
-In current PyYAML, **`unsafe_load()`** is still the intended way to reconstruct Python-specific tags. `safe_load()` rejects them, and `full_load()` only became reliably non-exploitable for this class of payloads after the **5.4** fixes.
+In current PyYAML, **`unsafe_load()`** is still the intended way to reconstruct Python-specific tags. `safe_load()` rejects them, and `full_load()` only became reliably non-exploitable for this class of payloads after the **5.4** fixes.<sup>[[4]](#references)</sup>
 
 ### Basic Exploit
 

--- a/src/pentesting-web/deserialization/python-yaml-deserialization.md
+++ b/src/pentesting-web/deserialization/python-yaml-deserialization.md
@@ -199,7 +199,7 @@ cat /tmp/example_yaml
     - /root/flag.txt
 ```
 
-### References
+## References
 
 - [1] [YAML Deserialization Attack in Python (Exploit-DB)](https://www.exploit-db.com/docs/english/47655-yaml-deserialization-attack-in-python.pdf)
 - [2] [YAML Deserialization Attack in Python (Net-Square)](https://net-square.com/yaml-deserialization-attack-in-python.html)


### PR DESCRIPTION
Fixes the last reference defect found while validating the full merged tree:

- `### References` -> `## References` (house style; it was the only non-h2 References heading in the repo)
- cites the previously-unused PyYAML documentation entry `[4]` on the documented loader-behaviour statement

Verified: 0 dangling citations, 0 uncited entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)