### PR TITLE
References: cite content sources on pages not covered by an open PR

### DIFF
--- a/src/AI/AI-Assisted-Fuzzing-and-Vulnerability-Discovery.md
+++ b/src/AI/AI-Assisted-Fuzzing-and-Vulnerability-Discovery.md
@@ -139,7 +139,7 @@ A frequent failure mode in AI-assisted review is asking one agent to inspect a w
 
 1. Enumerate source files.
 2. Send **one file at a time** plus minimal context (entrypoint, imports, nearby routes/callers).
-3. Require a **structured report** for each file: sources, sink, missing validation, exploit preconditions, and confidence.
+3. Require a **structured report** for each file: sources, sink, missing validation, exploit preconditions, and confidence.<sup>[[3]](#references)</sup>
 4. Deduplicate reports by **source→sink pattern** and manually validate the high-risk ones.
 
 This is token-heavy and noisy, but it is very effective at surfacing **simple high-impact source/sink bugs** that broad agentic reviews often miss.
@@ -159,7 +159,7 @@ This is token-heavy and noisy, but it is very effective at surfacing **simple hi
 
 - Use the LLM as a **source/sink reviewer first**, not as an exploit generator.
 - Ask it to explicitly list the **attacker-controlled field**, the **normalization/validation gap**, and the **dangerous sink**.
-- For large repos, deterministic per-file review is often more reliable than a single autonomous agent run, even when the latter uses a stronger model.
+- For large repos, deterministic per-file review is often more reliable than a single autonomous agent run, even when the latter uses a stronger model.<sup>[[2]](#references)</sup>
 - Expect weaker results on **Broken Access Control** and other business-logic bugs where exploitability depends on cross-file assumptions, role semantics, or product-specific threat models.
 
 ---

--- a/src/AI/AI-Models-RCE.md
+++ b/src/AI/AI-Models-RCE.md
@@ -30,7 +30,7 @@ Moreover, there some python pickle based models like the ones used by [PyTorch](
 
 ### Hydra metadata → RCE (works even with safetensors)
 
-`hydra.utils.instantiate()` imports and calls any dotted `_target_` in a configuration/metadata object. When libraries feed **untrusted model metadata** into `instantiate()`, an attacker can supply a callable and arguments that run immediately during model load (no pickle required).<sup>[[12]](#references)</sup>
+`hydra.utils.instantiate()` imports and calls any dotted `_target_` in a configuration/metadata object. When libraries feed **untrusted model metadata** into `instantiate()`, an attacker can supply a callable and arguments that run immediately during model load (no pickle required).<sup>[[12]](#references)[[13]](#references)</sup>
 
 Payload example (works in `.nemo` `model_config.yaml`, repo `config.json`, or `__metadata__` inside `.safetensors`):
 
@@ -42,7 +42,7 @@ _args_:
 
 Key points:
 - Triggered before model initialization in NeMo `restore_from/from_pretrained`, uni2TS HuggingFace coders, and FlexTok loaders.
-- Hydra’s string block-list is bypassable via alternative import paths (e.g., `enum.bltns.eval`) or application-resolved names (e.g., `nemo.core.classes.common.os.system` → `posix`).
+- Hydra’s string block-list is bypassable via alternative import paths (e.g., `enum.bltns.eval`) or application-resolved names (e.g., `nemo.core.classes.common.os.system` → `posix`).<sup>[[14]](#references)</sup>
 - FlexTok also parses stringified metadata with `ast.literal_eval`, enabling DoS (CPU/memory blowup) before the Hydra call.
 
 ### 🆕  InvokeAI RCE via `torch.load` (CVE-2024-12029)
@@ -105,7 +105,7 @@ Ready-made exploit: **Metasploit** module `exploit/linux/http/invokeai_rce_cve_2
 
 #### Mitigations
 
-* Upgrade to **InvokeAI ≥ 5.4.3** – the patch sets `scan=True` by default and performs malware scanning before deserialization.
+* Upgrade to **InvokeAI ≥ 5.4.3** – the patch sets `scan=True` by default and performs malware scanning before deserialization.<sup>[[2]](#references)</sup>
 * When loading checkpoints programmatically use `torch.load(file, weights_only=True)` or the new [`torch.load_safe`](https://pytorch.org/docs/stable/serialization.html#security) helper.
 * Enforce allow-lists / signatures for model sources and run the service with least-privilege.
 
@@ -158,7 +158,7 @@ Fix: Commit [b7eaea5](https://github.com/NVIDIA-Merlin/Transformers4Rec/pull/802
 
 Defensive guidance specific to PyTorch checkpoints:
 - Do not unpickle untrusted data. Prefer non-executable formats like [Safetensors](https://huggingface.co/docs/safetensors/index) or ONNX when possible.
-- If you must use PyTorch serialization, ensure `weights_only=True` (supported in newer PyTorch) or use a custom allow-listed unpickler similar to the Transformers4Rec patch.
+- If you must use PyTorch serialization, ensure `weights_only=True` (supported in newer PyTorch) or use a custom allow-listed unpickler similar to the Transformers4Rec patch.<sup>[[4]](#references)</sup>
 - Enforce model provenance/signatures and sandbox deserialization (seccomp/AppArmor; non-root user; restricted FS and no network egress).
 - Monitor for unexpected child processes from ML services at checkpoint load time; trace `torch.load()`/`pickle` usage.
 

--- a/src/AI/AI-Models-RCE.md
+++ b/src/AI/AI-Models-RCE.md
@@ -163,9 +163,9 @@ Defensive guidance specific to PyTorch checkpoints:
 - Monitor for unexpected child processes from ML services at checkpoint load time; trace `torch.load()`/`pickle` usage.
 
 POC and vulnerable/patch references:<sup>[[8]](#references)[[9]](#references)[[10]](#references)</sup>
-- Vulnerable pre-patch loader: https://gist.github.com/zdi-team/56ad05e8a153c84eb3d742e74400fd10.js
-- Malicious checkpoint POC: https://gist.github.com/zdi-team/fde7771bb93ffdab43f15b1ebb85e84f.js
-- Post-patch loader: https://gist.github.com/zdi-team/a0648812c52ab43a3ce1b3a090a0b091.js
+- Vulnerable pre-patch loader: https://gist.github.com/zdi-team/56ad05e8a153c84eb3d742e74400fd10.js<sup>[[8]](#references)</sup>
+- Malicious checkpoint POC: https://gist.github.com/zdi-team/fde7771bb93ffdab43f15b1ebb85e84f.js<sup>[[9]](#references)</sup>
+- Post-patch loader: https://gist.github.com/zdi-team/a0648812c52ab43a3ce1b3a090a0b091.js<sup>[[10]](#references)</sup>
 
 ## Example – crafting a malicious PyTorch model
 

--- a/src/AI/AI-Prompts.md
+++ b/src/AI/AI-Prompts.md
@@ -734,7 +734,7 @@ Escalate those files to deterministic parsing, conventional static analysis, san
 
 ## Encrypted Reasoning-State Replay, Transcript JSON Injection, and Reasoning Side Channels
 
-Some reasoning-model APIs return **opaque reasoning/thinking items** that the client must replay on later turns. OpenAI explicitly documents that reasoning items may contain `encrypted_content` and should be preserved when continuing a conversation, while Anthropic exposes signed/opaque thinking blocks that must also be passed back unchanged.<sup>[[18]](#references)[[19]](#references)[[21]](#references)</sup>
+Some reasoning-model APIs return **opaque reasoning/thinking items** that the client must replay on later turns. OpenAI explicitly documents that reasoning items may contain `encrypted_content` and should be preserved when continuing a conversation, while Anthropic exposes signed/opaque thinking blocks that must also be passed back unchanged.<sup>[[18]](#references)[[19]](#references)[[21]](#references)[[20]](#references)</sup>
 
 From an attacker perspective, treat these artifacts as **provider-native privileged state**, not as normal user text.
 

--- a/src/binary-exploitation/array-indexing.md
+++ b/src/binary-exploitation/array-indexing.md
@@ -8,13 +8,13 @@ This category includes all vulnerabilities that occur because it is possible to 
 
 However he you can find some nice **examples**:
 
-- [https://guyinatuxedo.github.io/11-index/swampctf19_dreamheaps/index.html](https://guyinatuxedo.github.io/11-index/swampctf19_dreamheaps/index.html)
+- [https://guyinatuxedo.github.io/11-index/swampctf19_dreamheaps/index.html](https://guyinatuxedo.github.io/11-index/swampctf19_dreamheaps/index.html)<sup>[[1]](#references)</sup>
   - There are **2 colliding arrays**, one for **addresses** where data is stored and one with the **sizes** of that data. It's possible to overwrite one from the other, enabling to write an arbitrary address indicating it as a size. This allows to write the address of the `free` function in the GOT table and then overwrite it with the address to `system`, and call free from a memory with `/bin/sh`.<sup>[[1]](#references)</sup>
-- [https://guyinatuxedo.github.io/11-index/csaw18_doubletrouble/index.html](https://guyinatuxedo.github.io/11-index/csaw18_doubletrouble/index.html)
+- [https://guyinatuxedo.github.io/11-index/csaw18_doubletrouble/index.html](https://guyinatuxedo.github.io/11-index/csaw18_doubletrouble/index.html)<sup>[[2]](#references)</sup>
   - 64 bits, no nx. Overwrite a size to get a kind of buffer overflow where every thing is going to be used a double number and sorted from smallest to biggest so it's needed to create a shellcode that fulfil that requirement, taking into account that the canary shouldn't be moved from it's position and finally overwriting the RIP with an address to ret, that fulfil he previous requirements and putting the biggest address a new address pointing to the start of the stack (leaked by the program) so it's possible to use the ret to jump there.<sup>[[2]](#references)</sup>
-- [https://faraz.faith/2019-10-20-secconctf-2019-sum/](https://faraz.faith/2019-10-20-secconctf-2019-sum/)
+- [https://faraz.faith/2019-10-20-secconctf-2019-sum/](https://faraz.faith/2019-10-20-secconctf-2019-sum/)<sup>[[3]](#references)</sup>
   - 64bits, no relro, canary, nx, no pie. There is an off-by-one in an array in the stack that allows to control a pointer granting WWW (it write the sum of all the numbers of the array in the overwritten address by the of-by-one in the array). The stack is controlled so the GOT `exit` address is overwritten with `pop rdi; ret`, and in the stack is added the address to `main` (looping back to `main`). The a ROP chain to leak the address of put in the GOT using puts is used (`exit` will be called so it will call `pop rdi; ret` therefore executing this chain in the stack). Finally a new ROP chain executing ret2lib is used.<sup>[[3]](#references)</sup>
-- [https://guyinatuxedo.github.io/14-ret_2_system/tu_guestbook/index.html](https://guyinatuxedo.github.io/14-ret_2_system/tu_guestbook/index.html)
+- [https://guyinatuxedo.github.io/14-ret_2_system/tu_guestbook/index.html](https://guyinatuxedo.github.io/14-ret_2_system/tu_guestbook/index.html)<sup>[[4]](#references)</sup>
   - 32 bit, no relro, no canary, nx, pie. Abuse a bad indexing to leak addresses of libc and heap from the stack. Abuse the buffer overflow o do a ret2lib calling `system('/bin/sh')` (the heap address is needed to bypass a check).<sup>[[4]](#references)</sup>
 
 ## References

--- a/src/binary-exploitation/format-strings/README.md
+++ b/src/binary-exploitation/format-strings/README.md
@@ -9,7 +9,7 @@ In C **`printf`** is a function that can be used to **print** some string. The *
 
 Other vulnerable functions are **`sprintf()`** and **`fprintf()`**.
 
-The vulnerability appears when an **attacker text is used as the first argument** to this function. The attacker will be able to craft a **special input abusing** the **printf format** string capabilities to read and **write any data in any address (readable/writable)**. Being able this way to **execute arbitrary code**.
+The vulnerability appears when an **attacker text is used as the first argument** to this function. The attacker will be able to craft a **special input abusing** the **printf format** string capabilities to read and **write any data in any address (readable/writable)**. Being able this way to **execute arbitrary code**.<sup>[[1]](#references)</sup>
 
 #### Formatters:
 
@@ -87,7 +87,7 @@ Notice that the attacker controls the `printf` **parameter, which basically mean
 
 ## **Arbitrary Read**
 
-It's possible to use the formatter **`%n$s`** to make **`printf`** get the **address** situated in the **n position**, following it and **print it as if it was a string** (print until a 0x00 is found). So if the base address of the binary is **`0x8048000`**, and we know that the user input starts in the 4th position in the stack, it's possible to print the starting of the binary with:
+It's possible to use the formatter **`%n$s`** to make **`printf`** get the **address** situated in the **n position**, following it and **print it as if it was a string** (print until a 0x00 is found). So if the base address of the binary is **`0x8048000`**, and we know that the user input starts in the 4th position in the stack, it's possible to print the starting of the binary with:<sup>[[4]](#references)</sup>
 
 ```python
 from pwn import *
@@ -153,7 +153,7 @@ Arbitrary reads can be useful to:
 
 ## **Arbitrary Write**
 
-The formatter **`%<num>$n`** **writes** the **number of written bytes** in the **indicated address** in the <num> param in the stack. If an attacker can write as many char as he will with printf, he is going to be able to make **`%<num>$n`** write an arbitrary number in an arbitrary address.
+The formatter **`%<num>$n`** **writes** the **number of written bytes** in the **indicated address** in the <num> param in the stack. If an attacker can write as many char as he will with printf, he is going to be able to make **`%<num>$n`** write an arbitrary number in an arbitrary address.<sup>[[5]](#references)</sup>
 
 Fortunately, to write the number 9999, it's not needed to add 9999 "A"s to the input, in order to so so it's possible to use the formatter **`%.<num-write>%<num>$n`** to write the number **`<num-write>`** in the **address pointed by the `num` position**.
 
@@ -166,14 +166,14 @@ However, note that usually in order to write an address such as `0x08049724` (wh
 
 Therefore, this vulnerability allows to **write anything in any address (arbitrary write).**
 
-In this example, the goal is going to be to **overwrite** the **address** of a **function** in the **GOT** table that is going to be called later. Although this could abuse other arbitrary write to exec techniques:
+In this example, the goal is going to be to **overwrite** the **address** of a **function** in the **GOT** table that is going to be called later. Although this could abuse other arbitrary write to exec techniques:<sup>[[2]](#references)</sup>
 
 
 {{#ref}}
 ../arbitrary-write-2-exec/
 {{#endref}}
 
-We are going to **overwrite** a **function** that **receives** its **arguments** from the **user** and **point** it to the **`system`** **function**.\
+We are going to **overwrite** a **function** that **receives** its **arguments** from the **user** and **point** it to the **`system`** **function**.<sup>[[6]](#references)</sup>\
 As mentioned, to write the address, usually 2 steps are needed: You **first writes 2Bytes** of the address and then the other 2. To do so **`$hn`** is used.
 
 - **HOB** is called to the 2 higher bytes of the address

--- a/src/binary-exploitation/integer-overflow-and-underflow.md
+++ b/src/binary-exploitation/integer-overflow-and-underflow.md
@@ -392,9 +392,9 @@ Why exploitation is reliable in this pattern:
 
 ## Other Examples
 
-- [https://guyinatuxedo.github.io/35-integer_exploitation/int_overflow_post/index.html](https://guyinatuxedo.github.io/35-integer_exploitation/int_overflow_post/index.html)
+- [https://guyinatuxedo.github.io/35-integer_exploitation/int_overflow_post/index.html](https://guyinatuxedo.github.io/35-integer_exploitation/int_overflow_post/index.html)<sup>[[4]](#references)</sup>
   - Only 1B is used to store the size of the password so it's possible to overflow it and make it think it's length of 4 while it actually is 260 to bypass the length check protection<sup>[[4]](#references)</sup>
-- [https://guyinatuxedo.github.io/35-integer_exploitation/puzzle/index.html](https://guyinatuxedo.github.io/35-integer_exploitation/puzzle/index.html)
+- [https://guyinatuxedo.github.io/35-integer_exploitation/puzzle/index.html](https://guyinatuxedo.github.io/35-integer_exploitation/puzzle/index.html)<sup>[[5]](#references)</sup>
 
   - Given a couple of numbers find out using z3 a new number that multiplied by the first one will give the second one:<sup>[[5]](#references)</sup>
 
@@ -402,7 +402,7 @@ Why exploitation is reliable in this pattern:
     (((argv[1] * 0x1064deadbeef4601) & 0xffffffffffffffff) == 0xD1038D2E07B42569)
     ```
 
-- [https://8ksec.io/arm64-reversing-and-exploitation-part-8-exploiting-an-integer-overflow-vulnerability/](https://8ksec.io/arm64-reversing-and-exploitation-part-8-exploiting-an-integer-overflow-vulnerability/)
+- [https://8ksec.io/arm64-reversing-and-exploitation-part-8-exploiting-an-integer-overflow-vulnerability/](https://8ksec.io/arm64-reversing-and-exploitation-part-8-exploiting-an-integer-overflow-vulnerability/)<sup>[[6]](#references)</sup>
   - Only 1B is used to store the size of the password so it's possible to overflow it and make it think it's length of 4 while it actually is 260 to bypass the length check protection and overwrite in the stack the next local variable and bypass both protections<sup>[[6]](#references)</sup>
 
 ## Go integer overflow detection with go-panikint

--- a/src/binary-exploitation/libc-heap/off-by-one-overflow.md
+++ b/src/binary-exploitation/libc-heap/off-by-one-overflow.md
@@ -110,15 +110,15 @@ print(hex(reveal(encoded_fd, chunk)))  # 0xdeadbeefcaf0
 ## Other Examples
 
 - [**https://heap-exploitation.dhavalkapil.com/attacks/shrinking_free_chunks**](https://heap-exploitation.dhavalkapil.com/attacks/shrinking_free_chunks)<sup>[[4]](#references)</sup>
-- [**Bon-nie-appetit. HTB Cyber Apocalypse CTF 2022**](https://7rocky.github.io/en/ctf/htb-challenges/pwn/bon-nie-appetit/)
+- [**Bon-nie-appetit. HTB Cyber Apocalypse CTF 2022**](https://7rocky.github.io/en/ctf/htb-challenges/pwn/bon-nie-appetit/)<sup>[[5]](#references)</sup>
   - Off-by-one because of `strlen` considering the next chunk's `size` field.
   - Tcache is being used, so a general off-by-one attacks works to get an arbitrary write primitive with Tcache poisoning.<sup>[[5]](#references)</sup>
-- [**Asis CTF 2016 b00ks**](https://ctf-wiki.mahaloz.re/pwn/linux/glibc-heap/off_by_one/#1-asis-ctf-2016-b00ks)
+- [**Asis CTF 2016 b00ks**](https://ctf-wiki.mahaloz.re/pwn/linux/glibc-heap/off_by_one/#1-asis-ctf-2016-b00ks)<sup>[[6]](#references)</sup>
   - It's possible to abuse an off by one to leak an address from the heap because the byte 0x00 of the end of a string being overwritten by the next field.
   - Arbitrary write is obtained by abusing the off by one write to make the pointer point to another place were a fake struct with fake pointers will be built. Then, it's possible to follow the pointer of this struct to obtain arbitrary write.
   - The libc address is leaked because if the heap is extended using mmap, the memory allocated by mmap has a fixed offset from libc.
   - Finally the arbitrary write is abused to write into the address of `__free_hook` with a one gadget.<sup>[[6]](#references)</sup>
-- [**plaidctf 2015 plaiddb**](https://ctf-wiki.mahaloz.re/pwn/linux/glibc-heap/off_by_one/#instance-2-plaidctf-2015-plaiddb)
+- [**plaidctf 2015 plaiddb**](https://ctf-wiki.mahaloz.re/pwn/linux/glibc-heap/off_by_one/#instance-2-plaidctf-2015-plaiddb)<sup>[[7]](#references)</sup>
   - There is a NULL off by one vulnerability in the `getline` function that reads user input lines. This function is used to read the "key" of the content and not the content.<sup>[[7]](#references)</sup>
   - In the writeup 5 initial chunks are created:
     - chunk1 (0x200)

--- a/src/binary-exploitation/libc-heap/unlink-attack.md
+++ b/src/binary-exploitation/libc-heap/unlink-attack.md
@@ -83,14 +83,14 @@ int main() {
 
 - The primitive is **not dead after tcache**. The main problem is that if a chunk is handled by **tcache** or **fastbins**, `unlink_chunk()` is never reached. Therefore, modern PoCs usually use **sizes outside tcache** (for example `0x420` in the current `how2heap` `unsafe_unlink.c`) or first fill the target tcache bin.<sup>[[2]](#references)</sup>
 - **Safe-linking** protects the singly linked lists used by **tcache** and **fastbins**, but it does **not** protect the doubly linked `fd`/`bk` pointers used by the unlink checks. It still matters in practice because many modern exploits use unsafe unlink only to get an overlap and then finish with [Tcache Bin Attack](tcache-bin-attack.md).
-- In modern challenges this technique is often just the **first stage**: create an overlap / move a pointer table / corrupt a known pointer, and then chain that into a libc leak, heap leak, GOT overwrite, FSOP, or tcache poisoning.
+- In modern challenges this technique is often just the **first stage**: create an overlap / move a pointer table / corrupt a known pointer, and then chain that into a libc leak, heap leak, GOT overwrite, FSOP, or tcache poisoning.<sup>[[3]](#references)</sup>
 
 ### Goal
 
 This attack allows an attacker to **change a pointer to a chunk so it points 3 qwords before its original storage location**. If that new location contains interesting data (other heap pointers, stack values, globals, or a pointer table), it may be possible to read or overwrite it and pivot into a stronger primitive.
 
 - If this pointer is stored in the stack, and the user can later read/write through it, it may be possible to leak sensitive stack data or even modify nearby saved state without directly touching the canary.
-- In several CTF examples this pointer is stored inside an **array of heap pointers** instead of the stack. Then, moving the pointer 3 qwords backwards is enough to retarget adjacent entries and turn the bug into arbitrary read/write against GOT entries or other application structures.
+- In several CTF examples this pointer is stored inside an **array of heap pointers** instead of the stack. Then, moving the pointer 3 qwords backwards is enough to retarget adjacent entries and turn the bug into arbitrary read/write against GOT entries or other application structures.<sup>[[4]](#references)[[5]](#references)</sup>
 
 ### Requirements
 

--- a/src/binary-exploitation/libc-heap/unsorted-bin-attack.md
+++ b/src/binary-exploitation/libc-heap/unsorted-bin-attack.md
@@ -13,7 +13,7 @@ bins-and-memory-allocations.md
 
 Unsorted lists are able to write the address to `unsorted_chunks (av)` in the `bk` address of the chunk. Therefore, if an attacker can **modify the address of the `bk` pointer** in a chunk inside the unsorted bin, he could be able to **write that address in an arbitrary address** which could be helpful to leak a Glibc addresses or bypass some defense.
 
-So, basically, this attack allows to **set a big number at an arbitrary address**. This big number is an address, which could be a heap address or a Glibc address. A traditional target was **`global_max_fast`** to allow to create fast bin bins with bigger sizes (and pass from an unsorted bin attack to a fast bin attack).
+So, basically, this attack allows to **set a big number at an arbitrary address**. This big number is an address, which could be a heap address or a Glibc address. A traditional target was **`global_max_fast`** to allow to create fast bin bins with bigger sizes (and pass from an unsorted bin attack to a fast bin attack).<sup>[[2]](#references)</sup>
 
 - Modern note (glibc ≥ 2.39): `global_max_fast` became an 8‑bit global. Blindly writing a pointer there via an unsorted-bin write will clobber adjacent libc data and will not reliably raise the fastbin limit anymore. Prefer other targets or other primitives when running against glibc 2.39+. See "Modern constraints" below and consider combining with other techniques like a [large bin attack](large-bin-attack.md) or a [fast bin attack](fast-bin-attack.md) once you have a stable primitive.
 
@@ -49,7 +49,7 @@ To use unsorted‑bin writes reliably on current glibc:
   - This means the address you target must tolerate two writes: first `*(TARGET) = victim` at free‑time; later, as the chunk is removed, `*(TARGET) = unsorted_chunks(av)` (the allocator rewrites `bck->fd` back to the bin head). Choose targets where simply forcing a large non‑zero value is useful.
 - Typical stable targets in modern exploits
   - Application or global state that treats "large" values as flags/limits.
-  - Indirect primitives (e.g., set up for a subsequent [fast bin attack]({{#ref}}fast-bin-attack.md{{#endref}}) or to pivot a later write‐what‐where).
+  - Indirect primitives (e.g., set up for a subsequent [fast bin attack]({{#ref}}fast-bin-attack.md{{#endref}}) or to pivot a later write‐what‐where).<sup>[[3]](#references)</sup>
   - Avoid `__malloc_hook`/`__free_hook` on new glibc: they were removed in 2.34. Avoid `global_max_fast` on ≥ 2.39 (see next note).
 - About `global_max_fast` on recent glibc
   - On glibc 2.39+, `global_max_fast` is an 8‑bit global. The classic trick of writing a heap pointer into it (to enlarge fastbins) no longer works cleanly and is likely to corrupt adjacent allocator state. Prefer other strategies.<sup>[[5]](#references)</sup>
@@ -61,7 +61,7 @@ Goal: achieve a single arbitrary write of a heap pointer to an arbitrary address
 - Layout/grooming
   - Allocate A, B, C with sizes large enough to bypass tcache (e.g., 0x5000). C prevents consolidation with the top chunk.
 - Corruption
-  - Overflow from A into B’s chunk header to set `B->bk = (mchunkptr)(TARGET - 0x10)`.
+  - Overflow from A into B’s chunk header to set `B->bk = (mchunkptr)(TARGET - 0x10)`.<sup>[[1]](#references)</sup>
 - Trigger
   - `free(B)`. At insertion time the allocator executes `bck->fd = B`, therefore `*(TARGET) = B`.
 - Continuation

--- a/src/binary-exploitation/libc-heap/unsorted-bin-attack.md
+++ b/src/binary-exploitation/libc-heap/unsorted-bin-attack.md
@@ -90,7 +90,7 @@ free(B); // triggers *(TARGET) = B (unsorted-bin insertion write)
 This is actually a very basic concept. The chunks in the unsorted bin are going to have pointers. The first chunk in the unsorted bin will actually have the **`fd`** and the **`bk`** links **pointing to a part of the main arena (Glibc)**.\
 Therefore, if you can **put a chunk inside a unsorted bin and read it** (use after free) or **allocate it again without overwriting at least 1 of the pointers** to then **read** it, you can have a **Glibc info leak**.
 
-A similar [**attack used in this writeup**](https://guyinatuxedo.github.io/33-custom_misc_heap/csaw18_alienVSsamurai/index.html), was to abuse a 4 chunks structure (A, B, C and D - D is only to prevent consolidation with top chunk) so a null byte overflow in B was used to make C indicate that B was unused. Also, in B the `prev_size` data was modified so the size instead of being the size of B was A+B.\
+A similar [**attack used in this writeup**](https://guyinatuxedo.github.io/33-custom_misc_heap/csaw18_alienVSsamurai/index.html), was to abuse a 4 chunks structure (A, B, C and D - D is only to prevent consolidation with top chunk) so a null byte overflow in B was used to make C indicate that B was unused. Also, in B the `prev_size` data was modified so the size instead of being the size of B was A+B.<sup>[[7]](#references)</sup>\
 Then C was deallocated, and consolidated with A+B (but B was still in used). A new chunk of size A was allocated and then the libc leaked addresses was written into B from where they were leaked.<sup>[[7]](#references)</sup>
 
 ## References

--- a/src/binary-exploitation/rop-return-oriented-programing/ret2lib/README.md
+++ b/src/binary-exploitation/rop-return-oriented-programing/ret2lib/README.md
@@ -8,8 +8,8 @@ The essence of **Ret2Libc** is to redirect the execution flow of a vulnerable pr
 
 ### **Example Steps (simplified)**
 
-- Get the address of the function to call (e.g. system) and the command to call (e.g. /bin/sh)
-- Generate a ROP chain to pass the first argument pointing to the command string and the execution flow to the function
+- Get the address of the function to call (e.g. system) and the command to call (e.g. /bin/sh)<sup>[[5]](#references)</sup>
+- Generate a ROP chain to pass the first argument pointing to the command string and the execution flow to the function<sup>[[6]](#references)</sup>
 
 ## Finding the addresses
 
@@ -141,7 +141,7 @@ ret2lib-printf-leak-arm64.md
 
 ## Ret-into-printf (or puts)
 
-This allows to **leak information from the process** by calling `printf`/`puts` with some specific data placed as an argument. For example putting the address of `puts` in the GOT into an execution of `puts` will **leak the address of `puts` in memory**.
+This allows to **leak information from the process** by calling `printf`/`puts` with some specific data placed as an argument. For example putting the address of `puts` in the GOT into an execution of `puts` will **leak the address of `puts` in memory**.<sup>[[2]](#references)</sup>
 
 ## Ret2printf
 

--- a/src/generic-methodologies-and-resources/basic-forensic-methodology/adaptixc2-config-extraction-and-ttps.md
+++ b/src/generic-methodologies-and-resources/basic-forensic-methodology/adaptixc2-config-extraction-and-ttps.md
@@ -233,9 +233,9 @@ DNS/DoH listener fingerprints<sup>[[4]](#references)</sup>
 ## Loader and persistence TTPs seen in incidents
 
 In‑memory PowerShell loaders<sup>[[1]](#references)</sup>
-- Download Base64/XOR payloads (Invoke‑RestMethod / WebClient)
-- Allocate unmanaged memory, copy shellcode, switch protection to 0x40 (PAGE_EXECUTE_READWRITE) via VirtualProtect
-- Execute via .NET dynamic invocation: Marshal.GetDelegateForFunctionPointer + delegate.Invoke()
+- Download Base64/XOR payloads (Invoke‑RestMethod / WebClient)<sup>[[9]](#references)</sup>
+- Allocate unmanaged memory, copy shellcode, switch protection to 0x40 (PAGE_EXECUTE_READWRITE) via VirtualProtect<sup>[[7]](#references)</sup>
+- Execute via .NET dynamic invocation: Marshal.GetDelegateForFunctionPointer + delegate.Invoke()<sup>[[6]](#references)</sup>
 
 Trojanized signed software / staged shellcode loaders<sup>[[5]](#references)</sup>
 - A 2026 Tropic Trooper chain used a trojanized SumatraPDF executable (TOSHIS loader) that redirected `_security_init_cookie` into malicious code instead of patching the PE entry point
@@ -250,7 +250,7 @@ Check these pages for in‑memory execution and AMSI/ETW considerations:
 
 Persistence mechanisms observed<sup>[[1]](#references)</sup>
 - Startup folder shortcut (.lnk) to re‑launch a loader at logon
-- Registry Run keys (HKCU/HKLM ...\CurrentVersion\Run), often with benign‑sounding names like "Updater" to start loader.ps1
+- Registry Run keys (HKCU/HKLM ...\CurrentVersion\Run), often with benign‑sounding names like "Updater" to start loader.ps1<sup>[[10]](#references)</sup>
 - DLL search‑order hijack by dropping msimg32.dll under %APPDATA%\Microsoft\Windows\Templates for susceptible processes
 
 Technique deep‑dives and checks:
@@ -264,7 +264,7 @@ Technique deep‑dives and checks:
 {{#endref}}
 
 Hunting ideas
-- PowerShell spawning RW→RX transitions: VirtualProtect to PAGE_EXECUTE_READWRITE inside powershell.exe
+- PowerShell spawning RW→RX transitions: VirtualProtect to PAGE_EXECUTE_READWRITE inside powershell.exe<sup>[[8]](#references)</sup>
 - Dynamic invocation patterns (GetDelegateForFunctionPointer)
 - Unmatched HTTPS 404s with `Server: AdaptixC2`, `Adaptix-Version`, `AdaptixC2 404`, or `You need to enter the correct connection details.`<sup>[[4]](#references)</sup>
 - DNS responses with `AA=true` and `TXT "OK"` for short queries under suspect domains<sup>[[4]](#references)</sup>

--- a/src/generic-methodologies-and-resources/basic-forensic-methodology/file-integrity-monitoring.md
+++ b/src/generic-methodologies-and-resources/basic-forensic-methodology/file-integrity-monitoring.md
@@ -110,7 +110,7 @@ Container FIM frequently misses the real write path. With Docker `overlay2`, cha
 
 - [AIDE](https://aide.github.io/)
 - [osquery](https://osquery.io/)
-- [Wazuh FIM / Syscheck](https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html)
+- [Wazuh FIM / Syscheck](https://documentation.wazuh.com/current/user-manual/capabilities/file-integrity/index.html)<sup>[[3]](#references)</sup>
 - [Elastic Auditbeat File Integrity Module](https://www.elastic.co/docs/reference/beats/auditbeat/auditbeat-module-file_integrity)
 - [Sysmon](https://learn.microsoft.com/en-us/sysinternals/downloads/sysmon)
 

--- a/src/generic-methodologies-and-resources/basic-forensic-methodology/partitions-file-systems-carving/README.md
+++ b/src/generic-methodologies-and-resources/basic-forensic-methodology/partitions-file-systems-carving/README.md
@@ -129,7 +129,7 @@ The partition table header defines the usable blocks on the disk. It also define
 
 ![MBR (master Boot Record) - GPT (GUID Partition Table): 56 (0x38) | 72 bytes | Partition name (36 UTF-16LE code units)](<../../../images/image (83).png>)
 
-More partition types in [https://en.wikipedia.org/wiki/GUID_Partition_Table](https://en.wikipedia.org/wiki/GUID_Partition_Table)
+More partition types in [https://en.wikipedia.org/wiki/GUID_Partition_Table](https://en.wikipedia.org/wiki/GUID_Partition_Table)<sup>[[1]](#references)</sup>
 
 ### Inspecting
 

--- a/src/generic-methodologies-and-resources/basic-forensic-methodology/pcap-inspection/dnscat-exfiltration.md
+++ b/src/generic-methodologies-and-resources/basic-forensic-methodology/pcap-inspection/dnscat-exfiltration.md
@@ -25,7 +25,7 @@ for p in rdpcap('ch21.pcap'):
 #print(f)
 ```
 
-For more information: [https://github.com/jrmdev/ctf-writeups/tree/master/bsidessf-2017/dnscap](https://github.com/jrmdev/ctf-writeups/tree/master/bsidessf-2017/dnscap)\
+For more information: [https://github.com/jrmdev/ctf-writeups/tree/master/bsidessf-2017/dnscap](https://github.com/jrmdev/ctf-writeups/tree/master/bsidessf-2017/dnscap)<sup>[[1]](#references)</sup>\
 [https://github.com/iagox86/dnscat2/blob/master/doc/protocol.md](https://github.com/iagox86/dnscat2/blob/master/doc/protocol.md)
 
 There is a script that works with Python3: [https://github.com/josemlwdf/DNScat-Decoder](https://github.com/josemlwdf/DNScat-Decoder)

--- a/src/generic-methodologies-and-resources/basic-forensic-methodology/specific-software-file-type-tricks/discord-cache-forensics.md
+++ b/src/generic-methodologies-and-resources/basic-forensic-methodology/specific-software-file-type-tricks/discord-cache-forensics.md
@@ -49,7 +49,7 @@ Media can be extracted by splitting headers from body and optionally decompressi
 
 ## Automated DFIR: Discord Forensic Suite (CLI/GUI)
 
-- Repo: https://github.com/jwdfir/discord_cache_parser
+- Repo: https://github.com/jwdfir/discord_cache_parser<sup>[[2]](#references)</sup>
 - Function: Recursively scans Discord’s cache folder, finds webhook/API/attachment URLs, parses f_* bodies, optionally carves media, and outputs HTML + CSV timeline reports with SHA‑256 hashes.<sup>[[2]](#references)</sup>
 
 Example CLI usage:

--- a/src/generic-methodologies-and-resources/basic-forensic-methodology/specific-software-file-type-tricks/mach-o-entitlements-and-ipsw-indexing.md
+++ b/src/generic-methodologies-and-resources/basic-forensic-methodology/specific-software-file-type-tricks/mach-o-entitlements-and-ipsw-indexing.md
@@ -195,11 +195,11 @@ Notes on DB portability (if you implement your own indexer):<sup>[[1]](#referenc
 
 ## Open-source tooling and references for entitlement hunting
 
-- Firmware mount/download: https://github.com/blacktop/ipsw
+- Firmware mount/download: https://github.com/blacktop/ipsw<sup>[[3]](#references)</sup>
 - Entitlement databases and references:
-  - Jonathan Levin’s entitlement DB: https://newosxbook.com/ent.php
-  - entdb: https://github.com/ChiChou/entdb
-- Large-scale indexer (Rust, self-hosted Web UI + OpenAPI): https://github.com/synacktiv/appledb_rs
+  - Jonathan Levin’s entitlement DB: https://newosxbook.com/ent.php<sup>[[4]](#references)</sup>
+  - entdb: https://github.com/ChiChou/entdb<sup>[[5]](#references)</sup>
+- Large-scale indexer (Rust, self-hosted Web UI + OpenAPI): https://github.com/synacktiv/appledb_rs<sup>[[2]](#references)</sup>
 - Apple headers for structures and constants:
   - loader.h (Mach-O headers, load commands)
   - cs_blobs.h (SuperBlob, GenericBlob, CodeDirectory)

--- a/src/generic-methodologies-and-resources/basic-forensic-methodology/specific-software-file-type-tricks/office-file-analysis.md
+++ b/src/generic-methodologies-and-resources/basic-forensic-methodology/specific-software-file-type-tricks/office-file-analysis.md
@@ -22,7 +22,7 @@ olevba -c /path/to/document #Extract macros
 
 ## OLE Compound File exploitation: Autodesk Revit RFA – ECC recomputation and controlled gzip
 
-Revit RFA models are stored as an [OLE Compound File](https://learn.microsoft.com/en-us/windows/win32/stg/istorage-compound-file-implementation) (aka CFBF). The serialized model is under storage/stream:<sup>[[1]](#references)</sup>
+Revit RFA models are stored as an [OLE Compound File](https://learn.microsoft.com/en-us/windows/win32/stg/istorage-compound-file-implementation) (aka CFBF). The serialized model is under storage/stream:<sup>[[1]](#references)[[3]](#references)</sup>
 
 - Storage: `Global`
 - Stream: `Latest` → `Global\Latest`
@@ -94,7 +94,7 @@ and general ROP guidance here:
 
 Tooling:<sup>[[1]](#references)</sup>
 
-- CompoundFileTool (OSS) to expand/rebuild OLE compound files: https://github.com/thezdi/CompoundFileTool
+- CompoundFileTool (OSS) to expand/rebuild OLE compound files: https://github.com/thezdi/CompoundFileTool<sup>[[2]](#references)</sup>
 - IDA Pro + WinDBG TTD for reverse/taint; disable page heap with TTD to keep traces compact.
 - A local proxy (e.g., Fiddler) can simulate supply-chain delivery by swapping RFAs in plugin traffic for testing.
 

--- a/src/generic-methodologies-and-resources/basic-forensic-methodology/specific-software-file-type-tricks/pdf-file-analysis.md
+++ b/src/generic-methodologies-and-resources/basic-forensic-methodology/specific-software-file-type-tricks/pdf-file-analysis.md
@@ -15,7 +15,7 @@ For in-depth exploration or manipulation of PDFs, tools like [qpdf](https://gith
 - Text behind images or overlapping images
 - Non-displayed comments
 
-For custom PDF analysis, Python libraries like [PeepDF](https://github.com/jesparza/peepdf) can be used to craft bespoke parsing scripts. Further, the PDF's potential for hidden data storage is so vast that resources like the NSA guide on PDF risks and countermeasures, though no longer hosted at its original location, still offer valuable insights. A [copy of the guide](http://www.itsecure.hu/library/file/Biztons%C3%A1gi%20%C3%BAtmutat%C3%B3k/Alkalmaz%C3%A1sok/Hidden%20Data%20and%20Metadata%20in%20Adobe%20PDF%20Files.pdf) and a collection of [PDF format tricks](https://github.com/corkami/docs/blob/master/PDF/PDF.md) by Ange Albertini can provide further reading on the subject.
+For custom PDF analysis, Python libraries like [PeepDF](https://github.com/jesparza/peepdf) can be used to craft bespoke parsing scripts. Further, the PDF's potential for hidden data storage is so vast that resources like the NSA guide on PDF risks and countermeasures, though no longer hosted at its original location, still offer valuable insights. A [copy of the guide](http://www.itsecure.hu/library/file/Biztons%C3%A1gi%20%C3%BAtmutat%C3%B3k/Alkalmaz%C3%A1sok/Hidden%20Data%20and%20Metadata%20in%20Adobe%20PDF%20Files.pdf) and a collection of [PDF format tricks](https://github.com/corkami/docs/blob/master/PDF/PDF.md) by Ange Albertini can provide further reading on the subject.<sup>[[4]](#references)[[5]](#references)</sup>
 
 ## Common Malicious Constructs
 
@@ -104,5 +104,7 @@ rule Suspicious_PDF_AutoExec {
 - [1] [Forensics CTF Field Guide](https://trailofbits.github.io/ctf/forensics/)
 - [2] [MalDoc in PDF – Detection bypass by embedding a malicious Word file into a PDF file](https://blogs.jpcert.or.jp/en/2023/08/maldocinpdf.html)
 - [3] [Adobe Security Bulletin – Security update available for Adobe Acrobat and Reader (APSB24-29)](https://helpx.adobe.com/security/products/acrobat/apsb24-29.html)
+- [4] [itsecure.hu - copy of the guide](http://www.itsecure.hu/library/file/Biztons%C3%A1gi%20%C3%BAtmutat%C3%B3k/Alkalmaz%C3%A1sok/Hidden%20Data%20and%20Metadata%20in%20Adobe%20PDF%20Files.pdf)
+- [5] [corkami/docs - PDF format tricks](https://github.com/corkami/docs/blob/master/PDF/PDF.md)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/generic-methodologies-and-resources/basic-forensic-methodology/specific-software-file-type-tricks/zips-tricks.md
+++ b/src/generic-methodologies-and-resources/basic-forensic-methodology/specific-software-file-type-tricks/zips-tricks.md
@@ -5,7 +5,7 @@
 **Command-line tools** for managing **zip files** are essential for diagnosing, repairing, and cracking zip files. Here are some key utilities:<sup>[[1]](#references)</sup>
 
 - **`unzip`**: Reveals why a zip file may not decompress.
-- **`zipdetails -v`**: Offers detailed analysis of zip file format fields.
+- **`zipdetails -v`**: Offers detailed analysis of zip file format fields.<sup>[[3]](#references)</sup>
 - **`zipinfo`**: Lists contents of a zip file without extracting them.
 - **`zip -F input.zip --out output.zip`** and **`zip -FF input.zip --out output.zip`**: Try to repair corrupted zip files.
 - **[fcrackzip](https://github.com/hyc/fcrackzip)**: A tool for brute-force cracking of zip passwords, effective for passwords up to around 7 characters.

--- a/src/generic-methodologies-and-resources/basic-forensic-methodology/windows-forensics/README.md
+++ b/src/generic-methodologies-and-resources/basic-forensic-methodology/windows-forensics/README.md
@@ -170,7 +170,7 @@ A screenshot depicting the task's content is provided: ![USB Detective - Plug an
 
 This configuration ensures regular maintenance and cleanup of drivers, with provisions for reattempting the task in case of consecutive failures.
 
-**For more information check:** [**https://blog.1234n6.com/2018/07/windows-plug-and-play-cleanup.html**](https://blog.1234n6.com/2018/07/windows-plug-and-play-cleanup.html)
+**For more information check:** [**https://blog.1234n6.com/2018/07/windows-plug-and-play-cleanup.html**](https://blog.1234n6.com/2018/07/windows-plug-and-play-cleanup.html)<sup>[[1]](#references)</sup>
 
 ## Emails
 
@@ -275,7 +275,7 @@ interesting-windows-registry-keys.md
 
 ### Basic Windows Processes
 
-In [this post](https://jonahacks.medium.com/investigating-common-windows-processes-18dee5f97c1d) you can learn about the common Windows processes to detect suspicious behaviours.
+In [this post](https://jonahacks.medium.com/investigating-common-windows-processes-18dee5f97c1d) you can learn about the common Windows processes to detect suspicious behaviours.<sup>[[2]](#references)</sup>
 
 ### Windows Recent APPs
 
@@ -503,6 +503,7 @@ Security EventID 1102 signals the deletion of logs, a critical event for forensi
 ## References
 
 - [1] [Windows Plug and Play Cleanup](https://blog.1234n6.com/2018/07/windows-plug-and-play-cleanup.html)
+- [2] [jonahacks.medium.com - Investigating Common Windows Processes](https://jonahacks.medium.com/investigating-common-windows-processes-18dee5f97c1d)
 
 {{#include ../../../banners/hacktricks-training.md}}
 

--- a/src/generic-methodologies-and-resources/external-recon-methodology/README.md
+++ b/src/generic-methodologies-and-resources/external-recon-methodology/README.md
@@ -138,7 +138,7 @@ python3 favihash.py -f https://target/favicon.ico -t targets.txt -s
 
 Simply said, favihash will allow us to discover domains that have the same favicon icon hash as our target.
 
-Moreover, you can also search technologies using the favicon hash as explained in [**this blog post**](https://medium.com/@Asm0d3us/weaponizing-favicon-ico-for-bugbounties-osint-and-what-not-ace3c214e139). That means that if you know the **hash of the favicon of a vulnerable version of a web tech** you can search if in shodan and **find more vulnerable places**:
+Moreover, you can also search technologies using the favicon hash as explained in [**this blog post**](https://medium.com/@Asm0d3us/weaponizing-favicon-ico-for-bugbounties-osint-and-what-not-ace3c214e139). That means that if you know the **hash of the favicon of a vulnerable version of a web tech** you can search if in shodan and **find more vulnerable places**:<sup>[[5]](#references)</sup>
 
 ```bash
 shodan search org:"Target" http.favicon.hash:116323821 --fields ip_str,port --separator " " | awk '{print $1":"$2}'
@@ -189,7 +189,7 @@ It's common to have a cron job such as
 ```
 
 to renew the all the domain certificates on the server. This means that even if the CA used for this doesn't set the time it was generated in the Validity time, it's possible to **find domains belonging to the same company in the certificate transparency logs**.\
-Check out this [**writeup for more information**](https://swarm.ptsecurity.com/discovering-domains-via-a-time-correlation-attack/).
+Check out this [**writeup for more information**](https://swarm.ptsecurity.com/discovering-domains-via-a-time-correlation-attack/).<sup>[[6]](#references)</sup>
 
 Also use **certificate transparency** logs directly:
 
@@ -207,7 +207,7 @@ Other useful tools are [**spoofcheck**](https://github.com/BishopFox/spoofcheck)
 
 Apparently is common for people to assign subdomains to IPs that belongs to cloud providers and at some point **lose that IP address but forget about removing the DNS record**. Therefore, just **spawning a VM** in a cloud (like Digital Ocean) you will be actually **taking over some subdomains(s)**.
 
-[**This post**](https://kmsec.uk/blog/passive-takeover/) explains a store about it and propose a script that **spawns a VM in DigitalOcean**, **gets** the **IPv4** of the new machine, and **searches in Virustotal for subdomain records** pointing to it.
+[**This post**](https://kmsec.uk/blog/passive-takeover/) explains a store about it and propose a script that **spawns a VM in DigitalOcean**, **gets** the **IPv4** of the new machine, and **searches in Virustotal for subdomain records** pointing to it.<sup>[[7]](#references)</sup>
 
 ### **Other ways**
 
@@ -508,7 +508,7 @@ cat subdomains.txt | dmut -d /tmp/words-permutations.txt -w 100 \
 
 #### Smart permutations generation
 
-- [**regulator**](https://github.com/cramppet/regulator): For more info read this [**post**](https://cramppet.github.io/regulator/index.html) but it will basically get the **main parts** from the **discovered subdomains** and will mix them to find more subdomains.
+- [**regulator**](https://github.com/cramppet/regulator): For more info read this [**post**](https://cramppet.github.io/regulator/index.html) but it will basically get the **main parts** from the **discovered subdomains** and will mix them to find more subdomains.<sup>[[8]](#references)</sup>
 
 ```bash
 python3 main.py adobe.com adobe adobe.rules
@@ -765,5 +765,9 @@ There are several tools out there that will perform part of the proposed actions
 - [2] [0xdf – HTB: Guardian](https://0xdf.gitlab.io/2026/02/28/htb-guardian.html)
 - [3] [Bishop Fox – On Favicons: From Browser Icons to Attack Surface Intelligence](https://bishopfox.com/blog/on-favicons-from-browser-icons-to-attack-surface-intelligence)
 - [4] [BishopFox/Favicons](https://github.com/BishopFox/Favicons)
+- [5] [@Asm0d3us - Weaponizing Favicon Ico For Bugbounties Osint And What Not](https://medium.com/@Asm0d3us/weaponizing-favicon-ico-for-bugbounties-osint-and-what-not-ace3c214e139)
+- [6] [swarm.ptsecurity.com - Discovering Domains Via A Time Correlation Attack](https://swarm.ptsecurity.com/discovering-domains-via-a-time-correlation-attack)
+- [7] [kmsec.uk - Passive Takeover](https://kmsec.uk/blog/passive-takeover)
+- [8] [cramppet.github.io - Regulator - Index](https://cramppet.github.io/regulator/index.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/generic-methodologies-and-resources/pentesting-network/dhcpv6.md
+++ b/src/generic-methodologies-and-resources/pentesting-network/dhcpv6.md
@@ -60,7 +60,7 @@ sudo atk6-dump_dhcp6 <IFACE>
 sudo atk6-fake_dhcps6 <IFACE> <PREFIX>/<LEN> <DNSv6>
 ```
 
-This is a generic on-link rogue DHCPv6 server. On Windows/AD networks, pair this with higher-level relays (see the IPv6 page) if you want NTLM relay primitives.
+This is a generic on-link rogue DHCPv6 server. On Windows/AD networks, pair this with higher-level relays (see the IPv6 page) if you want NTLM relay primitives.<sup>[[3]](#references)</sup>
 
 ### Pool Exhaustion / DHCPv6 Starvation
 

--- a/src/network-services-pentesting/pentesting-mssql-microsoft-sql-server/README.md
+++ b/src/network-services-pentesting/pentesting-mssql-microsoft-sql-server/README.md
@@ -215,7 +215,7 @@ SELECT * FROM sysusers
    - **Server** – Examples include databases, logins, endpoints, availability groups, and server roles.
    - **Database** – Examples cover database role, application roles, schema, certificates, full text catalogs, and users.
    - **Schema** – Includes tables, views, procedures, functions, synonyms, etc.
-2. **Permission:** Associated with SQL Server securables, permissions such as ALTER, CONTROL, and CREATE can be granted to a principal. Management of permissions occurs at two levels:
+2. **Permission:** Associated with SQL Server securables, permissions such as ALTER, CONTROL, and CREATE can be granted to a principal. Management of permissions occurs at two levels:<sup>[[11]](#references)</sup>
    - **Server Level** using logins
    - **Database Level** using users
 3. **Principal:** This term refers to the entity that is granted permission to a securable. Principals mainly include logins and database users. The control over access to securables is exercised through the granting or denying of permissions or by including logins and users in roles equipped with access rights.
@@ -416,9 +416,9 @@ KRB5CCNAME=<user_to_impersonate>.ccache mssqlclient.py -no-pass -k <fqdn>
 
 #### Linked-server credential mapping -> remote `sysadmin` -> OS RCE
 
-Linked servers can be configured with a **non-self login mapping** (`Local Login` -> `Remote Login`). In that case, a low-privileged login on the first SQL Server can execute queries on the second one **as the mapped remote principal**. This works the same way even when the linked instance lives in **another domain or forest**.<sup>[[2]](#references)</sup>
+Linked servers can be configured with a **non-self login mapping** (`Local Login` -> `Remote Login`). In that case, a low-privileged login on the first SQL Server can execute queries on the second one **as the mapped remote principal**. This works the same way even when the linked instance lives in **another domain or forest**.<sup>[[2]](#references)[[17]](#references)</sup>
 
-First enumerate the links and their mappings:
+First enumerate the links and their mappings:<sup>[[4]](#references)</sup>
 
 ```sql
 EXEC sp_linkedservers;

--- a/src/network-services-pentesting/pentesting-mssql-microsoft-sql-server/README.md
+++ b/src/network-services-pentesting/pentesting-mssql-microsoft-sql-server/README.md
@@ -657,7 +657,7 @@ GO
 
 ### Read Registry
 
-Microsoft SQL Server provides **multiple extended stored procedures** that allow you to interact with not only the network but also the file system and even the [**Windows Registry**](https://blog.waynesheffield.com/wayne/archive/2017/08/working-registry-sql-server/)**:**
+Microsoft SQL Server provides **multiple extended stored procedures** that allow you to interact with not only the network but also the file system and even the [**Windows Registry**](https://blog.waynesheffield.com/wayne/archive/2017/08/working-registry-sql-server/)**:**<sup>[[16]](#references)</sup>
 
 | **Regular**                 | **Instance-Aware**                   |
 | --------------------------- | ------------------------------------ |
@@ -879,7 +879,7 @@ After validating your permissions, you need to configure three things, which are
 
 To automate these configurations, [this repository ](https://github.com/IamLeandrooooo/SQLServerLinkedServersPasswords/)has the needed scripts. Besides having a powershell script for each step of the configuration, the repository also has a full script which combines the configuration scripts and the extraction and decryption of the passwords.
 
-For further information, refer to the following links regarding this attack: [Decrypting MSSQL Database Link Server Passwords](https://www.netspi.com/blog/technical/adversary-simulation/decrypting-mssql-database-link-server-passwords/)
+For further information, refer to the following links regarding this attack: [Decrypting MSSQL Database Link Server Passwords](https://www.netspi.com/blog/technical/adversary-simulation/decrypting-mssql-database-link-server-passwords/)<sup>[[19]](#references)</sup>
 
 [Troubleshooting the SQL Server Dedicated Administrator Connection](https://www.mssqltips.com/sqlservertip/5364/troubleshooting-the-sql-server-dedicated-administrator-connection/)
 
@@ -922,6 +922,7 @@ You probably will be able to **escalate to Administrator** following one of thes
 - [16] [Working with the Registry from SQL Server - Wayne Sheffield](https://blog.waynesheffield.com/wayne/archive/2017/08/working-registry-sql-server/)
 - [17] [GOADv2 pwning - part 12 - mayfly277](https://mayfly277.github.io/posts/GOADv2-pwning-part12/)
 - [18] [SQL Server exploitation notes - exploit7 (translated)](https://exploit7-tr.translate.goog/posts/sqlserver/?_x_tr_sl=es&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp)
+- [19] [netspi.com - Decrypting MSSQL Database Link Server Passwords](https://www.netspi.com/blog/technical/adversary-simulation/decrypting-mssql-database-link-server-passwords)
 
 
 ## HackTricks Automatic Commands

--- a/src/pentesting-web/browser-extension-pentesting-methodology/browext-permissions-and-host_permissions.md
+++ b/src/pentesting-web/browser-extension-pentesting-methodology/browext-permissions-and-host_permissions.md
@@ -6,7 +6,7 @@
 
 ### **`permissions`**
 
-Permissions are defined in the extension's **`manifest.json`** file using the **`permissions`** property and allow access to almost anything a browser can access (Cookies or Physical Storage):
+Permissions are defined in the extension's **`manifest.json`** file using the **`permissions`** property and allow access to almost anything a browser can access (Cookies or Physical Storage):<sup>[[2]](#references)</sup>
 
 The previous manifest declares that the extension requires the `storage` permission. This means that it can use [the storage API](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage) to store its data persistently. Unlike cookies or `localStorage` APIs which give users some level of control, **extension storage can normally only be cleared by uninstalling the extension**.
 
@@ -112,7 +112,7 @@ However, advertising companies could also abuse this storage.<sup>[[1]](#referen
 
 ### Search provider hijacking with `chrome_settings_overrides`
 
-A **low-permission** extension can still **take over omnibox searches** via **`chrome_settings_overrides.search_provider`**. Chrome allows an extension to define a custom search endpoint containing **`{searchTerms}`**, so a manifest-only extension can silently route every address-bar search through operator-controlled infrastructure:
+A **low-permission** extension can still **take over omnibox searches** via **`chrome_settings_overrides.search_provider`**. Chrome allows an extension to define a custom search endpoint containing **`{searchTerms}`**, so a manifest-only extension can silently route every address-bar search through operator-controlled infrastructure:<sup>[[6]](#references)</sup>
 
 ```json
 "chrome_settings_overrides": {
@@ -153,7 +153,7 @@ Practical checks:
 
 Manifest V3 split page access from API permissions: **`permissions`** still governs privileged APIs (cookies, tabs, history, scripting, etc.) while **`host_permissions`** controls which origins those APIs can touch. MV3 also made host permissions **runtime‑grantable**, so extensions can ship with none and pop a consent prompt later via `chrome.permissions.request()`—handy for legit least‑privilege flows, but also abused by malware to escalate after reputation is established.<sup>[[4]](#references)</sup>
 
-A stealthy variant is **`declarativeNetRequestWithHostAccess`** (Chrome ≥96). It provides the same request‑blocking/redirect power as `declarativeNetRequest` but **shows a weaker install prompt** than `<all_urls>` host permissions. Malicious extensions use it to silently get “block/redirect on any site” capability; test prompts with `chrome://extensions/?errors` and `chrome://extensions/?id=<id>`.
+A stealthy variant is **`declarativeNetRequestWithHostAccess`** (Chrome ≥96). It provides the same request‑blocking/redirect power as `declarativeNetRequest` but **shows a weaker install prompt** than `<all_urls>` host permissions. Malicious extensions use it to silently get “block/redirect on any site” capability; test prompts with `chrome://extensions/?errors` and `chrome://extensions/?id=<id>`.<sup>[[7]](#references)</sup>
 
 `declarativeNetRequest` dynamic rules let an extension reprogram network policy at runtime. With `<all_urls>` host access an attacker can weaponise it to hijack traffic or data exfil. Example:
 

--- a/src/pentesting-web/deserialization/java-dns-deserialization-and-gadgetprobe.md
+++ b/src/pentesting-web/deserialization/java-dns-deserialization-and-gadgetprobe.md
@@ -159,7 +159,7 @@ The **extension** has **passive** and active **capabilities**.<sup>[[4]](#refere
 
 By default it **checks passively** all the requests and responses sent **looking** for **Java serialized magic bytes** and will present a vulnerability warning if any is found:
 
-![https://techblog.mediaservice.net/2017/05/reliable-discovery-and-exploitation-of-java-deserialization-vulnerabilities/](<../../images/image (765).png>)
+![https://techblog.mediaservice.net/2017/05/reliable-discovery-and-exploitation-of-java-deserialization-vulnerabilities/](<../../images/image (765).png>)<sup>[[4]](#references)</sup>
 
 ### Active
 
@@ -168,7 +168,7 @@ By default it **checks passively** all the requests and responses sent **looking
 You can select a request, right click and `Send request to DS - Manual Testing`.\
 Then, inside the _Deserialization Scanner Tab_ --> _Manual testing tab_ you can select the **insertion point**. And **launch the testing** (Select the appropriate attack depending on the encoding used).
 
-![https://techblog.mediaservice.net/2017/05/reliable-discovery-and-exploitation-of-java-deserialization-vulnerabilities/](../../images/3-1.png)
+![https://techblog.mediaservice.net/2017/05/reliable-discovery-and-exploitation-of-java-deserialization-vulnerabilities/](../../images/3-1.png)<sup>[[4]](#references)</sup>
 
 Even if this is called "Manual testing", it's pretty **automated**. It will automatically check if the **deserialization** is **vulnerable** to **any ysoserial payload** checking the libraries present on the web server and will highlight the ones vulnerable. In order to **check** for **vulnerable libraries** you can select to launch **Javas Sleeps**, **sleeps** via **CPU** consumption, or using **DNS** as it has previously being mentioned.
 
@@ -177,7 +177,7 @@ Even if this is called "Manual testing", it's pretty **automated**. It will auto
 Once you have identified a vulnerable library you can send the request to the _Exploiting Tab_.\
 I this tab you have to **select** the **injection point** again, an **write** the **vulnerable library** you want to create a payload for, and the **command**. Then, just press the appropriate **Attack** button.
 
-![https://techblog.mediaservice.net/2017/05/reliable-discovery-and-exploitation-of-java-deserialization-vulnerabilities/](../../images/4.png)
+![https://techblog.mediaservice.net/2017/05/reliable-discovery-and-exploitation-of-java-deserialization-vulnerabilities/](../../images/4.png)<sup>[[4]](#references)</sup>
 
 ### Java Deserialization DNS Exfil information
 

--- a/src/pentesting-web/registration-vulnerabilities.md
+++ b/src/pentesting-web/registration-vulnerabilities.md
@@ -262,7 +262,7 @@ email=victim@mail.com|hacker@mail.com
 ### Weak Password Reset Token <a href="#weak-password-reset-token" id="weak-password-reset-token"></a>
 
 The password reset token should be randomly generated and unique every time.\
-Try to determine if the token expire or if it’s always the same, in some cases the generation algorithm is weak and can be guessed. The following variables might be used by the algorithm.
+Try to determine if the token expire or if it’s always the same, in some cases the generation algorithm is weak and can be guessed. The following variables might be used by the algorithm.<sup>[[3]](#references)</sup>
 
 - Timestamp
 - UserID

--- a/src/pentesting-web/sql-injection/cypher-injection-neo4j.md
+++ b/src/pentesting-web/sql-injection/cypher-injection-neo4j.md
@@ -4,8 +4,8 @@
 
 Check the following blogs:<sup>[[1]](#references)[[2]](#references)</sup>
 
-- [https://www.varonis.com/blog/neo4jection-secrets-data-and-cloud-exploits](https://www.varonis.com/blog/neo4jection-secrets-data-and-cloud-exploits)
-- [https://infosecwriteups.com/the-most-underrated-injection-of-all-time-cypher-injection-fa2018ba0de8](https://infosecwriteups.com/the-most-underrated-injection-of-all-time-cypher-injection-fa2018ba0de8)
+- [https://www.varonis.com/blog/neo4jection-secrets-data-and-cloud-exploits](https://www.varonis.com/blog/neo4jection-secrets-data-and-cloud-exploits)<sup>[[1]](#references)</sup>
+- [https://infosecwriteups.com/the-most-underrated-injection-of-all-time-cypher-injection-fa2018ba0de8](https://infosecwriteups.com/the-most-underrated-injection-of-all-time-cypher-injection-fa2018ba0de8)<sup>[[2]](#references)</sup>
 
 ## References
 

--- a/src/pentesting-web/sql-injection/ms-access-sql-injection.md
+++ b/src/pentesting-web/sql-injection/ms-access-sql-injection.md
@@ -93,7 +93,7 @@ You can also use a more traditional way:
 _Feel free to check this in the online playground._
 
 - Sqlmap common table names: [https://github.com/sqlmapproject/sqlmap/blob/master/data/txt/common-tables.txt](https://github.com/sqlmapproject/sqlmap/blob/master/data/txt/common-tables.txt)
-- There is another list in [http://nibblesec.org/files/MSAccessSQLi/MSAccessSQLi.html](http://nibblesec.org/files/MSAccessSQLi/MSAccessSQLi.html)
+- There is another list in [http://nibblesec.org/files/MSAccessSQLi/MSAccessSQLi.html](http://nibblesec.org/files/MSAccessSQLi/MSAccessSQLi.html)<sup>[[1]](#references)</sup>
 
 ### Brute-Forcing Columns names
 

--- a/src/pentesting-web/sql-injection/oracle-injection.md
+++ b/src/pentesting-web/sql-injection/oracle-injection.md
@@ -2,7 +2,7 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-**Serve this post a wayback machine copy of the deleted post from [https://ibreak.software/2020/06/using-sql-injection-to-perform-ssrf-xspa-attacks/](https://ibreak.software/2020/06/using-sql-injection-to-perform-ssrf-xspa-attacks/)**.
+**Serve this post a wayback machine copy of the deleted post from [https://ibreak.software/2020/06/using-sql-injection-to-perform-ssrf-xspa-attacks/](https://ibreak.software/2020/06/using-sql-injection-to-perform-ssrf-xspa-attacks/)**.<sup>[[3]](#references)</sup>
 
 ## SSRF
 

--- a/src/pentesting-web/xslt-server-side-injection-extensible-stylesheet-language-transformations.md
+++ b/src/pentesting-web/xslt-server-side-injection-extensible-stylesheet-language-transformations.md
@@ -12,7 +12,7 @@ The frameworks that are most frequently used include:
 - **Xalan** from Apache,
 - **Saxon** from Saxonica.
 
-For the exploitation of vulnerabilities associated with XSLT, it is necessary for xsl tags to be stored on the server side, followed by accessing that content. An illustration of such a vulnerability is documented in the following source: [https://www.gosecure.net/blog/2019/05/02/esi-injection-part-2-abusing-specific-implementations/](https://www.gosecure.net/blog/2019/05/02/esi-injection-part-2-abusing-specific-implementations/).
+For the exploitation of vulnerabilities associated with XSLT, it is necessary for xsl tags to be stored on the server side, followed by accessing that content. An illustration of such a vulnerability is documented in the following source: [https://www.gosecure.net/blog/2019/05/02/esi-injection-part-2-abusing-specific-implementations/](https://www.gosecure.net/blog/2019/05/02/esi-injection-part-2-abusing-specific-implementations/).<sup>[[10]](#references)</sup>
 
 ## Example - Tutorial
 
@@ -542,5 +542,6 @@ https://github.com/carlospolop/Auto_Wordlists/blob/main/wordlists/xslt.txt
 - [7] [lxml API - XMLParser](https://lxml.de/api/lxml.etree.XMLParser-class.html)
 - [8] [Saxon - Writing reflexive extension functions in Java](https://www.saxonica.com/html/documentation11/extensibility/extension-functions-J/reflexive-functions/index.html)
 - [9] [.NET - Script Blocks Using msxsl:script](https://learn.microsoft.com/en-us/dotnet/standard/data/xml/script-blocks-using-msxsl-script)
+- [10] [gosecure.net - Esi Injection Part 2 Abusing Specific Implementations](https://www.gosecure.net/blog/2019/05/02/esi-injection-part-2-abusing-specific-implementations)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/pentesting-web/xslt-server-side-injection-extensible-stylesheet-language-transformations.md
+++ b/src/pentesting-web/xslt-server-side-injection-extensible-stylesheet-language-transformations.md
@@ -4,9 +4,9 @@
 
 ## Basic Information
 
-XSLT is a technology employed for transforming XML documents into different formats. It comes in three versions: 1, 2, and 3, with version 1 being the most commonly utilized. The transformation process can be executed either on the server or within the browser.
+XSLT is a technology employed for transforming XML documents into different formats. It comes in three versions: 1, 2, and 3, with version 1 being the most commonly utilized. The transformation process can be executed either on the server or within the browser.<sup>[[2]](#references)</sup>
 
-The frameworks that are most frequently used include:
+The frameworks that are most frequently used include:<sup>[[3]](#references)</sup>
 
 - **Libxslt** from Gnome,
 - **Xalan** from Apache,
@@ -441,7 +441,7 @@ xmlns:php="http://php.net/xsl" >
 </html>
 ```
 
-Execute code using other frameworks in the PDF
+Execute code using other frameworks in the PDF<sup>[[1]](#references)</sup>
 
 ### **Java / .NET specific execution primitives**
 

--- a/src/windows-hardening/active-directory-methodology/dcshadow.md
+++ b/src/windows-hardening/active-directory-methodology/dcshadow.md
@@ -100,7 +100,7 @@ To get the current ACE of an object: `(New-Object System.DirectoryServices.Direc
 
 Notice that in this case you need to make **several changes,** not just one. So, in the **mimikatz1 session** (RPC server) use the parameter **`/stack` with each change** you want to make. This way, you will only need to **`/push`** one time to perform all the stucked changes in the rouge server.
 
-[**More information about DCShadow in ired.team.**](https://ired.team/offensive-security-experiments/active-directory-kerberos-abuse/t1207-creating-rogue-domain-controllers-with-dcshadow)
+[**More information about DCShadow in ired.team.**](https://ired.team/offensive-security-experiments/active-directory-kerberos-abuse/t1207-creating-rogue-domain-controllers-with-dcshadow)<sup>[[2]](#references)</sup>
 
 ## References
 

--- a/src/windows-hardening/active-directory-methodology/golden-dmsa-gmsa.md
+++ b/src/windows-hardening/active-directory-methodology/golden-dmsa-gmsa.md
@@ -32,7 +32,7 @@ This is analogous to a *Golden Ticket* for service accounts.<sup>[[1]](#referenc
 
 1. **Forest-level compromise** of **one DC** (or Enterprise Admin), or `SYSTEM` access to one of the DCs in the forest.
 2. Ability to enumerate service accounts (LDAP read / RID brute-force).
-3. .NET ≥ 4.7.2 x64 workstation to run [`GoldenDMSA`](https://github.com/Semperis/GoldenDMSA) or equivalent code.
+3. .NET ≥ 4.7.2 x64 workstation to run [`GoldenDMSA`](https://github.com/Semperis/GoldenDMSA) or equivalent code.<sup>[[3]](#references)</sup>
 
 ### Golden gMSA / dMSA
 #### Phase 1 – Extract the KDS Root Key
@@ -68,7 +68,7 @@ Get-ADServiceAccount -Filter * -Properties msDS-ManagedPasswordId | \
 GoldenGMSA.exe gmsainfo
 ```
 
-[`GoldenDMSA`](https://github.com/Semperis/GoldenDMSA) implements helper modes:<sup>[[1]](#references)</sup>
+[`GoldenDMSA`](https://github.com/Semperis/GoldenDMSA) implements helper modes:<sup>[[1]](#references)[[3]](#references)</sup>
 
 ```bash
 # LDAP enumeration (kerberos / simple bind)

--- a/src/windows-hardening/active-directory-methodology/over-pass-the-hash-pass-the-key.md
+++ b/src/windows-hardening/active-directory-methodology/over-pass-the-hash-pass-the-key.md
@@ -51,7 +51,7 @@ An alternative command sequence using Rubeus.exe demonstrates another facet of t
 
 This method mirrors the **Pass the Key** approach, with a focus on commandeering and utilizing the ticket directly for authentication purposes. In practice:
 
-- `Rubeus asktgt` sends the **raw Kerberos AS-REQ/AS-REP** itself and does **not** need admin rights unless you want to target another logon session with `/luid` or create a separate one with `/createnetonly`.
+- `Rubeus asktgt` sends the **raw Kerberos AS-REQ/AS-REP** itself and does **not** need admin rights unless you want to target another logon session with `/luid` or create a separate one with `/createnetonly`.<sup>[[2]](#references)</sup>
 - `mimikatz sekurlsa::pth` patches credential material into a logon session and therefore **touches LSASS**, which usually requires local admin or `SYSTEM` and is noisier from an EDR perspective.
 
 Examples with Mimikatz:

--- a/src/windows-hardening/active-directory-methodology/printers-spooler-service-abuse.md
+++ b/src/windows-hardening/active-directory-methodology/printers-spooler-service-abuse.md
@@ -94,7 +94,7 @@ If an attacker has already compromised a computer with [Unconstrained Delegation
 
 ## RPC Force authentication
 
-[Coercer](https://github.com/p0dalirius/Coercer)
+[Coercer](https://github.com/p0dalirius/Coercer)<sup>[[5]](#references)</sup>
 
 ### RPC UNC-path coercion matrix (interfaces/opnums that trigger outbound auth)
 - MS-RPRN (Print System Remote Protocol)

--- a/src/windows-hardening/active-directory-methodology/privileged-groups-and-token-privileges.md
+++ b/src/windows-hardening/active-directory-methodology/privileged-groups-and-token-privileges.md
@@ -44,7 +44,7 @@ Get-ADObject -LDAPFilter '(adminCount=1)' -Properties adminCount,distinguishedNa
 
 A script is available to expedite the restoration process: [Invoke-ADSDPropagation.ps1](https://github.com/edemilliere/ADSI/blob/master/Invoke-ADSDPropagation.ps1).
 
-For more details, visit [ired.team](https://ired.team/offensive-security-experiments/active-directory-kerberos-abuse/how-to-abuse-and-backdoor-adminsdholder-to-obtain-domain-admin-persistence).
+For more details, visit [ired.team](https://ired.team/offensive-security-experiments/active-directory-kerberos-abuse/how-to-abuse-and-backdoor-adminsdholder-to-obtain-domain-admin-persistence).<sup>[[14]](#references)</sup>
 
 ## AD Recycle Bin
 

--- a/src/windows-hardening/active-directory-methodology/resource-based-constrained-delegation.md
+++ b/src/windows-hardening/active-directory-methodology/resource-based-constrained-delegation.md
@@ -14,7 +14,7 @@ Another important difference from this Constrained Delegation to the other deleg
 ### New Concepts
 
 Back in Constrained Delegation it was told that the **`TrustedToAuthForDelegation`** flag inside the _userAccountControl_ value of the user is needed to perform a **S4U2Self.** But that's not completely truth.\
-The reality is that even without that value, you can perform a **S4U2Self** against any user if you are a **service** (have a SPN) but, if you **have `TrustedToAuthForDelegation`** the returned TGS will be **Forwardable** and if you **don't have** that flag the returned TGS **won't** be **Forwardable**.
+The reality is that even without that value, you can perform a **S4U2Self** against any user if you are a **service** (have a SPN) but, if you **have `TrustedToAuthForDelegation`** the returned TGS will be **Forwardable** and if you **don't have** that flag the returned TGS **won't** be **Forwardable**.<sup>[[5]](#references)</sup>
 
 However, if the **TGS** used in **S4U2Proxy** is **NOT Forwardable** trying to abuse a **basic Constrain Delegation** it **won't work**. But if you are trying to exploit a **Resource-Based constrain delegation, it will work**.<sup>[[1]](#references)[[2]](#references)</sup>
 

--- a/src/windows-hardening/active-directory-methodology/sccm-management-point-relay-sql-policy-secrets.md
+++ b/src/windows-hardening/active-directory-methodology/sccm-management-point-relay-sql-policy-secrets.md
@@ -3,7 +3,7 @@
 {{#include ../../banners/hacktricks-training.md}}
 
 ## TL;DR
-By coercing a **System Center Configuration Manager (SCCM) Management Point (MP)** to authenticate over SMB/RPC and **relaying** that NTLM machine account to the **site database (MSSQL)** you obtain `smsdbrole_MP` / `smsdbrole_MPUserSvc` rights.  These roles let you call a set of stored procedures that expose **Operating System Deployment (OSD)** policy blobs (Network Access Account credentials, Task-Sequence variables, etc.).  The blobs are hex-encoded/encrypted but can be decoded and decrypted with **PXEthief**, yielding plaintext secrets.
+By coercing a **System Center Configuration Manager (SCCM) Management Point (MP)** to authenticate over SMB/RPC and **relaying** that NTLM machine account to the **site database (MSSQL)** you obtain `smsdbrole_MP` / `smsdbrole_MPUserSvc` rights.  These roles let you call a set of stored procedures that expose **Operating System Deployment (OSD)** policy blobs (Network Access Account credentials, Task-Sequence variables, etc.).  The blobs are hex-encoded/encrypted but can be decoded and decrypted with **PXEthief**, yielding plaintext secrets.<sup>[[2]](#references)</sup>
 
 High-level chain:
 1. Discover MP & site DB ↦ unauthenticated HTTP endpoint `/SMS_MP/.sms_aut?MPKEYINFORMATIONMEDIA`.

--- a/src/windows-hardening/active-directory-methodology/sid-history-injection.md
+++ b/src/windows-hardening/active-directory-methodology/sid-history-injection.md
@@ -27,7 +27,7 @@ According to the [**docs**](https://technet.microsoft.com/library/cc835085.aspx)
 - **Applying SID Filter Quarantining to external trusts** using the netdom tool (`netdom trust /domain: /quarantine:yes on the domain controller`)
 - **Applying SID Filtering to domain trusts within a single forest** is not recommended as it is an unsupported configuration and can cause breaking changes. If a domain within a forest is untrustworthy then it should not be a member of the forest. In this situation it is necessary to first split the trusted and untrusted domains into separate forests where SID Filtering can be applied to an interforest trust
 
-Check this post for more information about bypassing this: [**https://itm8.com/articles/sid-filter-as-security-boundary-between-domains-part-4**](https://itm8.com/articles/sid-filter-as-security-boundary-between-domains-part-4)
+Check this post for more information about bypassing this: [**https://itm8.com/articles/sid-filter-as-security-boundary-between-domains-part-4**](https://itm8.com/articles/sid-filter-as-security-boundary-between-domains-part-4)<sup>[[4]](#references)</sup>
 
 ### Diamond Ticket (Rubeus + KRBTGT-AES256)
 
@@ -159,6 +159,7 @@ raiseChild.py -target-exec 10.10.10.10 <child_domain>/username
 - [1] [Sneaky Active Directory Persistence #14: SID History - adsecurity.org](https://adsecurity.org/?p=1772)
 - [2] [What is Security Identifier (SID)? - SentinelOne](https://www.sentinelone.com/blog/windows-sid-history-injection-exposure-blog/)
 - [3] [Security Considerations for Trusts - Microsoft TechNet](https://technet.microsoft.com/library/cc835085.aspx)
+- [4] [itm8.com - Sid Filter As Security Boundary Between Domains Part 4](https://itm8.com/articles/sid-filter-as-security-boundary-between-domains-part-4)
 
 {{#include ../../banners/hacktricks-training.md}}
 

--- a/src/windows-hardening/active-directory-methodology/unconstrained-delegation.md
+++ b/src/windows-hardening/active-directory-methodology/unconstrained-delegation.md
@@ -33,7 +33,7 @@ Rubeus.exe monitor /interval:10 [/filteruser:<username>] #Check every 10s for ne
 ```
 
 Load the ticket of Administrator (or victim user) in memory with **Mimikatz** or **Rubeus for a** [**Pass the Ticket**](pass-the-ticket.md)**.**\
-More info: [https://www.harmj0y.net/blog/activedirectory/s4u2pwnage/](https://www.harmj0y.net/blog/activedirectory/s4u2pwnage/)\
+More info: [https://www.harmj0y.net/blog/activedirectory/s4u2pwnage/](https://www.harmj0y.net/blog/activedirectory/s4u2pwnage/)<sup>[[2]](#references)</sup>\
 [**More information about Unconstrained delegation in ired.team.**](https://ired.team/offensive-security-experiments/active-directory-kerberos-abuse/domain-compromise-via-unrestricted-kerberos-delegation)<sup>[[2]](#references)[[3]](#references)</sup>
 
 ### **Force Authentication**

--- a/src/windows-hardening/authentication-credentials-uac-and-efs.md
+++ b/src/windows-hardening/authentication-credentials-uac-and-efs.md
@@ -156,7 +156,7 @@ Microsoft developed **Group Managed Service Accounts (gMSA)** to simplify the ma
 
 The passwords for gMSAs are stored in the LDAP property _**msDS-ManagedPassword**_ and are automatically reset every 30 days by Domain Controllers (DCs). This password, an encrypted data blob known as [MSDS-MANAGEDPASSWORD_BLOB](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/a9019740-3d73-46ef-a9ae-3ea8eb86ac2e), can only be retrieved by authorized administrators and the servers on which the gMSAs are installed, ensuring a secure environment. To access this information, a secured connection such as LDAPS is required, or the connection must be authenticated with 'Sealing & Secure'.
 
-![https://cube0x0.github.io/Relaying-for-gMSA/](../images/asd1.png)
+![https://cube0x0.github.io/Relaying-for-gMSA/](../images/asd1.png)<sup>[[3]](#references)</sup>
 
 You can read this password with [**GMSAPasswordReader**](https://github.com/rvazarkar/GMSAPasswordReader)**:**
 
@@ -164,7 +164,7 @@ You can read this password with [**GMSAPasswordReader**](https://github.com/rvaz
 /GMSAPasswordReader --AccountName jkohler
 ```
 
-[**Find more info in this post**](https://cube0x0.github.io/Relaying-for-gMSA/)
+[**Find more info in this post**](https://cube0x0.github.io/Relaying-for-gMSA/)<sup>[[3]](#references)</sup>
 
 Also, check this [web page](https://cube0x0.github.io/Relaying-for-gMSA/) about how to perform a **NTLM relay attack** to **read** the **password** of **gMSA**.<sup>[[3]](#references)</sup>
 
@@ -235,7 +235,7 @@ Powershell -command "Write-Host 'My voice is my passport, verify me.'"
 $command = "Write-Host 'My voice is my passport, verify me.'" $bytes = [System.Text.Encoding]::Unicode.GetBytes($command) $encodedCommand = [Convert]::ToBase64String($bytes) powershell.exe -EncodedCommand $encodedCommand
 ```
 
-More can be found [here](https://blog.netspi.com/15-ways-to-bypass-the-powershell-execution-policy/)
+More can be found [here](https://blog.netspi.com/15-ways-to-bypass-the-powershell-execution-policy/)<sup>[[4]](#references)</sup>
 
 ## Security Support Provider Interface (SSPI)
 

--- a/src/windows-hardening/authentication-credentials-uac-and-efs/README.md
+++ b/src/windows-hardening/authentication-credentials-uac-and-efs/README.md
@@ -157,7 +157,7 @@ Microsoft developed **Group Managed Service Accounts (gMSA)** to simplify the ma
 
 The passwords for gMSAs are stored in the LDAP property _**msDS-ManagedPassword**_ and are automatically reset every 30 days by Domain Controllers (DCs). This password, an encrypted data blob known as [MSDS-MANAGEDPASSWORD_BLOB](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/a9019740-3d73-46ef-a9ae-3ea8eb86ac2e), can only be retrieved by authorized administrators and the servers on which the gMSAs are installed, ensuring a secure environment. To access this information, a secured connection such as LDAPS is required, or the connection must be authenticated with 'Sealing & Secure'.
 
-![https://cube0x0.github.io/Relaying-for-gMSA/](../../images/asd1.png)
+![https://cube0x0.github.io/Relaying-for-gMSA/](../../images/asd1.png)<sup>[[1]](#references)</sup>
 
 You can read this password with [**GMSAPasswordReader**](https://github.com/rvazarkar/GMSAPasswordReader)**:**<sup>[[2]](#references)</sup>
 
@@ -165,7 +165,7 @@ You can read this password with [**GMSAPasswordReader**](https://github.com/rvaz
 /GMSAPasswordReader --AccountName jkohler
 ```
 
-[**Find more info in this post**](https://cube0x0.github.io/Relaying-for-gMSA/)
+[**Find more info in this post**](https://cube0x0.github.io/Relaying-for-gMSA/)<sup>[[1]](#references)</sup>
 
 Also, check this [web page](https://cube0x0.github.io/Relaying-for-gMSA/) about how to perform a **NTLM relay attack** to **read** the **password** of **gMSA**.<sup>[[1]](#references)</sup>
 

--- a/src/windows-hardening/authentication-credentials-uac-and-efs/uac-user-account-control.md
+++ b/src/windows-hardening/authentication-credentials-uac-and-efs/uac-user-account-control.md
@@ -174,7 +174,7 @@ Documentation and tool in [https://github.com/wh0amitz/KRBUACBypass](https://git
 
 ### UAC bypass exploits
 
-[**UACME** ](https://github.com/hfiref0x/UACME)which is a **compilation** of several UAC bypass exploits. Note that you will need to **compile UACME using visual studio or msbuild**. The compilation will create several executables (like `Source\Akagi\outout\x64\Debug\Akagi.exe`) , you will need to know **which one you need.**\
+[**UACME** ](https://github.com/hfiref0x/UACME)which is a **compilation** of several UAC bypass exploits. Note that you will need to **compile UACME using visual studio or msbuild**. The compilation will create several executables (like `Source\Akagi\outout\x64\Debug\Akagi.exe`) , you will need to know **which one you need.**<sup>[[3]](#references)</sup>\
 You should **be careful** because some bypasses will **promtp some other programs** that will **alert** the **user** that something is happening.<sup>[[3]](#references)</sup>
 
 UACME has the **build version from which each technique started working**.<sup>[[3]](#references)</sup> You can search for a technique affecting your versions:

--- a/src/windows-hardening/basic-powershell-for-pentesters/README.md
+++ b/src/windows-hardening/basic-powershell-for-pentesters/README.md
@@ -191,7 +191,7 @@ https://slaeryan.github.io/posts/falcon-zero-alpha.html
 
 ### AMSI Bypass 2 - Managed API Call Hooking
 
-Check [**this post for detailed info and the code**](https://practicalsecurityanalytics.com/new-amsi-bypass-using-clr-hooking/). Introduction:
+Check [**this post for detailed info and the code**](https://practicalsecurityanalytics.com/new-amsi-bypass-using-clr-hooking/). Introduction:<sup>[[1]](#references)</sup>
 
 This new technique relies upon API call hooking of .NET methods. As it turns out, .NET Methods need to get compiled down to native machine instructions in memory which end up looking very similar to native methods. These compiled methods can hooked to change the control flow of a program.
 

--- a/src/windows-hardening/lateral-movement/dcomexec.md
+++ b/src/windows-hardening/lateral-movement/dcomexec.md
@@ -31,7 +31,7 @@ Distributed Component Object Model (DCOM) objects present an interesting capabil
 Get-CimInstance Win32_DCOMApplication
 ```
 
-The COM object, [MMC Application Class (MMC20.Application)](https://technet.microsoft.com/en-us/library/cc181199.aspx), enables scripting of MMC snap-in operations. Notably, this object contains a `ExecuteShellCommand` method under `Document.ActiveView`. More information about this method can be found [here](<https://msdn.microsoft.com/en-us/library/aa815396(v=vs.85).aspx>). Check it running:
+The COM object, [MMC Application Class (MMC20.Application)](https://technet.microsoft.com/en-us/library/cc181199.aspx), enables scripting of MMC snap-in operations. Notably, this object contains a `ExecuteShellCommand` method under `Document.ActiveView`. More information about this method can be found [here](<https://msdn.microsoft.com/en-us/library/aa815396(v=vs.85).aspx>). Check it running:<sup>[[6]](#references)</sup>
 
 This feature facilitates the execution of commands over a network through a DCOM application. To interact with DCOM remotely as an admin, PowerShell can be utilized as follows:
 
@@ -212,5 +212,6 @@ SharpMove.exe action=dcom computername=remote.host.local command="C:\windows\tem
 - [3] [KB5004442—Manage changes for Windows DCOM Server Security Feature Bypass (CVE-2021-26414)](https://support.microsoft.com/en-us/topic/kb5004442-manage-changes-for-windows-dcom-server-security-feature-bypass-cve-2021-26414-f1400b52-c141-43d2-941e-37ed901c769c)
 - [4] [Lateral Movement: Abuse the Power of DCOM Excel Application](https://specterops.io/blog/2023/10/30/lateral-movement-abuse-the-power-of-dcom-excel-application/)
 - [5] [Leveraging Excel DDE for lateral movement via DCOM](https://www.cybereason.com/blog/leveraging-excel-dde-for-lateral-movement-via-dcom)
+- [6] [technet.microsoft.com - MMC Application Class (MMC20.Application)](https://technet.microsoft.com/en-us/library/cc181199.aspx)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/windows-hardening/ntlm/README.md
+++ b/src/windows-hardening/ntlm/README.md
@@ -284,7 +284,7 @@ If NetNTLMv1 is not accepted—due to enforced security policies, then the attac
 
 To handle this case, the Internal Monologue tool was updated: It dynamically acquires a server token using `AcceptSecurityContext()` to still **capture NetNTLMv2 responses** if NetNTLMv1 fails. While NetNTLMv2 is much harder to crack, it still opens a path for relay attacks or offline brute-force in limited cases.
 
-The PoC can be found in **[https://github.com/eladshamir/Internal-Monologue](https://github.com/eladshamir/Internal-Monologue)**.
+The PoC can be found in **[https://github.com/eladshamir/Internal-Monologue](https://github.com/eladshamir/Internal-Monologue)**.<sup>[[4]](#references)</sup>
 
 ## NTLM Relay and Responder
 

--- a/src/windows-hardening/ntlm/places-to-steal-ntlm-creds.md
+++ b/src/windows-hardening/ntlm/places-to-steal-ntlm-creds.md
@@ -2,7 +2,7 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-**Check all the great ideas from [https://osandamalith.com/2017/03/24/places-of-interest-in-stealing-netntlm-hashes/](https://osandamalith.com/2017/03/24/places-of-interest-in-stealing-netntlm-hashes/) from the download of a microsoft word file online to the ntlm leaks source: https://github.com/soufianetahiri/TeamsNTLMLeak/blob/main/README.md and [https://github.com/p0dalirius/windows-coerced-authentication-methods](https://github.com/p0dalirius/windows-coerced-authentication-methods)**
+**Check all the great ideas from [https://osandamalith.com/2017/03/24/places-of-interest-in-stealing-netntlm-hashes/](https://osandamalith.com/2017/03/24/places-of-interest-in-stealing-netntlm-hashes/) from the download of a microsoft word file online to the ntlm leaks source: https://github.com/soufianetahiri/TeamsNTLMLeak/blob/main/README.md and [https://github.com/p0dalirius/windows-coerced-authentication-methods](https://github.com/p0dalirius/windows-coerced-authentication-methods)**<sup>[[12]](#references)[[13]](#references)[[14]](#references)</sup>
 
 ### Writable SMB share + Explorer-triggered UNC lures (ntlm_theft/SCF/LNK/library-ms/desktop.ini)
 
@@ -223,6 +223,9 @@ README.md
 - [9] [Rapid7 – When IT Support Calls: Dissecting a ModeloRAT Campaign from Teams to Domain Compromise](https://www.rapid7.com/blog/post/tr-it-support-dissecting-modelorat-campaign-microsoft-teams-compromise)
 - [10] [Microsoft Learn – davclnt.h header](https://learn.microsoft.com/en-us/windows/win32/api/davclnt/)
 - [11] [Splunk – Windows Rundll32 WebDAV Request](https://research.splunk.com/endpoint/320099b7-7eb1-4153-a2b4-decb53267de2/)
+- [12] [osandamalith.com - Places Of Interest In Stealing Netntlm Hashes](https://osandamalith.com/2017/03/24/places-of-interest-in-stealing-netntlm-hashes)
+- [13] [soufianetahiri/TeamsNTLMLeak](https://github.com/soufianetahiri/TeamsNTLMLeak/blob/main/README.md)
+- [14] [p0dalirius/windows-coerced-authentication-methods](https://github.com/p0dalirius/windows-coerced-authentication-methods)
 
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/windows-hardening/stealing-credentials/README.md
+++ b/src/windows-hardening/stealing-credentials/README.md
@@ -86,7 +86,7 @@ This process is done automatically with [SprayKatz](https://github.com/aas-n/spr
 A DLL named **comsvcs.dll** found in `C:\Windows\System32` is responsible for **dumping process memory** in the event of a crash. This DLL includes a **function** named **`MiniDumpW`**, designed to be invoked using `rundll32.exe`.\
 It is irrelevant to use the first two arguments, but the third one is divided into three components. The process ID to be dumped constitutes the first component, the dump file location represents the second, and the third component is strictly the word **full**. No alternative options exist.\
 Upon parsing these three components, the DLL is engaged in creating the dump file and transferring the specified process's memory into this file.\
-Utilization of the **comsvcs.dll** is feasible for dumping the lsass process, thereby eliminating the need to upload and execute procdump. This method is described in detail at [https://en.hackndo.com/remote-lsass-dump-passwords/](https://en.hackndo.com/remote-lsass-dump-passwords).
+Utilization of the **comsvcs.dll** is feasible for dumping the lsass process, thereby eliminating the need to upload and execute procdump. This method is described in detail at [https://en.hackndo.com/remote-lsass-dump-passwords/](https://en.hackndo.com/remote-lsass-dump-passwords).<sup>[[9]](#references)</sup>
 
 The following command is employed for execution:
 
@@ -506,5 +506,6 @@ This means **hardware binding prevents off-device export but not same-user use o
 - [6] [Microsoft – `NCryptCreatePersistedKey` / CNG key storage](https://learn.microsoft.com/en-us/windows/win32/api/ncrypt/nf-ncrypt-ncryptcreatepersistedkey)
 - [7] [0xWord – Hacking Windows: Ataques a Sistemas y Redes Microsoft](https://0xword.com/es/libros/99-hacking-windows-ataques-a-sistemas-y-redes-microsoft.html)
 - [8] [How the Active Directory Data Store Really Works: Inside NTDS.dit (Part 1)](http://blogs.chrisse.se/2012/02/11/how-the-active-directory-data-store-really-works-inside-ntds-dit-part-1/)
+- [9] [en.hackndo.com - Remote Lsass Dump Passwords](https://en.hackndo.com/remote-lsass-dump-passwords)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/windows-hardening/windows-local-privilege-escalation/README.md
+++ b/src/windows-hardening/windows-local-privilege-escalation/README.md
@@ -956,7 +956,7 @@ Detection ideas for defenders
 
 ## PATH DLL Hijacking
 
-If you have **write permissions inside a folder present on PATH** you could be able to hijack a DLL loaded by a process and **escalate privileges**.
+If you have **write permissions inside a folder present on PATH** you could be able to hijack a DLL loaded by a process and **escalate privileges**.<sup>[[2]](#references)</sup>
 
 Check permissions of all folders inside PATH:
 

--- a/src/windows-hardening/windows-local-privilege-escalation/README.md
+++ b/src/windows-hardening/windows-local-privilege-escalation/README.md
@@ -275,7 +275,7 @@ A **local privilege escalation** vulnerability exists in Windows **domain** envi
 
 Find the **exploit in** [**https://github.com/Dec0ne/KrbRelayUp**](https://github.com/Dec0ne/KrbRelayUp)
 
-For more information about the flow of the attack check [https://research.nccgroup.com/2019/08/20/kerberos-resource-based-constrained-delegation-when-an-image-change-leads-to-a-privilege-escalation/](https://research.nccgroup.com/2019/08/20/kerberos-resource-based-constrained-delegation-when-an-image-change-leads-to-a-privilege-escalation/)
+For more information about the flow of the attack check [https://research.nccgroup.com/2019/08/20/kerberos-resource-based-constrained-delegation-when-an-image-change-leads-to-a-privilege-escalation/](https://research.nccgroup.com/2019/08/20/kerberos-resource-based-constrained-delegation-when-an-image-change-leads-to-a-privilege-escalation/)<sup>[[36]](#references)</sup>
 
 ## AlwaysInstallElevated
 
@@ -1379,7 +1379,7 @@ reg query 'HKEY_CURRENT_USER\Software\OpenSSH\Agent\Keys'
 ```
 
 If you find any entry inside that path it will probably be a saved SSH key. It is stored encrypted but can be easily decrypted using [https://github.com/ropnop/windows_sshagent_extract](https://github.com/ropnop/windows_sshagent_extract).\
-More information about this technique here: [https://blog.ropnop.com/extracting-ssh-private-keys-from-windows-10-ssh-agent/](https://blog.ropnop.com/extracting-ssh-private-keys-from-windows-10-ssh-agent/)
+More information about this technique here: [https://blog.ropnop.com/extracting-ssh-private-keys-from-windows-10-ssh-agent/](https://blog.ropnop.com/extracting-ssh-private-keys-from-windows-10-ssh-agent/)<sup>[[37]](#references)</sup>
 
 If `ssh-agent` service is not running and you want it to automatically start on boot run:
 
@@ -2193,5 +2193,7 @@ C:\Windows\microsoft.net\framework\v4.0.30319\MSBuild.exe -version #Compile the 
 - [33] [GoSecure – WSUS Attacks Part 2: CVE-2020-1013, a Windows 10 Local Privilege Escalation 1-Day](https://www.gosecure.net/blog/2020/09/08/wsus-attacks-part-2-cve-2020-1013-a-windows-10-local-privilege-escalation-1-day/)
 - [34] [Windows 7: Exploring Credential Manager and Windows Vault](https://www.neowin.net/news/windows-7-exploring-credential-manager-and-windows-vault)
 - [35] [jas502n - CVE-2019-1388 PoC](https://github.com/jas502n/CVE-2019-1388)
+- [36] [research.nccgroup.com - Kerberos Resource Based Constrained Delegation When An Image Change Leads To A Privilege Escalation](https://research.nccgroup.com/2019/08/20/kerberos-resource-based-constrained-delegation-when-an-image-change-leads-to-a-privilege-escalation)
+- [37] [blog.ropnop.com - Extracting Ssh Private Keys From Windows 10 Ssh Agent](https://blog.ropnop.com/extracting-ssh-private-keys-from-windows-10-ssh-agent)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/windows-hardening/windows-local-privilege-escalation/abusing-auto-updaters-and-ipc.md
+++ b/src/windows-hardening/windows-local-privilege-escalation/abusing-auto-updaters-and-ipc.md
@@ -256,7 +256,7 @@ Razer Synapse 4 added another useful pattern to this family: a low-privileged us
 Observed exploitation path:
 - Instantiate the COM object `RzUtility.Elevator`.
 - Call `LaunchProcessNoWait(<path>, "", 1)` to request an elevated launch.
-- In the public PoC, the PE-signature gate inside `simple_service.dll` is patched out before issuing the request, allowing an arbitrary attacker-chosen executable to be launched.<sup>[[6]](#references)</sup>
+- In the public PoC, the PE-signature gate inside `simple_service.dll` is patched out before issuing the request, allowing an arbitrary attacker-chosen executable to be launched.<sup>[[6]](#references)[[10]](#references)</sup>
 
 Minimal PowerShell invocation:
 

--- a/src/windows-hardening/windows-local-privilege-escalation/dpapi-extracting-passwords.md
+++ b/src/windows-hardening/windows-local-privilege-escalation/dpapi-extracting-passwords.md
@@ -164,7 +164,7 @@ Get-ChildItem -Hidden C:\Users\username\AppData\Local\Microsoft\Credentials\
 Get-ChildItem -Hidden C:\Users\username\AppData\Roaming\Microsoft\Credentials\
 ```
 
-[**SharpDPAPI**](https://github.com/GhostPack/SharpDPAPI) can find DPAPI encrypted blobs in the file system, registry and B64 blobs:
+[**SharpDPAPI**](https://github.com/GhostPack/SharpDPAPI) can find DPAPI encrypted blobs in the file system, registry and B64 blobs:<sup>[[12]](#references)</sup>
 
 ```bash
 # Search blobs in the registry
@@ -181,7 +181,7 @@ search /type:file /path:C:\path\to\file
 search /type:base64 [/base:<base64 string>]
 ```
 
-Note that [**SharpChrome**](https://github.com/GhostPack/SharpDPAPI) (from the same repo) can be used to decrypt using DPAPI sensitive data like cookies.
+Note that [**SharpChrome**](https://github.com/GhostPack/SharpDPAPI) (from the same repo) can be used to decrypt using DPAPI sensitive data like cookies.<sup>[[12]](#references)</sup>
 
 #### Chromium/Edge/Electron quick recipes (SharpChrome)
 

--- a/src/windows-hardening/windows-local-privilege-escalation/leaked-handle-exploitation.md
+++ b/src/windows-hardening/windows-local-privilege-escalation/leaked-handle-exploitation.md
@@ -676,11 +676,11 @@ int main(int argc, char **argv) {
 
 ## Other tools and examples
 
-- [**https://github.com/lab52io/LeakedHandlesFinder**](https://github.com/lab52io/LeakedHandlesFinder)
+- [**https://github.com/lab52io/LeakedHandlesFinder**](https://github.com/lab52io/LeakedHandlesFinder)<sup>[[2]](#references)</sup>
 
 This tool allows you to monitor leaked handles to find vulnerable ones and even auto-exploit them. It also has a tool to leak one.<sup>[[2]](#references)</sup>
 
-- [**https://github.com/abankalarm/ReHacks/tree/main/Leaky%20Handles**](https://github.com/abankalarm/ReHacks/tree/main/Leaky%20Handles)
+- [**https://github.com/abankalarm/ReHacks/tree/main/Leaky%20Handles**](https://github.com/abankalarm/ReHacks/tree/main/Leaky%20Handles)<sup>[[4]](#references)</sup>
 
 Another tool to leak a handle and exploit it.<sup>[[4]](#references)</sup>
 

--- a/src/windows-hardening/windows-local-privilege-escalation/seimpersonate-from-high-to-system.md
+++ b/src/windows-hardening/windows-local-privilege-escalation/seimpersonate-from-high-to-system.md
@@ -56,7 +56,7 @@ You can inspect candidate processes and their token/ACLs with **Process Explorer
 
 ### Code
 
-The following code from [here](https://medium.com/@seemant.bisht24/understanding-and-abusing-access-tokens-part-ii-b9069f432962). It allows to **indicate a Process ID as argument** and a CMD **running as the user** of the indicated process will be run.\
+The following code from [here](https://medium.com/@seemant.bisht24/understanding-and-abusing-access-tokens-part-ii-b9069f432962). It allows to **indicate a Process ID as argument** and a CMD **running as the user** of the indicated process will be run.<sup>[[3]](#references)</sup>\
 Running in a High Integrity process you can **indicate the PID of a process running as System** (like `winlogon`, `wininit`) and execute a `cmd.exe` as SYSTEM.<sup>[[3]](#references)</sup>
 
 ```cpp


### PR DESCRIPTION
Completes the external-URL pass for the pages that no other open references PR touches.

- Adds the missing superscript on lines whose source **already had** a References entry.
- Adds numbered entries for content sources (writeups, advisories, research posts) that were only linked inline, and cites them on the line that uses them.
- Tool, download and product links are deliberately left inline, uncited.

No existing reference entry was removed and no existing number was changed, so citations elsewhere on these pages are unaffected.