### PR TITLE
Audit 50 Windows reference pages

### DIFF
--- a/src/windows-hardening/active-directory-methodology/README.md
+++ b/src/windows-hardening/active-directory-methodology/README.md
@@ -37,14 +37,14 @@ To learn how to **attack an AD** you need to **understand** really good the **Ke
 You can take a lot to [https://wadcoms.github.io/](https://wadcoms.github.io) to have a quick view of which commands you can run to enumerate/exploit an AD.
 
 > [!WARNING]
-> Kerberos communication **requires a full qualifid name (FQDN)** for performing actions. If you try to access a machine by the IP address, **it'll use NTLM and not kerberos**.
+> Kerberos communication normally **requires a fully qualified domain name (FQDN)** so that the client can obtain a ticket for the correct SPN. Accessing a machine by IP address commonly falls back to NTLM instead of Kerberos.
 
 ## Recon Active Directory (No creds/sessions)
 
 If you just have access to an AD environment but you don't have any credentials/sessions you could:
 
 - **Pentest the network:**
-  - Scan the network, find machines and open ports and try to **exploit vulnerabilities** or **extract credentials** from them (for example, [printers could be very interesting targets](ad-information-in-printers.md).
+  - Scan the network, find machines and open ports, and try to **exploit vulnerabilities** or **extract credentials** from them (for example, [printers can be very interesting targets](ad-information-in-printers.md)).
   - Enumerating DNS could give information about key servers in the domain as web, printers, shares, vpn, media, etc.
     - `gobuster dns -d domain.local -t 25 -w /opt/Seclist/Discovery/DNS/subdomain-top2000.txt`
   - Take a look to the General [**Pentesting Methodology**](../../generic-methodologies-and-resources/pentesting-methodology.md) to find more information about how to do this.
@@ -182,7 +182,7 @@ You might be able to **obtain** some challenge **hashes** to crack **poisoning**
 
 ### NTLM Relay
 
-If you have managed to enumerate the active directory you will have **more emails and a better understanding of the network**. You might be able to to force NTLM [**relay attacks**](../../generic-methodologies-and-resources/pentesting-network/spoofing-llmnr-nbt-ns-mdns-dns-and-wpad-and-relay-attacks.md#relay-attack)  to get access to the AD env.
+Active Directory enumeration provides candidate accounts, hosts, and services that may be coerced into authenticating. Use that context to identify viable NTLM [**relay attacks**](../../generic-methodologies-and-resources/pentesting-network/spoofing-llmnr-nbt-ns-mdns-dns-and-wpad-and-relay-attacks.md#relay-attack) and potential paths into the AD environment.
 
 ### NetExec workspace-driven recon & relay posture checks
 
@@ -319,7 +319,7 @@ The exact same workflow applies to NetNTLM challenge-responses (`-m 27000/27100`
 
 For this phase you need to have **compromised the credentials or a session of a valid domain account.** If you have some valid credentials or a shell as a domain user, **you should remember that the options given before are still options to compromise other users**.
 
-Before start the authenticated enumeration you should know what is the **Kerberos double hop problem.**
+Before starting authenticated enumeration, understand the **Kerberos double-hop problem**.
 
 
 {{#ref}}
@@ -328,7 +328,7 @@ kerberos-double-hop-problem.md
 
 ### Enumeration
 
-Having compromised an account is a **big step to start compromising the whole domain**, because you are going to be able to start the **Active Directory Enumeration:**
+Compromising an account is a **major step toward assessing the domain**, because it enables authenticated **Active Directory enumeration**:
 
 Regarding [**ASREPRoast**](asreproast.md) you can now find every possible vulnerable user, and regarding [**Password Spraying**](password-spraying.md) you can get a **list of all the usernames** and try the password of the compromised account, empty passwords and new promising passwords.
 
@@ -361,13 +361,13 @@ More about this in:
 kerberoast.md
 {{#endref}}
 
-### Remote connexion (RDP, SSH, FTP, Win-RM, etc)
+### Remote connection (RDP, SSH, FTP, Win-RM, etc.)
 
 Once you have obtained some credentials you could check if you have access to any **machine**. For that matter, you could use **CrackMapExec** to attempt connecting on several servers with different protocols, accordingly to your ports scans.
 
 ### Local Privilege Escalation
 
-If you have compromised credentials or a session as a regular domain user and you have **access** with this user to **any machine in the domain** you should try to find your way to **escalate privileges locally and looting for credentials**. This is because only with local administrator privileges you will be able to **dump hashes of other users** in memory (LSASS) and locally (SAM).
+If you have compromised credentials or a session as a regular domain user and can access **any machine in the domain**, look for a path to **escalate privileges locally and collect credentials**. Local administrator privileges may allow you to **dump other users' hashes** from memory (LSASS) and local storage (SAM).
 
 There is a complete page in this book about [**local privilege escalation in Windows**](../windows-local-privilege-escalation/index.html) and a [**checklist**](../checklist-windows-privilege-escalation.md). Also, don't forget to use [**WinPEAS**](https://github.com/carlospolop/privilege-escalation-awesome-scripts-suite).
 
@@ -385,7 +385,7 @@ It's very **unlikely** that you will find **tickets** in the current user **givi
 
 ### NTLM Relay
 
-If you have managed to enumerate the active directory you will have **more emails and a better understanding of the network**. You might be able to to force NTLM [**relay attacks**](../../generic-methodologies-and-resources/pentesting-network/spoofing-llmnr-nbt-ns-mdns-dns-and-wpad-and-relay-attacks.md#relay-attack)**.**
+With domain credentials or a user session, revisit NTLM [**relay attacks**](../../generic-methodologies-and-resources/pentesting-network/spoofing-llmnr-nbt-ns-mdns-dns-and-wpad-and-relay-attacks.md#relay-attack): authenticated enumeration and coercion techniques can expose relay paths that were unavailable during unauthenticated reconnaissance.
 
 ### Looks for Creds in Computer Shares | SMB Shares
 
@@ -461,7 +461,7 @@ crackmapexec smb --local-auth 10.10.10.10/23 -u administrator -H 10298e182387f9c
 ### MSSQL Abuse & Trusted Links
 
 If a user has privileges to **access MSSQL instances**, he could be able to use it to **execute commands** in the MSSQL host (if running as SA), **steal** the NetNTLM **hash** or even perform a **relay** **attack**.\
-Also, if a MSSQL instance is trusted (database link) by a different MSSQL instance. If the user has privileges over the trusted database, he is going to be able to **use the trust relationship to execute queries also in the other instance**. These trusts can be chained and at some point the user might be able to find a misconfigured database where he can execute commands.\
+If an MSSQL instance is trusted through a database link by another instance, a user with privileges over the linked database may be able to **use the trust relationship to execute queries on the other instance**. These trusts can be chained and may eventually reach a misconfigured database where the user can execute commands.\
 **The links between databases work even across forest trusts.**
 
 
@@ -796,7 +796,7 @@ Get-DomainForeignGroupMember
 ### Child-to-Parent forest privilege escalation
 
 ```bash
-# Fro powerview
+# From PowerView
 Get-DomainTrust
 
 SourceName      : sub.domain.local    --> current domain

--- a/src/windows-hardening/active-directory-methodology/abusing-ad-mssql.md
+++ b/src/windows-hardening/active-directory-methodology/abusing-ad-mssql.md
@@ -7,7 +7,7 @@
 
 ### Python
 
-The [MSSQLPwner](https://github.com/ScorpionesLabs/MSSqlPwner) tool is based on impacket, and allows also authenticate using kerberos tickets, and attack through link chains
+The [MSSQLPwner](https://github.com/ScorpionesLabs/MSSqlPwner) tool is based on Impacket. It supports authentication with Kerberos tickets and attacks through linked-server chains.<sup>[[1]](#references)</sup>
 
 <figure><img src="https://raw.githubusercontent.com/ScorpionesLabs/MSSqlPwner/main/assets/interractive.png"></figure>
   
@@ -89,16 +89,16 @@ mssqlpwner hosts.txt brute -ul users.txt -hl hashes.txt
 
 mssqlpwner corp.com/user:lab@192.168.1.65 -windows-auth interactive
 
-````
+```
 
 ---
-###  Powershell
+### PowerShell
 
-The powershell module [PowerUpSQL](https://github.com/NetSPI/PowerUpSQL) is very useful in this case.
+The PowerShell module [PowerUpSQL](https://github.com/NetSPI/PowerUpSQL) provides discovery, auditing, and exploitation functions for SQL Server environments.<sup>[[2]](#references)</sup>
 
 ```bash
 Import-Module .\PowerupSQL.psd1
-````
+```
 
 ### Enumerating from the network without domain session
 
@@ -107,7 +107,7 @@ Import-Module .\PowerupSQL.psd1
 Get-SQLInstanceLocal
 Get-SQLInstanceLocal | Get-SQLServerInfo
 
-#If you don't have a AD account, you can try to find MSSQL scanning via UDP
+#If you don't have an AD account, you can try to find MSSQL instances by scanning via UDP
 #First, you will need a list of hosts to scan
 Get-Content c:\temp\computers.txt | Get-SQLInstanceScanUDP –Verbose –Threads 10
 
@@ -136,10 +136,10 @@ Get-SQLServerDefaultLoginPw
 #Test connections with each one
 Get-SQLInstanceDomain | Get-SQLConnectionTestThreaded -verbose
 
-#Try to connect and obtain info from each MSSQL server (also useful to check conectivity)
+#Try to connect and obtain info from each MSSQL server (also useful to check connectivity)
 Get-SQLInstanceDomain | Get-SQLServerInfo -Verbose
 
-# Get DBs, test connections and get info in oneliner
+# Get DBs, test connections and get info in one line
 Get-SQLInstanceDomain | Get-SQLConnectionTest | ? { $_.Status -eq "Accessible" } | Get-SQLServerInfo
 ```
 
@@ -157,13 +157,13 @@ Get-SQLInstanceDomain | Get-SQLTable -DatabaseName DBName
 # List columns in a table
 Get-SQLInstanceDomain | Get-SQLColumn -DatabaseName DBName -TableName TableName
 
-# Get some sample data from a column in a table (columns username & passwor din the example)
-Get-SQLInstanceDomain | GetSQLColumnSampleData -Keywords "username,password" -Verbose -SampleSize 10
+# Get some sample data from a column in a table (columns username & password in the example)
+Get-SQLInstanceDomain | Get-SQLColumnSampleData -Keywords "username,password" -Verbose -SampleSize 10
 
 #Perform a SQL query
 Get-SQLQuery -Instance "sql.domain.io,1433" -Query "select @@servername"
 
-#Dump an instance (a lot of CVSs generated in current dir)
+#Dump an instance (a lot of CSVs are generated in the current directory)
 Invoke-SQLDumpInfo -Verbose -Instance "dcorp-mssql"
 
 # Search keywords in columns trying to access the MSSQL DBs
@@ -173,7 +173,7 @@ Get-SQLInstanceDomain | Get-SQLConnectionTest | ? { $_.Status -eq "Accessible" }
 
 ### MSSQL RCE
 
-It might be also possible to **execute commands** inside the MSSQL host
+It may also be possible to **execute commands** on the MSSQL host through `xp_cmdshell`.<sup>[[5]](#references)</sup>
 
 ```bash
 Invoke-SQLOSCmd -Instance "srv.sub.domain.local,1433" -Command "whoami" -RawResults
@@ -191,15 +191,15 @@ Check in the page mentioned in the **following section how to do this manually.*
 
 ## MSSQL Trusted Links
 
-If a MSSQL instance is trusted (database link) by a different MSSQL instance. If the user has privileges over the trusted database, he is going to be able to **use the trust relationship to execute queries also in the other instance**. This trusts can be chained and at some point the user might be able to find some misconfigured database where he can execute commands.
+If one MSSQL instance trusts another through a linked-server configuration, a user with sufficient permissions can **use that trust relationship to execute queries on the other instance**. These links can be chained, potentially reaching a misconfigured server on which the user can execute commands.<sup>[[3]](#references)</sup>
 
 **The links between databases work even across forest trusts.**
 
 ### Powershell Abuse
 
 ```bash
-#Look for MSSQL links of an accessible instance
-Get-SQLServerLink -Instance dcorp-mssql -Verbose #Check for DatabaseLinkd > 0
+#Look for MSSQL links from an accessible instance
+Get-SQLServerLink -Instance dcorp-mssql -Verbose #Check for DatabaseLinkId > 0
 
 #Crawl trusted links, starting from the given one (the user being used by the MSSQL instance is also specified)
 Get-SQLServerLinkCrawl -Instance mssql-srv.domain.local -Verbose
@@ -219,7 +219,7 @@ Invoke-SQLAudit -Verbose -Instance "dcorp-mssql.dollarcorp.moneycorp.local"
 #Try to escalate privileges on an instance
 Invoke-SQLEscalatePriv –Verbose –Instance "SQLServer1\Instance1"
 
-#Manual trusted link queery
+#Manual trusted-link query
 Get-SQLQuery -Instance "sql.domain.io,1433" -Query "select * from openquery(""sql2.domain.io"", 'select * from information_schema.tables')"
 ## Enable xp_cmdshell and check it
 Get-SQLQuery -Instance "sql.domain.io,1433" -Query 'SELECT * FROM OPENQUERY("sql2.domain.io", ''SELECT * FROM sys.configurations WHERE name = ''''xp_cmdshell'''''');'
@@ -229,7 +229,7 @@ Get-SQLQuery -Instance "sql.domain.io,1433" -Query 'EXEC(''sp_configure ''''xp_c
 Get-SQLQuery -Instance "sql.rto.local,1433" -Query 'SELECT * FROM OPENQUERY("sql.rto.external", ''select @@servername; exec xp_cmdshell ''''powershell whoami'''''');'
 ```
 
-Another similar tool taht could be used is [**https://github.com/lefayjey/SharpSQLPwn**](https://github.com/lefayjey/SharpSQLPwn):
+Another tool that can be used is [**SharpSQLPwn**](https://github.com/lefayjey/SharpSQLPwn):<sup>[[6]](#references)</sup>
 
 ```bash
 SharpSQLPwn.exe /modules:LIC /linkedsql:<fqdn of SQL to exeecute cmd in> /cmd:whoami /impuser:sa
@@ -239,7 +239,7 @@ inject-assembly 4704 ../SharpCollection/SharpSQLPwn.exe /modules:LIC /linkedsql:
 
 ### Metasploit
 
-You can easily check for trusted links using metasploit.
+You can easily check for trusted links using Metasploit.
 
 ```bash
 #Set username, password, windows auth (if using AD), IP...
@@ -247,13 +247,13 @@ msf> use exploit/windows/mssql/mssql_linkcrawler
 [msf> set DEPLOY true] #Set DEPLOY to true if you want to abuse the privileges to obtain a meterpreter session
 ```
 
-Notice that metasploit will try to abuse only the `openquery()` function in MSSQL (so, if you can't execute command with `openquery()` you will need to try the `EXECUTE` method **manually** to execute commands, see more below.)
+Metasploit tries to abuse only the `OPENQUERY()` function. If command execution through `OPENQUERY()` fails, try the `EXECUTE` method **manually**, as described below.<sup>[[4]](#references)</sup>
 
 ### Manual - Openquery()
 
 From **Linux** you could obtain a MSSQL console shell with **sqsh** and **mssqlclient.py.**
 
-From **Windows** you could also find the links and execute commands manually using a **MSSQL client like** [**HeidiSQL**](https://www.heidisql.com)
+From **Windows**, you can also find the links and execute commands manually using an **MSSQL client such as** [**HeidiSQL**](https://www.heidisql.com).<sup>[[7]](#references)</sup>
 
 _Login using Windows authentication:_
 
@@ -281,7 +281,7 @@ select * from openquery("dcorp-sql1", 'select * from master..sysservers')
 
 ![Find Trustable Links - Execute queries in trustable link: Check where double and single quotes are used, it's important to use them that way](<../../images/image (643).png>)
 
-You can continue these trusted links chain forever manually.
+You can continue traversing these trusted-link chains manually.
 
 ```sql
 # First level RCE
@@ -291,7 +291,7 @@ SELECT * FROM OPENQUERY("<computer>", 'select @@servername; exec xp_cmdshell ''p
 SELECT * FROM OPENQUERY("<computer1>", 'select * from openquery("<computer2>", ''select @@servername; exec xp_cmdshell ''''powershell -enc blah'''''')')
 ```
 
-If you cannot perform actions like `exec xp_cmdshell` from `openquery()` try with the `EXECUTE` method.
+If you cannot perform actions such as `exec xp_cmdshell` through `OPENQUERY()`, try the `EXECUTE` method.
 
 ### Manual - EXECUTE
 
@@ -305,11 +305,11 @@ EXECUTE('EXECUTE(''sp_addsrvrolemember ''''hacker'''' , ''''sysadmin'''' '') AT 
 
 ## Local Privilege Escalation
 
-The **MSSQL local user** usually has a special type of privilege called **`SeImpersonatePrivilege`**. This allows the account to "impersonate a client after authentication".
+The **MSSQL service account** often has the **`SeImpersonatePrivilege`** user right, which allows the account to impersonate a client after authentication.
 
 A strategy that many authors have come up with is to force a SYSTEM service to authenticate to a rogue or man-in-the-middle service that the attacker creates. This rogue service is then able to impersonate the SYSTEM service whilst it's trying to authenticate.
 
-[SweetPotato](https://github.com/CCob/SweetPotato) has a collection of these various techniques which can be executed via Beacon's `execute-assembly` command.
+[SweetPotato](https://github.com/CCob/SweetPotato) collects several of these techniques and can be executed through Beacon's `execute-assembly` command.<sup>[[8]](#references)</sup>
 
 
 
@@ -319,5 +319,16 @@ See how the default SQL roles of SCCM **Management Points** can be abused to dum
 {{#ref}}
 sccm-management-point-relay-sql-policy-secrets.md
 {{#endref}}
+
+## References
+
+- [1] [ScorpionesLabs – MSSqlPwner](https://github.com/ScorpionesLabs/MSSqlPwner)
+- [2] [NetSPI – PowerUpSQL](https://github.com/NetSPI/PowerUpSQL)
+- [3] [Microsoft Learn – Linked servers (Database Engine)](https://learn.microsoft.com/en-us/sql/relational-databases/linked-servers/linked-servers-database-engine?view=sql-server-ver17)
+- [4] [Microsoft Learn – OPENQUERY](https://learn.microsoft.com/en-us/sql/t-sql/functions/openquery-transact-sql?view=sql-server-ver17)
+- [5] [Microsoft Learn – xp_cmdshell server configuration option](https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/xp-cmdshell-server-configuration-option?view=sql-server-ver17)
+- [6] [lefayjey – SharpSQLPwn](https://github.com/lefayjey/SharpSQLPwn)
+- [7] [HeidiSQL](https://www.heidisql.com)
+- [8] [CCob – SweetPotato](https://github.com/CCob/SweetPotato)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/windows-hardening/active-directory-methodology/ad-certificates/README.md
+++ b/src/windows-hardening/active-directory-methodology/ad-certificates/README.md
@@ -131,6 +131,12 @@ certutil.exe -TCAInfo
 certutil -v -dstemplate
 ```
 
+Rubeus can also use a password-protected PFX certificate for PKINIT authentication and request a TGT. The optional `/getcredentials` switch requests a U2U service ticket and attempts to recover the account NT hash:<sup>[[4]](#references)</sup>
+
+```powershell
+Rubeus.exe asktgt /user:<USER> /certificate:C:\temp\leaked.pfx /password:<PFX_PASSWORD> /getcredentials /ptt
+```
+
 ## References
 
 - [1] [Certified Pre-Owned: Abusing Active Directory Certificate Services](https://www.specterops.io/assets/resources/Certified_Pre-Owned.pdf)

--- a/src/windows-hardening/active-directory-methodology/ad-certificates/domain-escalation.md
+++ b/src/windows-hardening/active-directory-methodology/ad-certificates/domain-escalation.md
@@ -554,7 +554,7 @@ certipy account update -username John@corp.local -password Passw0rd! -user Jane 
 Attempting authentication with the issued certificate now yields the NT hash of `Administrator@corp.local`. The command must include `-domain <domain>` due to the certificate's lack of domain specification:
 
 ```bash
-certipy auth -pfx adminitrator.pfx -domain corp.local
+certipy auth -pfx administrator.pfx -domain corp.local
 ```
 
 ## Weak Certificate Mappings - ESC10
@@ -661,7 +661,7 @@ If CA Server Do not configured with `IF_ENFORCEENCRYPTICERTREQUEST`, it can be m
 You can use `certipy` to enumerate if `Enforce Encryption for Requests` is Disabled and certipy will show `ESC11` Vulnerabilities.
 
 ```bash
-$ certipy find -u mane@domain.local -p 'password' -dc-ip 192.168.100.100 -stdout
+$ certipy find -u <user>@domain.local -p 'password' -dc-ip 192.168.100.100 -stdout
 Certipy v4.0.0 - by Oliver Lyak (ly4k)
 
 Certificate Authorities
@@ -868,7 +868,7 @@ Using built-in default version 1 certificate templates, an attacker can craft a 
 
 ### Abuse
 
-The following is referenced to [this link]((https://github.com/ly4k/Certipy/wiki/06-%E2%80%90-Privilege-Escalation#esc15-arbitrary-application-policy-injection-in-v1-templates-cve-2024-49019-ekuwu),Click to see more detailed usage methods.<sup>[[14]](#references)</sup>
+The [Certipy privilege-escalation documentation](https://github.com/ly4k/Certipy/wiki/06-%E2%80%90-Privilege-Escalation#esc15-arbitrary-application-policy-injection-in-v1-templates-cve-2024-49019-ekuwu) contains more detailed usage examples.<sup>[[14]](#references)</sup>
 
 
 Certipy's `find` command can help identify V1 templates that are potentially susceptible to ESC15 if the CA is unpatched.
@@ -1097,4 +1097,3 @@ Both scenarios lead to an **increase in the attack surface** from one forest to 
 - [16] [Furious5 – AD CS ESC16: Misconfiguration and Exploitation](https://medium.com/@muneebnawaz3849/ad-cs-esc16-misconfiguration-and-exploitation-9264e022a8c6)
 
 {{#include ../../../banners/hacktricks-training.md}}
-

--- a/src/windows-hardening/active-directory-methodology/adws-enumeration.md
+++ b/src/windows-hardening/active-directory-methodology/adws-enumeration.md
@@ -27,7 +27,7 @@ ADWS interactions are implemented over WS-Enumeration: every query starts with a
 * Supports **proxying through SOCKS** (useful from C2 implants).
 * Fine-grained search filters identical to LDAP `-q '(objectClass=user)'`.
 * Optional **write** operations ( `--set` / `--delete` ).
-* **BOFHound output mode** for direct ingestion into BloodHound.
+* **BOFHound output mode** for direct ingestion into BloodHound.<sup>[[3]](#references)</sup>
 * `--parse` flag to prettify timestamps / `userAccountControl` when human readability is required.<sup>[[2]](#references)</sup>
 
 ### Targeted collection flags & write operations
@@ -148,7 +148,7 @@ For arbitrary object classes, the `create custom` command consumes a YAML templa
 
 ## SOAPHound – High-Volume ADWS Collection (Windows)
 
-[FalconForce SOAPHound](https://github.com/FalconForceTeam/SOAPHound) is a .NET collector that keeps all LDAP interactions inside ADWS and emits BloodHound v4-compatible JSON. It builds a complete cache of `objectSid`, `objectGUID`, `distinguishedName` and `objectClass` once (`--buildcache`), then re-uses it for high-volume `--bhdump`, `--certdump` (ADCS), or `--dnsdump` (AD-integrated DNS) passes so only ~35 critical attributes ever leave the DC. AutoSplit (`--autosplit --threshold <N>`) automatically shards queries by CN prefix to stay under the 30-minute EnumerationContext timeout in large forests.<sup>[[8]](#references)</sup>
+[FalconForce SOAPHound](https://github.com/FalconForceTeam/SOAPHound) is a .NET collector that keeps all LDAP interactions inside ADWS and emits BloodHound v4-compatible JSON. It builds a complete cache of `objectSid`, `objectGUID`, `distinguishedName` and `objectClass` once (`--buildcache`), then reuses it for high-volume `--bhdump`, `--certdump` (ADCS), or `--dnsdump` (AD-integrated DNS) passes so only ~35 critical attributes ever leave the DC. AutoSplit (`--autosplit --threshold <N>`) automatically shards queries by CN prefix to stay under the 30-minute EnumerationContext timeout in large forests.<sup>[[8]](#references)</sup>
 
 Typical workflow on a domain-joined operator VM:
 

--- a/src/windows-hardening/active-directory-methodology/badsuccessor-dmsa-migration-abuse.md
+++ b/src/windows-hardening/active-directory-methodology/badsuccessor-dmsa-migration-abuse.md
@@ -11,7 +11,7 @@ Delegated Managed Service Accounts (**dMSA**) are the next-generation successor 
 
 If an attacker can create **any** dMSA inside an OU and directly manipulate those 2 attributes, LSASS & the KDC will treat the dMSA as a *successor* of the linked account.  When the attacker subsequently authenticates as the dMSA **they inherit all the privileges of the linked account** – up to **Domain Admin** if the Administrator account is linked.<sup>[[1]](#references)</sup>
 
-This technique was coined **BadSuccessor** by Unit 42 in 2025.  At the time of writing **no security patch** is available; only hardening of OU permissions mitigates the issue.<sup>[[1]](#references)[[2]](#references)</sup>
+This technique was coined **BadSuccessor** by Unit 42 in 2025. Microsoft later assigned it **CVE-2025-53779** and released a security update in **August 2025**. The technique remains relevant to unpatched Windows Server 2025 environments and to reviews of dangerous OU delegation.<sup>[[1]](#references)[[2]](#references)[[6]](#references)</sup>
 
 ### Attack prerequisites
 
@@ -87,6 +87,7 @@ Correlating `4662` (attribute modification), `4741` (creation of a computer/serv
 
 ## Mitigation
 
+* Apply Microsoft's security update for **CVE-2025-53779** and verify the patch level of every Windows Server 2025 domain controller.<sup>[[6]](#references)</sup>
 * Apply the principle of **least privilege** – only delegate *Service Account* management to trusted roles.
 * Remove `Create Child` / `msDS-DelegatedManagedServiceAccount` from OUs that do not explicitly require it.
 * Monitor for the event IDs listed above and alert on *non-Tier-0* identities creating or editing dMSAs.
@@ -105,5 +106,6 @@ golden-dmsa-gmsa.md
 - [3] [SharpSuccessor PoC](https://github.com/logangoins/SharpSuccessor)
 - [4] [BadSuccessor.ps1 – Pentest-Tools-Collection](https://github.com/LuemmelSec/Pentest-Tools-Collection/blob/main/tools/ActiveDirectory/BadSuccessor.ps1)
 - [5] [NetExec BadSuccessor module](https://github.com/Pennyw0rth/NetExec/blob/main/nxc/modules/badsuccessor.py)
+- [6] [Microsoft Security Response Center – CVE-2025-53779](https://msrc.microsoft.com/update-guide/vulnerability/CVE-2025-53779)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/windows-hardening/active-directory-methodology/constrained-delegation.md
+++ b/src/windows-hardening/active-directory-methodology/constrained-delegation.md
@@ -140,7 +140,7 @@ tgt::ask /user:dcorp-adminsrv$ /domain:sub.domain.local /rc4:8c6264140d5ae7d03f7
 ```
 
 ```bash:kekeo + Mimikatz
-#Obtain a TGT for the Constained allowed user
+#Obtain a TGT for the constrained-delegation user
 tgt::ask /user:dcorp-adminsrv$ /domain:dollarcorp.moneycorp.local /rc4:8c6264140d5ae7d03f7f2a53088a291d
 
 #Get a TGS for the service you are allowed (in this case time) and for other one (in this case LDAP)

--- a/src/windows-hardening/active-directory-methodology/dcshadow.md
+++ b/src/windows-hardening/active-directory-methodology/dcshadow.md
@@ -45,13 +45,13 @@ For example: `Set-DCShadowPermissions -FakeDC mcorp-student1 SAMAccountName root
 lsadump::dcshadow /object:student1 /attribute:SIDHistory /value:S-1-521-280534878-1496970234-700767426-519
 ```
 
-```bash:Chage PrimaryGroupID (put user as member of Domain Administrators)
+```bash:Change PrimaryGroupID (put user as member of Domain Administrators)
 lsadump::dcshadow /object:student1 /attribute:primaryGroupID /value:519
 ```
 
 ```bash:Modify ntSecurityDescriptor of AdminSDHolder (give Full Control to a user)
 #First, get the ACE of an admin already in the Security Descriptor of AdminSDHolder: SY, BA, DA or -519
-(New-Object System.DirectoryServices.DirectoryEntry("LDAP://CN=Admin SDHolder,CN=System,DC=moneycorp,DC=local")).psbase.Objec tSecurity.sddl
+(New-Object System.DirectoryServices.DirectoryEntry("LDAP://CN=Admin SDHolder,CN=System,DC=moneycorp,DC=local")).psbase.ObjectSecurity.sddl
 #Second, add to the ACE permissions to your user and push it using DCShadow
 lsadump::dcshadow /object:CN=AdminSDHolder,CN=System,DC=moneycorp,DC=local /attribute:ntSecurityDescriptor /value:<whole modified ACL>
 ```
@@ -96,9 +96,9 @@ We need to append following ACEs with our user's SID at the end:<sup>[[2]](#refe
 - On the target user object: `(A;;WP;;;UserSID)`
 - On the Sites object in Configuration container: `(A;CI;CCDC;;;UserSID)`
 
-To get the current ACE of an object: `(New-Object System.DirectoryServices.DirectoryEntry("LDAP://DC=moneycorp,DC=loca l")).psbase.ObjectSecurity.sddl`
+To get the current ACE of an object: `(New-Object System.DirectoryServices.DirectoryEntry("LDAP://DC=moneycorp,DC=local")).psbase.ObjectSecurity.sddl`
 
-Notice that in this case you need to make **several changes,** not just one. So, in the **mimikatz1 session** (RPC server) use the parameter **`/stack` with each change** you want to make. This way, you will only need to **`/push`** one time to perform all the stucked changes in the rouge server.
+In this case you need to make **several changes**, not just one. In the **mimikatz1 session** (RPC server), use the **`/stack` parameter with each change**. You then need to **`/push`** only once to apply all stacked changes from the rogue server.
 
 [**More information about DCShadow in ired.team.**](https://ired.team/offensive-security-experiments/active-directory-kerberos-abuse/t1207-creating-rogue-domain-controllers-with-dcshadow)<sup>[[2]](#references)</sup>
 

--- a/src/windows-hardening/active-directory-methodology/dcsync.md
+++ b/src/windows-hardening/active-directory-methodology/dcsync.md
@@ -93,7 +93,7 @@ Operational notes:
 `-just-dc` generates 3 files:
 
 - one with the **NTLM hashes**
-- one with the the **Kerberos keys**
+- one with the **Kerberos keys**
 - one with cleartext passwords from the NTDS for any accounts set with [**reversible encryption**](https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/store-passwords-using-reversible-encryption) enabled. You can get users with reversible encryption with
 
   ```bash
@@ -102,7 +102,7 @@ Operational notes:
 
 ### Persistence
 
-If you are a domain admin, you can grant this permissions to any user with the help of `powerview`:<sup>[[3]](#references)</sup>
+If you are a domain admin, you can grant these permissions to any user with the help of PowerView:<sup>[[3]](#references)</sup>
 
 ```bash
 Add-ObjectAcl -TargetDistinguishedName "dc=dollarcorp,dc=moneycorp,dc=local" -PrincipalSamAccountName username -Rights DCSync -Verbose

--- a/src/windows-hardening/active-directory-methodology/external-forest-domain-oneway-inbound.md
+++ b/src/windows-hardening/active-directory-methodology/external-forest-domain-oneway-inbound.md
@@ -111,7 +111,7 @@ Invoke-Mimikatz -Command '"kerberos::golden /user:<username> /domain:<current do
 
 # Use this inter-realm TGT to request a TGS in the target domain to access the CIFS service of the DC
 ## We are asking to access CIFS of the external DC because in the enumeration we show the group was part of the local administrators group
-Rubeus.exe asktgs /service:cifs/dc.doamin.external /domain:dc.domain.external /dc:dc.domain.external /ticket:C:\path\save\ticket.kirbi /nowrap
+Rubeus.exe asktgs /service:cifs/dc.domain.external /domain:dc.domain.external /dc:dc.domain.external /ticket:C:\path\save\ticket.kirbi /nowrap
 
 # Now you have a TGS to access the CIFS service of the domain controller
 ```
@@ -127,7 +127,7 @@ Rubeus.exe asktgs /service:krbtgt/domain.external /domain:sub.domain.local /dc:d
 
 # Use this inter-realm TGT to request a TGS in the target domain to access the CIFS service of the DC
 ## We are asking to access CIFS of the external DC because in the enumeration we show the group was part of the local administrators group
-Rubeus.exe asktgs /service:cifs/dc.doamin.external /domain:dc.domain.external /dc:dc.domain.external /ticket:doIFMT[...snip...]5BTA== /nowrap
+Rubeus.exe asktgs /service:cifs/dc.domain.external /domain:dc.domain.external /dc:dc.domain.external /ticket:doIFMT[...snip...]5BTA== /nowrap
 
 # Now you have a TGS to access the CIFS service of the domain controller
 ```

--- a/src/windows-hardening/active-directory-methodology/kerberoast.md
+++ b/src/windows-hardening/active-directory-methodology/kerberoast.md
@@ -27,13 +27,15 @@ Many services still run under user accounts with hand-managed passwords. The KDC
 | AES + PBKDF2 | PBKDF2-HMAC-SHA1 with 4,096 iterations and a per-principal salt generated from the domain + SPN | etype 17/18 (`$krb5tgs$17$`, `$krb5tgs$18$`) | ~6.8 million guesses/s | Salt blocks rainbow tables but still allows fast cracking of short passwords. |
 | RC4 + NT hash | Single MD4 of the password (unsalted NT hash); Kerberos only mixes in an 8-byte confounder per ticket | etype 23 (`$krb5tgs$23$`) | ~4.18 **billion** guesses/s | ~1000× faster than AES; attackers force RC4 whenever `msDS-SupportedEncryptionTypes` permits it. |
 
-*Benchmarks from Chick3nman as d in [Matthew Green's Kerberoasting analysis](https://blog.cryptographyengineering.com/2025/09/10/kerberoasting/).<sup>[[3]](#references)</sup>
+*Benchmarks from Chick3nman as cited in [Matthew Green's Kerberoasting analysis](https://blog.cryptographyengineering.com/2025/09/10/kerberoasting/).<sup>[[3]](#references)</sup>
 
 RC4’s confounder only randomizes the keystream; it does not add work per guess. Unless service accounts rely on random secrets (gMSA/dMSA, machine accounts, or vault-managed strings), compromise speed is purely GPU budget. Enforcing AES-only etypes removes the billion-guesses-per-second downgrade, but weak human passwords still fall to PBKDF2.<sup>[[3]](#references)</sup>
 
 ### Attack
 
 #### Linux
+
+A practical end-to-end example using NetExec to request roastable tickets and Hashcat to crack them is available in reference [1].<sup>[[1]](#references)</sup>
 
 ```bash
 # Metasploit Framework

--- a/src/windows-hardening/windows-local-privilege-escalation/dll-hijacking/writable-sys-path-dll-hijacking-privesc.md
+++ b/src/windows-hardening/windows-local-privilege-escalation/dll-hijacking/writable-sys-path-dll-hijacking-privesc.md
@@ -4,11 +4,11 @@
 
 ## Introduction
 
-If you found that you can **write in a System Path folder** (note that this won't work if you can write in a User Path folder) it's possible that you could **escalate privileges** in the system.
+If you can **write to a directory in the system-wide `PATH`** (not merely your user `PATH`), you may be able to **escalate privileges** on the system.
 
-In order to do that you can abuse a **Dll Hijacking** where you are going to **hijack a library being loaded** by a service or process with **more privileges** than yours, and because that service is loading a Dll that probably doesn't even exist in the entire system, it's going to try to load it from the System Path where you can write.
+This can be abused through **DLL hijacking** when a more-privileged service or process tries to load a DLL that does not exist in its earlier search locations and eventually searches the writable system `PATH` directory.
 
-For more info about **what is Dll Hijackig** check:
+For more information about **DLL hijacking**, see:
 
 
 {{#ref}}
@@ -17,9 +17,9 @@ For more info about **what is Dll Hijackig** check:
 
 ## Privesc with Dll Hijacking
 
-### Finding a missing Dll
+### Finding a Missing DLL
 
-The first thing you need is to **identify a process** running with **more privileges** than you that is trying to **load a Dll from the System Path** you can write in.
+First, **identify a process** running with **more privileges** that tries to **load a DLL from a writable system `PATH` directory**.
 
 Remember that this technique depends on a **Machine/System PATH** entry, not only on your **User PATH**. Therefore, before spending time on Procmon, it's worth enumerating the **Machine PATH** entries and checking which ones are writable:<sup>[[1]](#references)</sup>
 
@@ -34,7 +34,7 @@ $machinePath | ForEach-Object {
 }
 ```
 
-The problem in this cases is that probably thoses processes are already running. To find which Dlls are lacking the services you need to launch procmon as soon as possible (before processes are loaded). So, to find lacking .dlls do:
+The problem in these cases is that those processes are probably already running. To identify DLLs that services try and fail to load, launch Procmon as early as possible (before the processes start), then:
 
 - **Create** the folder `C:\privesc_hijacking` and add the path `C:\privesc_hijacking` to **System Path env variable**. You can do this **manually** or with **PS**:
 
@@ -59,7 +59,7 @@ if ($envPath -notlike "*$folderPath*") {
 - Then, **reboot**. When the computer is restarted **`procmon`** will start **recording** events asap.
 - Once **Windows** is **started execute `procmon`** again, it'll tell you that it has been running and will **ask you if you want to store** the events in a file. Say **yes** and **store the events in a file**.
 - **After** the **file** is **generated**, **close** the opened **`procmon`** window and **open the events file**.
-- Add these **filters** and you will find all the Dlls that some **proccess tried to load** from the writable System Path folder:
+- Add these **filters** to find all DLLs that a **process tried to load** from the writable System Path folder:
 
 <figure><img src="../../../images/image (945).png" alt=""><figcaption></figcaption></figure>
 
@@ -72,7 +72,7 @@ Running this in a free **virtual (vmware) Windows 11 machine** I got these resul
 
 <figure><img src="../../../images/image (607).png" alt=""><figcaption></figcaption></figure>
 
-In this case the .exe are useless so ignore them, the missed DLLs where from:
+In this case, ignore the `.exe` results. The missing-DLL probes came from:
 
 | Service                         | Dll                | CMD line                                                             |
 | ------------------------------- | ------------------ | -------------------------------------------------------------------- |
@@ -80,7 +80,7 @@ In this case the .exe are useless so ignore them, the missed DLLs where from:
 | Diagnostic Policy Service (DPS) | Unknown.DLL        | `C:\Windows\System32\svchost.exe -k LocalServiceNoNetwork -p -s DPS` |
 | ???                             | SharedRes.dll      | `C:\Windows\system32\svchost.exe -k UnistackSvcGroup`                |
 
-After finding this, I found this interesting blog post that also explains how to [**abuse WptsExtensions.dll for privesc**](https://juggernaut-sec.com/dll-hijacking/#Windows_10_Phantom_DLL_Hijacking_-_WptsExtensionsdll). Which is what we **are going to do now**.<sup>[[3]](#references)</sup>
+The following example uses the technique described in this article about [**abusing `WptsExtensions.dll` for privilege escalation**](https://juggernaut-sec.com/dll-hijacking/#Windows_10_Phantom_DLL_Hijacking_-_WptsExtensionsdll).<sup>[[3]](#references)</sup>
 
 ### Other candidates worth triaging
 
@@ -96,13 +96,13 @@ Treat these names as **triage hints**, not guaranteed wins: they are **SKU/build
 
 ### Exploitation
 
-So, to **escalate privileges** we are going to hijack the library **WptsExtensions.dll**. Having the **path** and the **name** we just need to **generate the malicious dll**.
+To **escalate privileges**, hijack **`WptsExtensions.dll`**. Once the **path** and **name** are known, generate the malicious DLL.
 
 You can [**try to use any of these examples**](#creating-and-compiling-dlls). You could run payloads such as: get a rev shell, add a user, execute a beacon...
 
 > [!WARNING]
-> Note that **not all the service are run** with **`NT AUTHORITY\SYSTEM`** some are also run with **`NT AUTHORITY\LOCAL SERVICE`** which has **less privileges** and you **won't be able to create a new user** abuse its permissions.\
-> However, that user has the **`seImpersonate`** privilege, so you can use the[ **potato suite to escalate privileges**](../roguepotato-and-printspoofer.md). So, in this case a rev shell is a better option that trying to create a user.
+> Note that **not all services run** as **`NT AUTHORITY\SYSTEM`**. Some run as **`NT AUTHORITY\LOCAL SERVICE`**, which has **fewer privileges**, so abusing one of these services may not let you create a new user.\
+> However, that account has the **`SeImpersonatePrivilege`** user right, so you can use the [**Potato suite to escalate privileges**](../roguepotato-and-printspoofer.md). In this case, a reverse shell is a better option than trying to create a user.
 
 At the moment of writing the **Task Scheduler** service is run with **Nt AUTHORITY\SYSTEM**.
 

--- a/src/windows-hardening/windows-local-privilege-escalation/dpapi-extracting-passwords.md
+++ b/src/windows-hardening/windows-local-privilege-escalation/dpapi-extracting-passwords.md
@@ -8,22 +8,22 @@
 
 The Data Protection API (DPAPI) is primarily utilized within the Windows operating system for the **symmetric encryption of asymmetric private keys**, leveraging either user or system secrets as a significant source of entropy. This approach simplifies encryption for developers by enabling them to encrypt data using a key derived from the user's logon secrets or, for system encryption, the system's domain authentication secrets, thus obviating the need for developers to manage the protection of the encryption key themselves.
 
-The most common way to use DPAPI is through the **`CryptProtectData` and `CryptUnprotectData`** functions, which allow applications to encrypt and decrypt data securely with the session of the process that is currently logged on. This means that the encrypted data can only be decrypted by the same user or system that encrypted it.
+The most common way to use DPAPI is through the **`CryptProtectData` and `CryptUnprotectData`** functions, which allow applications to encrypt and decrypt data using the security context of the currently logged-on process. By default, the data can be decrypted only by the same user or system context that encrypted it.<sup>[[2]](#references)[[3]](#references)</sup>
 
-Moreover, these functions accepts also an **`entropy` parameter** which will also be used during encryption and decryption, therefore, in order to decrypt something encrypted using this parameter, you must provide the same entropy value that was used during encryption.
+These functions also accept an optional **entropy parameter** used during encryption and decryption. Data protected with optional entropy requires that same entropy value for decryption.<sup>[[2]](#references)[[6]](#references)</sup>
 
 ### Users key generation
 
-The DPAPI generates a unique key (called **`pre-key`**) for each user based on their credentials. This key is derived from the user's password and other factors and the algorithm depends on the type of user but ends being a SHA1. For example, for domain users, **it depends on the NTLM hash of the user**.
+DPAPI derives a user-specific value (often called a **pre-key**) from the user's credentials. The exact derivation depends on the account and operating-system version; for domain users, tooling can derive the needed value from the user's NTLM material.<sup>[[2]](#references)</sup>
 
 This is specially interesting because if an attacker can obtain the user's password hash, they can:
 
 - **Decrypt any data that was encrypted using DPAPI** with that user's key without needing to contact any API
 - Try to **crack the password** offline trying to generate the valid DPAPI key
 
-Moreover, every time some data is encrypted by a user using DPAPI, a new **master key** is generated. This master key is the one actually used to encrypt data. Each master key is given with a **GUID** (Globally Unique Identifier) that identifies it.
+DPAPI maintains one or more **master keys** for each user rather than creating a new master key for every protected blob. Each master key has a **GUID** (Globally Unique Identifier), and an encrypted blob records which master key protects it.<sup>[[2]](#references)</sup>
 
-The master keys are stored in the **`%APPDATA%\Microsoft\Protect\<sid>\<guid>`** directory, where `{SID}` is the Security Identifier of that user. The master key is stored encrypted by the user's **`pre-key`** and also by a **domain backup key** for recovery (so the same key is stored encrypted 2 times by 2 different pass).
+Master keys are stored in the **`%APPDATA%\Microsoft\Protect\<sid>\<guid>`** directory, where `{SID}` is the user's Security Identifier. The master-key file contains material protected by the user's **pre-key** and, for domain users, recovery material protected by a **domain backup key**.<sup>[[2]](#references)</sup>
 
 Note that the **domain key used to encrypt the master key is in the domain controllers and never changes**, so if an attacker has access to the domain controller, they can retrieve the domain backup key and decrypt the master keys of all users in the domain.<sup>[[2]](#references)</sup>
 

--- a/src/windows-hardening/windows-local-privilege-escalation/integrity-levels.md
+++ b/src/windows-hardening/windows-local-privilege-escalation/integrity-levels.md
@@ -4,29 +4,29 @@
 
 ## Integrity Levels
 
-In Windows Vista and later versions, all protected items come with an **integrity level** tag. This setup mostly assigns a "medium" integrity level to files and registry keys, except for certain folders and files that Internet Explorer 7 can write to at a low integrity level. The default behavior is for processes initiated by standard users to have a medium integrity level, whereas services typically operate at a system integrity level. A high-integrity label safeguards the root directory.
+In Windows Vista and later versions, securable objects can carry an **integrity level** label. Most objects are treated as medium integrity, while specific locations intended for low-integrity applications can be labelled low. Processes started by standard users normally run at medium integrity, elevated applications run at high integrity, and many services run at system integrity.<sup>[[1]](#references)</sup>
 
-A key rule is that objects can't be modified by processes with a lower integrity level than the object's level. The integrity levels are:
+A key rule is that objects cannot be modified by processes with a lower integrity level than the object's level. Windows applies this Mandatory Integrity Control (MIC) check before evaluating the object's discretionary access control list (DACL). The commonly encountered levels are:<sup>[[1]](#references)[[2]](#references)</sup>
 
-- **Untrusted**: This level is for processes with anonymous logins. Example: Chrome
+- **Untrusted**: The lowest level, represented by `SECURITY_MANDATORY_UNTRUSTED_RID`.
 - **Low**: Mainly for internet interactions, especially in Internet Explorer's Protected Mode, affecting associated files and processes, and certain folders like the **Temporary Internet Folder**. Low integrity processes face significant restrictions, including no registry write access and limited user profile write access.
 - **Medium**: The default level for most activities, assigned to standard users and objects without specific integrity levels. Even members of the Administrators group operate at this level by default.
 - **High**: Reserved for administrators, allowing them to modify objects at lower integrity levels, including those at the high level itself.
 - **System**: The highest operational level for the Windows kernel and core services, out of reach even for administrators, ensuring protection of vital system functions.
-- **Installer**: A unique level that stands above all others, enabling objects at this level to uninstall any other object.
 
-You can get the integrity level of a process using **Process Explorer** from **Sysinternals**, accessing the **properties** of the process and viewing the "**Security**" tab:
+Windows also defines a protected-process integrity value above System. **TrustedInstaller**, however, is a Windows service identity rather than a separate MIC level; its ability to modify protected operating-system resources comes from the permissions granted to that identity.
+
+You can obtain the integrity level of a process using **Process Explorer** from **Sysinternals** by opening the process properties and viewing the **Security** tab:<sup>[[3]](#references)</sup>
 
 ![Integrity Levels - Integrity Levels: You can get the integrity level of a process using Process Explorer from Sysinternals , accessing the properties of the process and viewing the "...](<../../images/image (824).png>)
 
-You can also get your **current integrity level** using `whoami /groups`
+You can also obtain your **current integrity level** using `whoami /groups`:
 
 ![Integrity Levels - Integrity Levels: You can also get your current integrity level using whoami /groups](<../../images/image (325).png>)
 
-### Integrity Levels in File-system
+### Integrity Levels in the File System
 
-A object inside the file-system may need an **minimum integrity level requirement** and if a process doesn't have this integrity process it won't be able to interact with it.\
-For example, lets **create a regular from a regular user console file and check the permissions**:
+An object in the file system may have a **minimum integrity-level requirement**. A process below that level is subject to the object's mandatory policy even when its DACL would otherwise grant access. For example, create a regular file from a standard-user console and inspect its permissions:<sup>[[1]](#references)[[4]](#references)</sup>
 
 ```
 echo asd >asd.txt
@@ -39,7 +39,7 @@ asd.txt BUILTIN\Administrators:(I)(F)
         NT AUTHORITY\BATCH:(I)(M,DC)
 ```
 
-Now, lets assign a minimum integrity level of **High** to the file. This **must be done from a console** running as **administrator** as a **regular console** will be running in Medium Integrity level and **won't be allowed** to assign High Integrity level to an object:
+Now, assign a minimum integrity level of **High** to the file. This **must be done from a console** running as **administrator**, because a regular console runs at Medium integrity and **will not be allowed** to assign High integrity to an object:
 
 ```
 icacls asd.txt /setintegritylevel(oi)(ci) High
@@ -56,7 +56,7 @@ asd.txt BUILTIN\Administrators:(I)(F)
         Mandatory Label\High Mandatory Level:(NW)
 ```
 
-This is where things get interesting. You can see that the user `DESKTOP-IDJHTKP\user` has **FULL privileges** over the file (indeed this was the user that created the file), however, due to the minimum integrity level implemented he won't be able to modify the file anymore unless he is running inside a High Integrity Level (note that he will be able to read it):
+The user `DESKTOP-IDJHTKP\user` has **FULL privileges** over the file because that user created it. However, the mandatory label prevents the user from modifying the file unless the process is running at High integrity. The user can still read it because the displayed mandatory policy is `(NW)`, or no-write-up:
 
 ```
 echo 1234 > asd.txt
@@ -72,7 +72,7 @@ Access is denied.
 
 ### Integrity Levels in Binaries
 
-I made a copy of `cmd.exe` in `C:\Windows\System32\cmd-low.exe` and set it an **integrity level of low from an administrator console:**
+The following example uses a copy of `cmd.exe` at `C:\Windows\System32\cmd-low.exe` and assigns it a **Low integrity level from an administrator console**:
 
 ```
 icacls C:\Windows\System32\cmd-low.exe
@@ -88,13 +88,19 @@ Now, when I run `cmd-low.exe` it will **run under a low-integrity level** instea
 
 ![Integrity Levels in File-system - Integrity Levels in Binaries: Now, when I run cmd-low.exe it will run under a low-integrity level instead of a medium one](<../../images/image (313).png>)
 
-For curious people, if you assign high integrity level to a binary (`icacls C:\Windows\System32\cmd-high.exe /setintegritylevel high`) it won't run with high integrity level automatically (if you invoke it from a medium integrity level --by default-- it will run under a medium integrity level).
+Assigning a High integrity label to a binary (`icacls C:\Windows\System32\cmd-high.exe /setintegritylevel high`) does not make it run at High integrity automatically. If invoked from a Medium-integrity process, it runs at Medium integrity because a new process receives the lower of the executable file's and the caller's integrity levels.<sup>[[1]](#references)</sup>
 
 ### Integrity Levels in Processes
 
-Not all files and folders have a minimum integrity level, **but all processes are running under an integrity level**. And similar to what happened with the file-system, **if a process wants to write inside another process it must have at least the same integrity level**. This means that a process with low integrity level can’t open a handle with full access to a process with medium integrity level.
+Not all files and folders have an explicit minimum integrity label, **but every process runs at an integrity level**. As with file-system objects, **a process that wants write access to another process must have at least the same integrity level**. Therefore, a Low-integrity process cannot open a Medium-integrity process with full access.<sup>[[1]](#references)</sup>
 
-Due to the restrictions commented in this and the previous section, from a security point of view, it's always **recommended to run a process in the lower level of integrity possible**.
+Because of these restrictions, the safest approach is to **run each process at the lowest integrity level that still lets it perform its intended work**.
+
+## References
+
+- [1] [Microsoft Learn – Mandatory Integrity Control](https://learn.microsoft.com/en-us/windows/win32/secauthz/mandatory-integrity-control)
+- [2] [Microsoft Learn – MANDATORY_LEVEL enumeration](https://learn.microsoft.com/en-us/windows/win32/api/winnt/ne-winnt-mandatory_level)
+- [3] [Microsoft Sysinternals – Process Explorer](https://learn.microsoft.com/en-us/sysinternals/downloads/process-explorer)
+- [4] [Microsoft Learn – icacls](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/icacls)
 
 {{#include ../../banners/hacktricks-training.md}}
-

--- a/src/windows-hardening/windows-local-privilege-escalation/juicypotato.md
+++ b/src/windows-hardening/windows-local-privilege-escalation/juicypotato.md
@@ -29,7 +29,7 @@ We decided to weaponize [RottenPotatoNG](https://github.com/breenmachine/RottenP
 
 > For the theory, see [Rotten Potato - Privilege Escalation from Service Accounts to SYSTEM](https://foxglovesecurity.com/2016/09/26/rotten-potato-privilege-escalation-from-service-accounts-to-system/) and follow the chain of links and references.<sup>[[4]](#references)</sup>
 
-We discovered that, other than `BITS` there are a several COM servers we can abuse. They just need to:
+Besides `BITS`, several COM servers can be abused. They only need to:
 
 1. be instantiable by the current user, normally a “service user” which has impersonation privileges
 2. implement the `IMarshal` interface

--- a/src/windows-hardening/windows-local-privilege-escalation/leaked-handle-exploitation.md
+++ b/src/windows-hardening/windows-local-privilege-escalation/leaked-handle-exploitation.md
@@ -4,20 +4,20 @@
 
 ## Introduction
 
-Handles in a process allow to **access** different **Windows resources**:
+Process handles provide **access** to different **Windows resources**:
 
 ![RootedCON2022 - Exploiting Leaked Handles for LPE](<../../images/image (246).png>)
 
-There have been already several **privilege escalation** cases where a **privileged process** with **open and inheritable handles** have **run** an **unprivileged process** giving it **access to all those handles**.
+Several **privilege-escalation** vulnerabilities have involved a **privileged process** with **open, inheritable handles** launching an **unprivileged process** and unintentionally giving it **access to those handles**.
 
-For example, imagine that **a process running as SYSTEM open a new process** (`OpenProcess()`) with **full access**. The same process **also creates a new process** (`CreateProcess()`) **with low privileges but inheriting all the open handles of the main process**.\
-Then, if you have **full access to the low privileged process**, you can grab the **open handle to the privileged process created** with `OpenProcess()` and **inject a shellcode**.
+For example, imagine that **a process running as SYSTEM opens another process** with `OpenProcess()` and requests **full access**. It then calls `CreateProcess()` to launch a **low-privileged child that inherits all open handles from the parent**.\
+If you control the low-privileged process, you can use the **inherited handle to the privileged process** to **inject shellcode**.
 
 ## **Interesting Handles**
 
 ### **Process**
 
-As you read on the initial example if an **unprivileged process inherits a process handle** of a **privileged process** with enough permissions it will be able to execute **arbitrary code on it**.
+As in the initial example, an **unprivileged process** that inherits a sufficiently privileged **process handle** may be able to execute **arbitrary code in the target process**.
 
 In [**this excellent article**](http://dronesec.pw/blog/2019/08/22/exploiting-leaked-process-and-thread-handles/) you can see how to exploit any process handle that has any of the following permissions:<sup>[[1]](#references)</sup>
 
@@ -29,7 +29,7 @@ In [**this excellent article**](http://dronesec.pw/blog/2019/08/22/exploiting-le
 
 ### Thread
 
-Similar to the process handles, if an **unprivileged process inherits a thread handle** of a **privileged process** with enough permissions it will be able to execute **arbitrary code on it**.
+Similarly, an **unprivileged process** that inherits a sufficiently privileged **thread handle** may be able to execute **arbitrary code through the target thread**.
 
 In [**this excellent article**](http://dronesec.pw/blog/2019/08/22/exploiting-leaked-process-and-thread-handles/) you can also see how to exploit any process handle that has any of the following permissions:<sup>[[1]](#references)[[3]](#references)</sup>
 
@@ -39,9 +39,9 @@ In [**this excellent article**](http://dronesec.pw/blog/2019/08/22/exploiting-le
 
 ### File, Key & Section Handles
 
-If an **unprivileged process inherits** a **handle** with **write** equivalent **permissions** over a **privileged file or registry**, it will be able to **overwrite** the file/registry (and with a lot of **luck**, **escalate privileged**).
+If an **unprivileged process inherits** a handle with **write-equivalent permissions** to a **privileged file or registry key**, it can **overwrite** that object and may be able to **escalate privileges**.
 
-**Section Handles** are similar to file handles, the common name of this kinds of [objects is **"File Mapping"**](https://docs.microsoft.com/en-us/windows/win32/memory/file-mapping). They are used to work with **big files without keeping the entire** file in memory. That makes the exploitation kind of "similar" to the exploitation of a File Handle.
+**Section handles** are similar to file handles; these objects are commonly exposed as [**file mappings**](https://docs.microsoft.com/en-us/windows/win32/memory/file-mapping). They allow a process to work with **large files without keeping the entire file** in memory, so their exploitation can resemble file-handle exploitation.
 
 ## How to see handles of processes
 
@@ -49,7 +49,7 @@ If an **unprivileged process inherits** a **handle** with **write** equivalent *
 
 [**Process Hacker**](https://github.com/processhacker/processhacker) is a tool you can download for free. It has several amazing options to inspect processes and one of them is the **capability to see the handles of each process**.
 
-Note that in order to **see all the handles of all the processes, the SeDebugPrivilege is needed** (so you need to run Process Hacker as administrator).
+To **see all handles in all processes, `SeDebugPrivilege` is required**, so run Process Hacker as administrator.
 
 To see the handles of a process, right click in the process and select Handles:
 
@@ -71,7 +71,7 @@ The [**Handles** ](https://docs.microsoft.com/en-us/sysinternals/downloads/handl
 
 ### Methodology
 
-Now that you know how to find handles of processes what you need to check is if any **unprivileged process is having access to privileged handles**. In that case, the user of the process could be able to obtain the handle and abuse it to escalate privileges.
+After learning how to find process handles, check whether an **unprivileged process has access to privileged handles**. If so, the process owner may be able to obtain and abuse a handle to escalate privileges.
 
 > [!WARNING]
 > It was mentioned before that you need the SeDebugPrivilege to access all the handles. But a **user can still access the handles of his processes**, so it might be useful if you want to privesc just from that user to **execute the tools with the user regular permissions**.
@@ -82,9 +82,9 @@ Now that you know how to find handles of processes what you need to check is if 
 
 ## Vulnerable Example
 
-For example, the following code belongs to a **Windows service** that would be vulnerable. The vulnerable code of this service binary is located inside the **`Exploit`** function. This function is starts **creating a new handle process with full access**. Then, it's **creating a low privileged process** (by copying the low privileged token of _explorer.exe_) executing _C:\users\username\desktop\client.exe_. The **vulnerability resides in the fact it's creating the low privileged process with `bInheritHandles` as `TRUE`**.
+For example, the following code belongs to a vulnerable **Windows service**. The vulnerability is in the service binary's **`Exploit`** function. This function first **opens a handle to a process with full access**. It then **creates a low-privileged process** (by copying the low-privileged token of _explorer.exe_) that executes _C:\users\username\desktop\client.exe_. The vulnerability exists because it creates the low-privileged process with `bInheritHandles` set to `TRUE`.
 
-Therefore, this low privileges process is able to grab the handle of the high privileged process crated first and inject and execute a shellcode (see next section).
+Therefore, this low-privileged process can inherit the previously created handle to the high-privileged process and use it to inject and execute shellcode (see the next section).
 
 ```c
 #include <windows.h>
@@ -98,7 +98,7 @@ SERVICE_STATUS_HANDLE serviceStatusHandle = 0;
 HANDLE stopServiceEvent = 0;
 
 
-//Find PID of a proces from its name
+//Find the PID of a process from its name
 int FindTarget(const char *procname) {
 
 	HANDLE hProcSnap;
@@ -298,8 +298,8 @@ int _tmain( int argc, TCHAR* argv[] )
 > In a real scenario you probably **won't be able to control the binary** that is going to be executed by the vulnerable code (_C:\users\username\desktop\client.exe_ in this case). Probably you will **compromise a process and you will need to look if you can access any vulnerable handle of any privileged process**.
 
 In this example you can find the code of a possible exploit for _C:\users\username\desktop\client.exe_.\
-The most interesting part of this code is located in `GetVulnProcHandle`. This function will **start fetching all the handles**, then it will **check if any of them belongs to the same PID** and if the handle belongs to a **process**. If all these requirements are completed (an accessible open process handle is found) , it try to **inject and execute a shellcode abusing the handle of the process**.\
-The injection of the shellcode is done inside the **`Inject`** function and it will just **write the shellcode inside the privileged process and create a thread inside the same process** to execute the shellcode).
+The most interesting part of this code is in `GetVulnProcHandle`. This function **enumerates all handles**, then checks whether any belongs to the same PID and refers to a **process**. If these requirements are met (an accessible open process handle is found), it attempts to **inject and execute shellcode by abusing the process handle**.\
+The **`Inject`** function performs the injection by **writing the shellcode into the privileged process and creating a thread in that process** to execute it.
 
 ```c
 #include <windows.h>
@@ -506,8 +506,7 @@ int main(int argc, char **argv) {
 
 ### Exploit Example 2
 
-> [!TIP]
-> In a real scenario you probably **won't be able to control the binary** that is going to be executed by the vulnerable code (_C:\users\username\desktop\client.exe_ in this case). Probably you will **compromise a process and you will need to look if you can access any vulnerable handle of any privileged process**.
+The real-world handle-discovery constraint described in the first exploit example also applies to this token-based variant.
 
 In this example, **instead of abusing the open handle to inject** and execute a shellcode, it's going to be **used the token of the privileged open handle process to create a new one**. This is done in lines from 138 to 148.
 
@@ -692,4 +691,3 @@ Another tool to leak a handle and exploit it.<sup>[[4]](#references)</sup>
 - [4] [ReHacks - Leaky Handles (abankalarm)](https://github.com/abankalarm/ReHacks/tree/main/Leaky%20Handles)
 
 {{#include ../../banners/hacktricks-training.md}}
-

--- a/src/windows-hardening/windows-local-privilege-escalation/privilege-escalation-abusing-tokens.md
+++ b/src/windows-hardening/windows-local-privilege-escalation/privilege-escalation-abusing-tokens.md
@@ -11,11 +11,11 @@ If you **don't know what are Windows Access Tokens** read this page before conti
 access-tokens.md
 {{#endref}}
 
-**Maybe you could be able to escalate privileges abusing the tokens you already have**
+**You may be able to escalate privileges by abusing tokens you already hold.**
 
 ### SeImpersonatePrivilege
 
-This is privilege that is held by any process allows the impersonation (but not creation) of any token, given that a handle to it can be obtained. A privileged token can be acquired from a Windows service (DCOM) by inducing it to perform NTLM authentication against an exploit, subsequently enabling the execution of a process with SYSTEM privileges.<sup>[[2]](#references)</sup> This vulnerability can be exploited using various tools, such as [juicy-potato](https://github.com/ohpe/juicy-potato), [RogueWinRM](https://github.com/antonioCoco/RogueWinRM) (which requires winrm to be disabled), [SweetPotato](https://github.com/CCob/SweetPotato), and [PrintSpoofer](https://github.com/itm4n/PrintSpoofer).
+This privilege allows a process to impersonate (but not create) a token when it can obtain a handle to that token. A privileged token can be acquired from a Windows service (DCOM) by inducing it to perform NTLM authentication against an exploit, subsequently enabling execution of a process with SYSTEM privileges.<sup>[[2]](#references)</sup> This primitive can be exploited using tools such as [JuicyPotato](https://github.com/ohpe/juicy-potato), [RogueWinRM](https://github.com/antonioCoco/RogueWinRM) (which requires WinRM to be disabled), [SweetPotato](https://github.com/CCob/SweetPotato), and [PrintSpoofer](https://github.com/itm4n/PrintSpoofer).
 
 Modern operator notes:
 
@@ -96,7 +96,7 @@ SeCreateTokenPrivilege is a powerful permission, especially useful when a user p
 
 ### SeLoadDriverPrivilege
 
-This privilege allows to **load and unload device drivers** with the creation of a registry entry with specific values for `ImagePath` and `Type`. Since direct write access to `HKLM` (HKEY_LOCAL_MACHINE) is restricted, `HKCU` (HKEY_CURRENT_USER) must be utilized instead. However, to make `HKCU` recognizable to the kernel for driver configuration, a specific path must be followed.<sup>[[2]](#references)</sup>
+This privilege allows a process to **load and unload device drivers** by creating a registry entry with specific `ImagePath` and `Type` values. Since direct write access to `HKLM` (HKEY_LOCAL_MACHINE) is restricted, `HKCU` (HKEY_CURRENT_USER) can be used instead. However, a specific path is required to make the `HKCU` entry recognizable to the kernel as a driver configuration.<sup>[[2]](#references)</sup>
 
 Modern offensive use is usually **BYOVD** (bring your own vulnerable driver): load a **signed but vulnerable** kernel driver and then use its IOCTLs to disable protections or jump to kernel code execution. Keep in mind that on recent Windows 11/Server builds the **Microsoft vulnerable driver blocklist** and/or **HVCI/Memory Integrity** often break older public chains, so the classic `szkg64.sys`-style examples are no longer universally reliable.
 
@@ -128,7 +128,7 @@ More ways to abuse this privilege in [https://www.ired.team/offensive-security-e
 
 ### SeTakeOwnershipPrivilege
 
-This is similar to to **SeRestorePrivilege**. Its primary function allows a process to **assume ownership of an object**, circumventing the requirement for explicit discretionary access through the provision of WRITE_OWNER access rights. The process involves first securing ownership of the intended registry key for writing purposes, then altering the DACL to enable write operations.<sup>[[2]](#references)</sup>
+This is similar to **SeRestorePrivilege**. Its primary function allows a process to **assume ownership of an object**, circumventing the requirement for explicit discretionary access through the provision of WRITE_OWNER access rights. The process involves first securing ownership of the intended registry key for writing purposes, then altering the DACL to enable write operations.<sup>[[2]](#references)</sup>
 
 ```bash
 takeown /f 'C:\some\file.txt' #Now the file is owned by you

--- a/src/windows-hardening/windows-local-privilege-escalation/privilege-escalation-with-autorun-binaries.md
+++ b/src/windows-hardening/windows-local-privilege-escalation/privilege-escalation-with-autorun-binaries.md
@@ -15,12 +15,12 @@ Get-CimInstance Win32_StartupCommand | select Name, command, Location, User | fl
 
 ## Scheduled Tasks
 
-**Tasks** can be schedules to run with **certain frequency**. See which binaries are scheduled to run with:
+**Tasks** can be scheduled to run at a **specific frequency**. Use the following commands to see which binaries are scheduled to run:
 
 ```bash
 schtasks /query /fo TABLE /nh | findstr /v /i "disable deshab"
 schtasks /query /fo LIST 2>nul | findstr TaskName
-schtasks /query /fo LIST /v > schtasks.txt; cat schtask.txt | grep "SYSTEM\|Task To Run" | grep -B 1 SYSTEM
+schtasks /query /fo LIST /v > schtasks.txt; cat schtasks.txt | grep "SYSTEM\|Task To Run" | grep -B 1 SYSTEM
 Get-ScheduledTask | where {$_.TaskPath -notlike "\Microsoft*"} | ft TaskName,TaskPath,State
 
 #Schtask to give admin access

--- a/src/windows-hardening/windows-local-privilege-escalation/seimpersonate-from-high-to-system.md
+++ b/src/windows-hardening/windows-local-privilege-escalation/seimpersonate-from-high-to-system.md
@@ -56,7 +56,7 @@ You can inspect candidate processes and their token/ACLs with **Process Explorer
 
 ### Code
 
-The following code from [here](https://medium.com/@seemant.bisht24/understanding-and-abusing-access-tokens-part-ii-b9069f432962). It allows to **indicate a Process ID as argument** and a CMD **running as the user** of the indicated process will be run.<sup>[[3]](#references)</sup>\
+The following code comes from [this access-token article](https://medium.com/@seemant.bisht24/understanding-and-abusing-access-tokens-part-ii-b9069f432962). It accepts a **process ID as an argument** and starts a command shell **as the user** of that process.<sup>[[3]](#references)</sup>\
 Running in a High Integrity process you can **indicate the PID of a process running as System** (like `winlogon`, `wininit`) and execute a `cmd.exe` as SYSTEM.<sup>[[3]](#references)</sup>
 
 ```cpp


### PR DESCRIPTION
Audits the reserved 50-page Windows/Active Directory batch for reference structure, citation coverage, duplicate prose, technical accuracy, Markdown syntax, and grammar while preserving technical content.\n\nValidation: all 50 pages pass reference and duplicate checks; mdbook build succeeds.