### PR TITLE
Preserve technical fidelity in reference audit edits

### DIFF
--- a/src/macos-hardening/macos-auto-start-locations.md
+++ b/src/macos-hardening/macos-auto-start-locations.md
@@ -1004,7 +1004,7 @@ Writeup: [https://theevilbit.github.io/beyond/beyond_0017](https://theevilbit.gi
 
 **Compile a color picker** bundle with your code (you could use [**this one for example**](https://github.com/viktorstrate/color-picker-plus)) and add a constructor (like in the [Screen Saver section](macos-auto-start-locations.md#screen-saver)) and copy the bundle to `~/Library/ColorPickers`.<sup>[[20]](#references)</sup>
 
-Then, when the color picker is triggered your should should be as well.
+Then, when the color picker is triggered, your bundle should execute as well.
 
 Note that the binary loading your library has a **very restrictive sandbox**: `/System/Library/Frameworks/AppKit.framework/Versions/C/XPCServices/LegacyExternalColorPickerService-x86_64.xpc/Contents/MacOS/LegacyExternalColorPickerService-x86_64`
 

--- a/src/macos-hardening/macos-security-and-privilege-escalation/macos-proces-abuse/macos-ipc-inter-process-communication/macos-xpc/README.md
+++ b/src/macos-hardening/macos-security-and-privilege-escalation/macos-proces-abuse/macos-ipc-inter-process-communication/macos-xpc/README.md
@@ -26,7 +26,7 @@ XPC services are **started** by **launchd** when required and can be **shut down
 
 ## System-Wide XPC Services
 
-System-wide XPC services are accessible outside a single application. These launchd-managed Mach services need to be **defined in plist** files located in directories such as **`/System/Library/LaunchDaemons`**, **`/Library/LaunchDaemons`**, **`/System/Library/LaunchAgents`**, or **`/Library/LaunchAgents`**.<sup>[[3]](#references)</sup>
+Unlike application-specific services, system-wide XPC services are not restricted to their containing application. They may be reachable by clients from multiple users, depending on the launchd domain and the service's own authorization checks. These launchd-managed Mach services need to be **defined in plist** files located in directories such as **`/System/Library/LaunchDaemons`**, **`/Library/LaunchDaemons`**, **`/System/Library/LaunchAgents`**, or **`/Library/LaunchAgents`**.<sup>[[2]](#references)[[3]](#references)</sup>
 
 These plist files have a **`MachServices`** key containing the service name and a **`Program`** key containing the path to the binary:
 

--- a/src/macos-hardening/macos-security-and-privilege-escalation/macos-proces-abuse/macos-library-injection/README.md
+++ b/src/macos-hardening/macos-security-and-privilege-escalation/macos-proces-abuse/macos-library-injection/README.md
@@ -57,8 +57,8 @@ macos-dyld-hijacking-and-dyld_insert_libraries.md
 > [!CAUTION]
 > Remember that **previous Library Validation restrictions also apply** to perform Dylib hijacking attacks.
 
-As in Windows, in MacOS you can also **hijack dylibs** to make **applications** **execute** **arbitrary** **code** (well, actually froma regular user this could not be possible as you might need a TCC permission towrite inside an `.app` bundle and hijack a library).\
-However, the way **MacOS** applications **load** libraries is **more restricted** than in Windows. This implies that **malware** developers can still use this technique for **stealth**, but the probably to be able to **abuse this to escalate privileges is much lower**.
+As on Windows, on macOS you can **hijack dylibs** to make **applications execute arbitrary code**. From a regular user account this may not be possible, because writing inside an `.app` bundle to hijack a library can require a TCC permission.\
+However, the way **macOS** applications **load** libraries is **more restricted** than on Windows. Malware developers can still use this technique for **stealth**, but abusing it to escalate privileges is much less likely.
 
 First of all, is **more common** to find that **MacOS binaries indicates the full path** to the libraries to load. And second, **MacOS never search** in the folders of the **$PATH** for libraries.
 

--- a/src/macos-hardening/macos-security-and-privilege-escalation/macos-proces-abuse/macos-library-injection/macos-dyld-process.md
+++ b/src/macos-hardening/macos-security-and-privilege-escalation/macos-proces-abuse/macos-library-injection/macos-dyld-process.md
@@ -227,7 +227,7 @@ Check how is each library loaded:
 
 ```
 DYLD_PRINT_SEGMENTS=1 ./apple
-dyld[21147]: reusing existing shared cache (/System/Volumes/Preboot/Cryptexes/OS/System/Library/dyld/dyld_shared_cache_arm64e):
+dyld[21147]: re-using existing shared cache (/System/Volumes/Preboot/Cryptexes/OS/System/Library/dyld/dyld_shared_cache_arm64e):
 dyld[21147]:         0x181944000->0x1D5D4BFFF init=5, max=5 __TEXT
 dyld[21147]:         0x1D5D4C000->0x1D5EC3FFF init=1, max=3 __DATA_CONST
 dyld[21147]:         0x1D7EC4000->0x1D8E23FFF init=3, max=3 __DATA
@@ -273,10 +273,10 @@ dyld[21623]: running initializer 0x18e59e5c0 in /usr/lib/libSystem.B.dylib
 ### Others
 
 - `DYLD_BIND_AT_LAUNCH`: Lazy bindings are resolved with non lazy ones
-- `DYLD_DISABLE_PREFETCH`: DIsable pre-fetching of \_\_DATA and \_\_LINKEDIT content
+- `DYLD_DISABLE_PREFETCH`: Disable pre-fetching of \_\_DATA and \_\_LINKEDIT content
 - `DYLD_FORCE_FLAT_NAMESPACE`: Single-level bindings
 - `DYLD_[FRAMEWORK/LIBRARY]_PATH | DYLD_FALLBACK_[FRAMEWORK/LIBRARY]_PATH | DYLD_VERSIONED_[FRAMEWORK/LIBRARY]_PATH`: Resolution paths
-- `DYLD_INSERT_LIBRARIES`: Load an specific library
+- `DYLD_INSERT_LIBRARIES`: Load a specific library
 - `DYLD_PRINT_TO_FILE`: Write dyld debug in a file
 - `DYLD_PRINT_APIS`: Print libdyld API calls
 - `DYLD_PRINT_APIS_APP`: Print libdyld API calls made by main

--- a/src/macos-hardening/macos-security-and-privilege-escalation/macos-security-protections/macos-dangerous-entitlements.md
+++ b/src/macos-hardening/macos-security-and-privilege-escalation/macos-security-protections/macos-dangerous-entitlements.md
@@ -82,9 +82,9 @@ This entitlement allows to **use DYLD environment variables** that could be used
 
 [**According to this blog**](https://objective-see.org/blog/blog_0x4C.html) **and** [**this blog**](https://wojciechregula.blog/post/play-the-music-and-bypass-tcc-aka-cve-2020-29621/), these entitlements allow a process to **modify** the **TCC** database.<sup>[[6]](#references)[[7]](#references)</sup>
 
-### **`system.install.apple-software`** and **`system.install.apple-software.standar-user`**
+### Authorization rights **`system.install.apple-software`** and **`system.install.apple-software.standard-user`**
 
-These entitlements allow a process to **install software without asking the user for permission**, which can be helpful for **privilege escalation**.
+These Authorization Services rights govern the installation of Apple-provided software. A process entitled to obtain them may bypass the usual authorization flow, which can be helpful for **privilege escalation**.<sup>[[14]](#references)</sup>
 
 ### `com.apple.private.security.kext-management`
 
@@ -313,5 +313,6 @@ For detailed IOKit/DriverKit exploitation, see:
 - [11] [Apple Developer — Allow Unsigned Executable Memory Entitlement](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_cs_allow-unsigned-executable-memory)
 - [12] [Apple Developer — Disable Executable Memory Protection Entitlement](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_cs_disable-executable-page-protection)
 - [13] [Apple Developer — Entitlements](https://developer.apple.com/documentation/bundleresources/entitlements)
+- [14] [Apple Developer Archive — Authorization Services Programming Guide](https://developer.apple.com/library/archive/documentation/Security/Conceptual/authorization_concepts/01introduction/introduction.html)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/macos-hardening/macos-security-and-privilege-escalation/macos-security-protections/macos-fs-tricks/README.md
+++ b/src/macos-hardening/macos-security-and-privilege-escalation/macos-security-protections/macos-fs-tricks/README.md
@@ -505,7 +505,7 @@ int main() {
 
 This feature is particularly useful for preventing certain classes of security vulnerabilities such as **unauthorized file access** or **race conditions**. These vulnerabilities occurs when for example a thread is accessing a file description giving **another vulnerable thread access over it** or when a file descriptor is **inherited** by a vulnerable child process. Some functions related to this functionality are:
 
-- `guarded_open_np`: Opened a FD with a guard
+- `guarded_open_np`: Opens a file descriptor with a guard
 - `guarded_close_np`: Close it
 - `change_fdguard_np`: Change guard flags on a descriptor (even removing the guard protection)
 

--- a/src/macos-hardening/macos-security-and-privilege-escalation/macos-security-protections/macos-sandbox/README.md
+++ b/src/macos-hardening/macos-security-and-privilege-escalation/macos-security-protections/macos-sandbox/README.md
@@ -112,7 +112,7 @@ AAAhAboBAAAAAAgAAABZAO4B5AHjBMkEQAUPBSsGPwsgASABHgEgASABHwEf...
 ```
 
 > [!WARNING]
-> Everything created/modified by a Sandboxed application will get the **quarantine attribute**e. This will prevent a sandbox space by triggering Gatekeeper if the sandbox app tries to execute something with **`open`**.
+> Everything created or modified by a sandboxed application gets the **quarantine attribute**. This can prevent a sandbox escape by triggering Gatekeeper if the sandboxed application tries to execute something with **`open`**.
 
 ## Sandbox Profiles
 

--- a/src/macos-hardening/macos-security-and-privilege-escalation/macos-security-protections/macos-sandbox/macos-sandbox-debug-and-bypass/README.md
+++ b/src/macos-hardening/macos-security-and-privilege-escalation/macos-security-protections/macos-sandbox/macos-sandbox-debug-and-bypass/README.md
@@ -10,8 +10,8 @@ In the previous image it's possible to observe **how the sandbox will be loaded*
 
 The compiler will link `/usr/lib/libSystem.B.dylib` to the binary.
 
-Then, **`libSystem.B`** will be calling other several functions until the **`xpc_pipe_routine`** sends the entitlements of the app to **`securityd`**. Securityd checks if the process should be quarantine inside the Sandbox, and if so, it will be quarantine.\
-Finally, the sandbox will be activated will a call to **`__sandbox_ms`** which will call **`__mac_syscall`**.<sup>[[1]](#references)[[3]](#references)</sup>
+Then, **`libSystem.B`** calls several functions until **`xpc_pipe_routine`** sends the application's entitlements to **`securityd`**. Securityd checks whether the process should be quarantined inside the sandbox and, if so, quarantines it.\
+Finally, the sandbox is activated with a call to **`__sandbox_ms`**, which calls **`__mac_syscall`**.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ## Possible Bypasses
 
@@ -513,4 +513,3 @@ Process 2517 exited with status = 0 (0x00000000)
 - [6] [Vicarius vSociety - CVE-2023-26818 (Sandbox): macOS TCC Bypass w/ Telegram using DyLib Injection (Part 2)](https://www.vicarius.io/vsociety/posts/cve-2023-26818-sandbox-macos-tcc-bypass-w-telegram-using-dylib-injection-part-2-3?q=CVE-2023-26818)
 
 {{#include ../../../../../banners/hacktricks-training.md}}
-

--- a/src/macos-hardening/macos-security-and-privilege-escalation/macos-security-protections/macos-tcc/macos-tcc-bypasses/README.md
+++ b/src/macos-hardening/macos-security-and-privilege-escalation/macos-security-protections/macos-tcc/macos-tcc-bypasses/README.md
@@ -263,7 +263,7 @@ Plugins are extra code usually in the form of libraries or plist, that will be *
 
 The application `/System/Library/CoreServices/Applications/Directory Utility.app` had the entitlement **`kTCCServiceSystemPolicySysAdminFiles`**, loaded plugins with **`.daplug`** extension and **didn't have the hardened** runtime.
 
-In order to weaponize this CVE, the **`NFSHomeDirectory`** is **changed** (abusing the previous entitlement) in order to be able to **take over the users TCC database**e to bypass TCC.
+To weaponize this CVE, the **`NFSHomeDirectory`** is **changed** (abusing the previous entitlement) to **take over the user's TCC database** and bypass TCC.
 
 For more info check the [**original report**](https://wojciechregula.blog/post/change-home-directory-and-bypass-tcc-aka-cve-2020-27937/).<sup>[[12]](#references)</sup>
 


### PR DESCRIPTION
Second full preservation pass over the 50-page reference batch. Restores literal runtime output, preserves system-wide XPC reachability context, corrects exact Authorization Services identifiers/classification, and fixes malformed prose introduced or left in edited lines without removing technical content.