### PR TITLE
Restore AD enumeration and DPAPI derivation context

### DIFF
--- a/src/windows-hardening/active-directory-methodology/README.md
+++ b/src/windows-hardening/active-directory-methodology/README.md
@@ -182,7 +182,7 @@ You might be able to **obtain** some challenge **hashes** to crack **poisoning**
 
 ### NTLM Relay
 
-Active Directory enumeration provides candidate accounts, hosts, and services that may be coerced into authenticating. Use that context to identify viable NTLM [**relay attacks**](../../generic-methodologies-and-resources/pentesting-network/spoofing-llmnr-nbt-ns-mdns-dns-and-wpad-and-relay-attacks.md#relay-attack) and potential paths into the AD environment.
+Active Directory enumeration provides usernames, email identifiers and naming patterns, candidate hosts, and services that may be coerced into authenticating. Use that context to identify viable NTLM [**relay attacks**](../../generic-methodologies-and-resources/pentesting-network/spoofing-llmnr-nbt-ns-mdns-dns-and-wpad-and-relay-attacks.md#relay-attack) and potential paths into the AD environment.
 
 ### NetExec workspace-driven recon & relay posture checks
 

--- a/src/windows-hardening/windows-local-privilege-escalation/dpapi-extracting-passwords.md
+++ b/src/windows-hardening/windows-local-privilege-escalation/dpapi-extracting-passwords.md
@@ -14,7 +14,7 @@ These functions also accept an optional **entropy parameter** used during encryp
 
 ### Users key generation
 
-DPAPI derives a user-specific value (often called a **pre-key**) from the user's credentials. The exact derivation depends on the account and operating-system version; for domain users, tooling can derive the needed value from the user's NTLM material.<sup>[[2]](#references)</sup>
+DPAPI derives a user-specific value (often called a **pre-key**) from the user's credentials. The exact derivation depends on the account and operating-system version. For example, Impacket tries an HMAC-SHA1 path based on the SHA-1 digest of the UTF-16LE password, another based on the password's MD4/NT hash, and a PBKDF2-SHA256-derived path for Protected Users. This is why offline tooling can often derive the required material from either the plaintext password or an available NT hash.<sup>[[2]](#references)[[10]](#references)</sup>
 
 This is specially interesting because if an attacker can obtain the user's password hash, they can:
 


### PR DESCRIPTION
Third semantic preservation audit of PR #2669. Restores email/naming-pattern value in AD enumeration and replaces the former oversimplified SHA-1 DPAPI statement with the concrete SHA-1, MD4/NT-hash, and Protected Users derivation paths implemented by Impacket.\n\nAll 50 pages pass citation, reference, duplicate, banner, fence, spelling, and diff checks. The full build had already passed after PR #2670; this run reached an unrelated external-reference network stall in the repository preprocessor.