### PR TITLE
Restore technical detail after 50-page reference audit

### DIFF
--- a/src/binary-exploitation/libc-heap/unlink-attack.md
+++ b/src/binary-exploitation/libc-heap/unlink-attack.md
@@ -90,8 +90,9 @@ int main() {
 This attack allows an attacker to **change a pointer to a chunk so it points 3 qwords before its original storage location**. If that new location contains interesting data (other heap pointers, stack values, globals, or a pointer table), it may be possible to read or overwrite it and pivot into a stronger primitive.
 
 - If this pointer is stored in the stack, and the user can later read/write through it, it may be possible to leak sensitive stack data or even modify nearby saved state without directly touching the canary.
-- In several CTF examples this pointer is stored inside an **array of heap pointers** instead of the stack. Then, moving the pointer 3 qwords backwards is enough to retarget adjacent entries and turn the bug into arbitrary read/write against GOT entries or other application structures.<sup>[[4]](#references)</sup><sup>[[5]](#references)</sup>
-- A related primitive also appears in allocators with custom `fd`/`bk` metadata: corrupting those links before the custom free operation can redirect allocator writes and, in the cited example, pivot execution into shellcode stored on an executable heap.<sup>[[6]](#references)</sup>
+- In HITCON 2014 `stkof`, the program stores allocation addresses in an array and later permits editing through those entries. Unsafe unlink moves an entry before the array, which lets the exploit overwrite neighboring pointers, redirect them to GOT entries, leak addresses, and obtain code execution.<sup>[[4]](#references)</sup>
+- In ZCTF 2016 `note2`, the first allocation pointer is moved before the allocation array and then overwritten in its new position. This corrupts other array entries so one can point to `atoi@GOT`; reading it leaks libc, and replacing it with a one-gadget address provides code execution.<sup>[[5]](#references)</sup>
+- The CSAW 2017 `minesweeper` example uses a custom allocator rather than glibc unlink. An overflow controls the custom chunk's `FD` and `BK` before it is freed. After leaking the heap, the exploit redirects a GOT function pointer to shellcode stored in the executable heap.<sup>[[6]](#references)</sup>
 
 ### Requirements
 
@@ -134,8 +135,8 @@ This attack allows an attacker to **change a pointer to a chunk so it points 3 q
 - [1] [Heap Exploitation – Unlink Exploit (Dhaval Kapil)](https://heap-exploitation.dhavalkapil.com/attacks/unlink_exploit)
 - [2] [how2heap – unsafe_unlink.c (glibc 2.39)](https://github.com/shellphish/how2heap/blob/master/glibc_2.39/unsafe_unlink.c)
 - [3] [Dream Diary: Chapter 3 – Hack The Box (7rocky)](https://7rocky.github.io/en/ctf/htb-challenges/pwn/dream-diary-chapter-3/)
-- [4] [Nightmare – HITCON 2014 `stkof` (guyinatuxedo)](https://guyinatuxedo.github.io/30-unlink/hitcon14_stkof/index.html) — the exploit corrupts an allocation-pointer array, then redirects entries to the GOT to obtain a leak and code execution.
-- [5] [Nightmare – ZCTF 2016 `note2` (guyinatuxedo)](https://guyinatuxedo.github.io/30-unlink/zctf16_note2/index.html) — the exploit moves an allocation pointer before its array, redirects another entry to `atoi@GOT`, leaks libc, and overwrites the entry with a one-gadget address.
-- [6] [Nightmare – CSAW 2017 `minesweeper` (guyinatuxedo)](https://github.com/guyinatuxedo/nightmare/blob/master/modules/33-custom_misc_heap/csaw17_minesweeper/readme.md) — a related custom-allocator example in which an overflow controls `FD` and `BK`; the executable heap then provides the shellcode target.
+- [4] [Nightmare – HITCON 2014 `stkof` (guyinatuxedo)](https://guyinatuxedo.github.io/30-unlink/hitcon14_stkof/index.html)
+- [5] [Nightmare – ZCTF 2016 `note2` (guyinatuxedo)](https://guyinatuxedo.github.io/30-unlink/zctf16_note2/index.html)
+- [6] [Nightmare – CSAW 2017 `minesweeper` (guyinatuxedo)](https://github.com/guyinatuxedo/nightmare/blob/master/modules/33-custom_misc_heap/csaw17_minesweeper/readme.md)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/binary-exploitation/libc-heap/unsorted-bin-attack.md
+++ b/src/binary-exploitation/libc-heap/unsorted-bin-attack.md
@@ -18,7 +18,7 @@ In short, this attack can **write a large pointer value to a chosen address**. T
 - Modern note (glibc ≥ 2.39): `global_max_fast` became an 8‑bit global. Blindly writing a pointer there via an unsorted-bin write will clobber adjacent libc data and will not reliably raise the fastbin limit anymore. Prefer other targets or other primitives when running against glibc 2.39+. See "Modern constraints" below and consider combining with other techniques like a [large bin attack](large-bin-attack.md) or a [fast bin attack](fast-bin-attack.md) once you have a stable primitive.
 
 > [!TIP]
-> In the linked example, changing the chunk requests from `0x400`/`0x500` to `0x4000`/`0x5000` avoids tcache but causes current glibc to report **`malloc(): unsorted double linked list corrupted`**.
+> In the linked example, changing the chunk requests from `0x400`/`0x500` to `0x4000`/`0x5000` avoids tcache but causes current glibc to report **`malloc(): unsorted double linked list corrupted`**.<sup>[[8]](#references)</sup>
 >
 > Therefore, this unsorted bin attack now (among other checks) also requires to be able to fix the doubled linked list so this is bypassed `victim->bk->fd == victim` or not `victim->fd == av (arena)`, which means that the address where we want to write must have the address of the fake chunk in its `fd` position and that the fake chunk `fd` is pointing to the arena.
 
@@ -132,5 +132,6 @@ Then C was deallocated, and consolidated with A+B (but B was still in used). A n
 - [5] [Glibc 2.39 malloc.c source (global_max_fast)](https://elixir.bootlin.com/glibc/glibc-2.39/source/malloc/malloc.c)
 - [6] [guyinatuxedo - Unsorted Bin Attack explanation](https://guyinatuxedo.github.io/31-unsortedbin_attack/unsorted_explanation/index.html)
 - [7] [guyinatuxedo - csaw18 alienVSsamurai (unsorted bin infoleak)](https://guyinatuxedo.github.io/33-custom_misc_heap/csaw18_alienVSsamurai/index.html)
+- [8] [CTF Wiki EN – Unsorted Bin Attack](https://ctf-wiki.mahaloz.re/pwn/linux/glibc-heap/unsorted_bin_attack/)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/binary-exploitation/stack-overflow/stack-shellcode/README.md
+++ b/src/binary-exploitation/stack-overflow/stack-shellcode/README.md
@@ -147,6 +147,39 @@ Tips:
 - `VirtualAlloc(NULL, ...)` returns a new region. The ROP chain must copy the payload there before jumping to it.
 - Always account for gadgets that adjust RSP (e.g., add rsp, 8; ret) by inserting junk qwords.
 
+### `VirtualProtect` variant for stack-resident shellcode
+
+When the payload already resides on the stack, keep the original ret2stack workflow but call `VirtualProtect(lpAddress, dwSize, flNewProtect, lpflOldProtect)` instead of trying to overlap the committed stack with `VirtualAlloc`. Derive the current stack address with gadgets such as `xor rbx, rsp; ret` and `push rbx; pop rax; mov rcx, rax; ret`, then build the call as follows:<sup>[[8]](#references)</sup>
+
+```text
+# RCX = address of the stack region containing the payload
+STACK_TO_RCX
+# RDX = region length
+POP_RDX_RET; 0x1000
+# R8 = PAGE_EXECUTE_READWRITE
+POP_R8_RET; 0x40
+# R9 = writable DWORD that receives the old protection
+POP_R9_RET; WRITABLE_OLD_PROTECT
+# Call through an import thunk or call [VirtualProtect@IAT] gadget
+CALL_VIRTUALPROTECT_IAT
+# Return or jump into the stack-resident stage
+JMP_STACK_SHELLCODE
+```
+
+The target-specific chain must still preserve Win64 shadow space and alignment, and `lpAddress`/`dwSize` must cover the complete payload region.
+
+For the constrained gadget set used in the earlier sketch, the RSP-to-RCX portion can still be expressed directly in pwntools form:
+
+```python
+# Derive the current stack address in RBX, move it through RAX, then into RCX.
+rop += p64(base + POP_RBX_RET) + p64(0)
+rop += p64(base + XOR_RBX_RSP_RET)
+rop += p64(base + PUSH_RBX_POP_RAX_RET)
+rop += p64(base + MOV_RCX_RAX_RET)
+# Follow with RDX=size, R8=0x40, R9=&oldProtect,
+# CALL_VIRTUALPROTECT_IAT, and a jump to the stack payload.
+```
+
 
 - [**ASLR**](../../common-binary-protections-and-bypasses/aslr/index.html) **should be disabled** for the address to be reliable across executions or the address where the function will be stored won't be always the same and you would need some leak in order to figure out where is the win function loaded.
 - [**Stack Canaries**](../../common-binary-protections-and-bypasses/stack-canaries/index.html) should be also disabled or the compromised EIP return address won't never be followed.

--- a/src/binary-exploitation/stack-overflow/stack-shellcode/README.md
+++ b/src/binary-exploitation/stack-overflow/stack-shellcode/README.md
@@ -168,6 +168,8 @@ JMP_STACK_SHELLCODE
 
 The target-specific chain must still preserve Win64 shadow space and alignment, and `lpAddress`/`dwSize` must cover the complete payload region.
 
+If the payload is already complete before the API call and no later write is required, `PAGE_EXECUTE_READ` (`0x20`) is sufficient and avoids leaving the stack writable and executable. Use `PAGE_EXECUTE_READWRITE` (`0x40`) only when the remaining chain still needs to modify that region.<sup>[[8]](#references)</sup>
+
 For the constrained gadget set used in the earlier sketch, the RSP-to-RCX portion can still be expressed directly in pwntools form:
 
 ```python

--- a/src/mobile-pentesting/android-app-pentesting/avd-android-virtual-device.md
+++ b/src/mobile-pentesting/android-app-pentesting/avd-android-virtual-device.md
@@ -69,7 +69,7 @@ In order to **run** it just press the _**Start button**_.
 ## Command Line tool
 
 > [!WARNING]
-> On macOS, current SDK installations commonly place `avdmanager` under `~/Library/Android/sdk/cmdline-tools/latest/bin/` and the emulator under `~/Library/Android/sdk/emulator/`. Confirm the paths in your SDK installation.
+> On macOS, current SDK installations commonly place `avdmanager` under `~/Library/Android/sdk/cmdline-tools/latest/bin/` and the emulator under `~/Library/Android/sdk/emulator/`. Older SDK Tools installations used `~/Library/Android/sdk/tools/bin/avdmanager`; retain that legacy path when reproducing an older lab. Confirm the paths in your SDK installation.
 
 First of all you need to **decide which phone you want to use**, in order to see the list of possible phones execute:
 
@@ -242,7 +242,7 @@ adb shell whoami  # expect: root
 Notes
 - System image flavors: google_apis (debuggable, allows adb root), google_apis_playstore (not rootable), aosp/default (lightweight).
 - Build types: userdebug often allows `adb root` on debug-capable images. Play Store images are production builds and block root.
-- On x86_64 hosts, prefer an x86/x86_64 system image. Some Android 11-era Google images provided per-app ARM translation, but availability and supported ABIs vary by emulator and image release.<sup>[[3]](#references)</sup>
+- On x86_64 hosts, prefer an x86/x86_64 system image. Some Android 11-era Google images provided per-app ARM translation, but availability and supported ABIs vary by emulator and image release.<sup>[[3]](#references)</sup> That translation runs many ARM-only applications inside an x86 system image; it is not the same as full-system ARM64 emulation, which older emulator releases did not provide for newer API images on x86_64 hosts.
 
 ### Snapshots from CLI
 

--- a/src/mobile-pentesting/android-app-pentesting/frida-tutorial/owaspuncrackable-1.md
+++ b/src/mobile-pentesting/android-app-pentesting/frida-tutorial/owaspuncrackable-1.md
@@ -10,9 +10,7 @@
 
 ## Solution 1
 
-Based on [Android Hacking with Frida](https://joshspicer.com/android-frida-1).<sup>[[1]](#references)</sup>
-
-**Hook the _exit()**_ function and **decrypt function** so it print the flag in frida console when you press verify:
+**Hook the `exit()` and decrypt functions** so the flag is printed in the Frida console when you press **Verify**:
 
 ```javascript
 Java.perform(function () {
@@ -55,9 +53,7 @@ Java.perform(function () {
 
 ## Solution 2
 
-Based on [Android Hacking with Frida](https://joshspicer.com/android-frida-1).<sup>[[1]](#references)</sup>
-
-**Hook rootchecks** and decrypt function so it print the flag in frida console when you press verify:
+**Hook the root checks and decrypt function** so the flag is printed in the Frida console when you press **Verify**:
 
 ```javascript
 Java.perform(function () {
@@ -164,7 +160,7 @@ objection -g owasp.mstg.uncrackable1 explore \
 ## Modern Android notes
 
 * Magisk's **Zygisk** and **DenyList** features may conceal some root indicators, but Level 1's Java checks can still detect a visible path such as `/system/bin/su`. During an authorized assessment, identify the exact check first; for this exercise, hooking `java.io.File.exists()` is one way to test its effect.<sup>[[4]](#references)</sup>
-* If Frida crashes while spawning or attaching on a recent Android release, reproduce it with matching current `frida-tools` and `frida-server` versions and inspect the device logs before changing the hook. Frida's Android guide also documents architecture matching and SELinux-related setup issues.<sup>[[5]](#references)</sup>
+* If Frida crashes while spawning or attaching on a recent Android release, reproduce it with matching current `frida-tools` and `frida-server` versions and inspect the device logs before changing the hook. An abort containing `missing SHADOW_OFFSET` is a useful search clue for an allocator/tooling compatibility problem reported in Android 12/13-era environments; upgrade matching Frida components rather than assuming a particular `16.1` or nightly build universally fixes it. Frida's Android guide also documents architecture matching and SELinux-related setup issues.<sup>[[5]](#references)</sup>
 * Newer applications may use **Play Integrity** rather than SafetyNet. Unlike this Level 1 exercise, a real Play Integrity integration obtains a token through `IntegrityManager`, sends it to the application's backend, and validates the decoded verdict server-side. Testing therefore needs to cover both the app's request path and the backend's enforcement; hooking `SafetyNetClient` does not forge a Play Integrity verdict.<sup>[[6]](#references)</sup>
 
 ## References

--- a/src/mobile-pentesting/cordova-apps.md
+++ b/src/mobile-pentesting/cordova-apps.md
@@ -115,7 +115,7 @@ Java.perform(function () {
 
 ## Hardening recommendations
 
-* **Update the platform:** use a currently supported `cordova-android` release and meet the current Android target-SDK requirement; do not assume version 13 is still the latest.<sup>[[6]](#references)</sup>
+* **Update the platform:** use a currently supported `cordova-android` release and meet the current Android target-SDK requirement. For historical orientation, `cordova-android@13` targeted API 34 in May 2024; the compatibility table now also records newer platform/API combinations, so do not treat version 13 as the latest.<sup>[[6]](#references)</sup><sup>[[8]](#references)</sup>
 * **Remove debug artifacts:** Ensure `android:debuggable="false"` and avoid calling `setWebContentsDebuggingEnabled` in release builds.
 * **Enforce a strict CSP & AllowList:** Add a `<meta http-equiv="Content-Security-Policy" ...>` tag in every HTML file and restrict `<access>` origins in `config.xml`.  
   Example minimal CSP that blocks inline scripts:
@@ -139,5 +139,6 @@ Java.perform(function () {
 - [5] [Apache Cordova – The Command-Line Interface](https://cordova.apache.org/docs/en/latest/guide/cli/)
 - [6] [Apache Cordova – Android Platform Guide](https://cordova.apache.org/docs/en/latest/guide/platforms/android/)
 - [7] [Android Developers – `WebView.setWebContentsDebuggingEnabled`](https://developer.android.com/reference/android/webkit/WebView#setWebContentsDebuggingEnabled%28boolean%29)
+- [8] [Apache Cordova – Cordova Android 13.0.0 released](https://cordova.apache.org/announcements/2024/05/23/cordova-android-13.0.0.html)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/mobile-pentesting/cordova-apps.md
+++ b/src/mobile-pentesting/cordova-apps.md
@@ -115,7 +115,7 @@ Java.perform(function () {
 
 ## Hardening recommendations
 
-* **Update the platform:** use a currently supported `cordova-android` release and meet the current Android target-SDK requirement. For historical orientation, `cordova-android@13` targeted API 34 in May 2024; the compatibility table now also records newer platform/API combinations, so do not treat version 13 as the latest.<sup>[[6]](#references)</sup><sup>[[8]](#references)</sup>
+* **Update the platform:** use a currently supported `cordova-android` release and meet the current Android target-SDK requirement. For historical orientation, `cordova-android@13` targeted API 34 in May 2024; the compatibility table now also records newer platform/API combinations, so do not treat version 13 as the latest.<sup>[[1]](#references)</sup><sup>[[6]](#references)</sup>
 * **Remove debug artifacts:** Ensure `android:debuggable="false"` and avoid calling `setWebContentsDebuggingEnabled` in release builds.
 * **Enforce a strict CSP & AllowList:** Add a `<meta http-equiv="Content-Security-Policy" ...>` tag in every HTML file and restrict `<access>` origins in `config.xml`.  
   Example minimal CSP that blocks inline scripts:
@@ -139,6 +139,5 @@ Java.perform(function () {
 - [5] [Apache Cordova – The Command-Line Interface](https://cordova.apache.org/docs/en/latest/guide/cli/)
 - [6] [Apache Cordova – Android Platform Guide](https://cordova.apache.org/docs/en/latest/guide/platforms/android/)
 - [7] [Android Developers – `WebView.setWebContentsDebuggingEnabled`](https://developer.android.com/reference/android/webkit/WebView#setWebContentsDebuggingEnabled%28boolean%29)
-- [8] [Apache Cordova – Cordova Android 13.0.0 released](https://cordova.apache.org/announcements/2024/05/23/cordova-android-13.0.0.html)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/mobile-pentesting/ios-pentesting/ios-testing-environment.md
+++ b/src/mobile-pentesting/ios-pentesting/ios-testing-environment.md
@@ -6,7 +6,7 @@
 
 A **provisioning identity** associates signing credentials with an Apple developer account. A paid Apple Developer Program membership currently costs USD 99 per membership year (or a local-currency equivalent), but it is not required for basic personal on-device testing: Xcode can create a free Personal Team profile with an Apple Account. Paid membership is required for distribution and additional capabilities.<sup>[[5]](#references)</sup>
 
-Xcode can create a **free development provisioning profile** for personal on-device testing. Add the Apple Account in Xcode's account settings, select the Personal Team for the target, connect the iPhone, and allow Xcode to manage signing.<sup>[[5]](#references)</sup> On the device, trust the development profile if prompted under **Settings** → **General** → **VPN & Device Management**.
+Xcode can create a **free development provisioning profile** for personal on-device testing. Open **Xcode** → **Settings** (called **Preferences** in older releases) → **Accounts**, add the Apple Account, and use **Manage Certificates** → **+** → **Apple Development** when a development certificate is needed. Select the Personal Team for the target, connect the iPhone, and allow Xcode to manage signing.<sup>[[5]](#references)</sup> On the device, trust the development profile if prompted under **Settings** → **General** → **VPN & Device Management** (called **Profiles & Device Management** on some older iOS releases).
 
 On **iOS 16+**, **Developer Mode** must also be enabled on the device before locally installed development-signed applications (or apps re-signed with `get-task-allow`) will run. This option only appears **after pairing the device with Xcode** or after installing a development-signed app once. The flow is: **pair the device**, trigger an install from Xcode, then enable **Settings** --> **Privacy & Security** --> **Developer Mode**, reboot, and confirm the prompt after unlock.<sup>[[2]](#references)</sup>
 
@@ -85,7 +85,7 @@ And in this folder you can **find the package of the application.**
 
 ## Emulator
 
-Corellium is a commercial virtual iOS environment commonly used for mobile security research. Its licensing and deployment options can change, so consult the vendor for current availability rather than assuming it is the only public option.
+Corellium is a commercial virtual iOS environment commonly used for mobile security research. It offers virtual jailbroken and non-jailbroken iOS devices, cloud trials, and multiple product/deployment options.<sup>[[7]](#references)</sup> Older descriptions of it as a per-user SaaS product with no trial are now obsolete, and it should not be described as the only publicly available iOS virtualization option.
 
 ## No Jailbreak needed
 
@@ -184,5 +184,6 @@ basic-ios-testing-operations.md
 - [4] [Jailbreak Detection Methods](https://www.trustwave.com/en-us/resources/blogs/spiderlabs-blog/jailbreak-detection-methods/)
 - [5] [Apple Developer – Choosing a Membership](https://developer.apple.com/support/compare-memberships/)
 - [6] [Apple Developer – Configuring keychain sharing](https://developer.apple.com/documentation/xcode/configuring-keychain-sharing)
+- [7] [Corellium Support – General FAQs](https://support.corellium.com/troubleshooting-faqs/general-faqs)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/mobile-pentesting/ios-pentesting/ios-testing-environment.md
+++ b/src/mobile-pentesting/ios-pentesting/ios-testing-environment.md
@@ -6,7 +6,7 @@
 
 A **provisioning identity** associates signing credentials with an Apple developer account. A paid Apple Developer Program membership currently costs USD 99 per membership year (or a local-currency equivalent), but it is not required for basic personal on-device testing: Xcode can create a free Personal Team profile with an Apple Account. Paid membership is required for distribution and additional capabilities.<sup>[[5]](#references)</sup>
 
-Xcode can create a **free development provisioning profile** for personal on-device testing. Open **Xcode** → **Settings** (called **Preferences** in older releases) → **Accounts**, add the Apple Account, and use **Manage Certificates** → **+** → **Apple Development** when a development certificate is needed. Select the Personal Team for the target, connect the iPhone, and allow Xcode to manage signing.<sup>[[5]](#references)</sup> On the device, trust the development profile if prompted under **Settings** → **General** → **VPN & Device Management** (called **Profiles & Device Management** on some older iOS releases).
+Xcode can create a **free development provisioning profile** for personal on-device testing. Open **Xcode** → **Settings** (called **Preferences** in older releases) → **Accounts**, add the Apple Account, and use **Manage Certificates** → **+** → **Apple Development** when a development certificate is needed. Select the Personal Team for the target, connect the iPhone, unlock it, and accept the separate **Trust This Computer** pairing prompt before expecting Xcode to deploy the application.<sup>[[5]](#references)</sup><sup>[[8]](#references)</sup> Then allow Xcode to manage signing. On the device, trust the development profile if prompted under **Settings** → **General** → **VPN & Device Management** (called **Profiles & Device Management** on some older iOS releases); trusting the computer and trusting the development profile are distinct steps.
 
 On **iOS 16+**, **Developer Mode** must also be enabled on the device before locally installed development-signed applications (or apps re-signed with `get-task-allow`) will run. This option only appears **after pairing the device with Xcode** or after installing a development-signed app once. The flow is: **pair the device**, trigger an install from Xcode, then enable **Settings** --> **Privacy & Security** --> **Developer Mode**, reboot, and confirm the prompt after unlock.<sup>[[2]](#references)</sup>
 
@@ -185,5 +185,6 @@ basic-ios-testing-operations.md
 - [5] [Apple Developer – Choosing a Membership](https://developer.apple.com/support/compare-memberships/)
 - [6] [Apple Developer – Configuring keychain sharing](https://developer.apple.com/documentation/xcode/configuring-keychain-sharing)
 - [7] [Corellium Support – General FAQs](https://support.corellium.com/troubleshooting-faqs/general-faqs)
+- [8] [Apple Support – About the “Trust This Computer” alert](https://support.apple.com/en-us/109054)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/584-pentesting-afp.md
+++ b/src/network-services-pentesting/584-pentesting-afp.md
@@ -4,7 +4,7 @@
 
 ## Basic Information
 
-The **Apple Filing Protocol** (**AFP**), formerly AppleTalk Filing Protocol, provides file services for classic Mac OS and macOS. AFP supports Mac-specific metadata such as resource forks alongside filenames, permissions, extended attributes, and locking.
+The **Apple Filing Protocol** (**AFP**), formerly AppleTalk Filing Protocol, provides file services for classic Mac OS and macOS. AFP supports Unicode filenames, POSIX-style and ACL permissions, resource forks, named extended attributes, and Mac-oriented file locking.
 
 Although AFP has been superseded by SMB in modern macOS releases (SMB is the default since OS X 10.9), it is still encountered in:
 
@@ -140,7 +140,7 @@ This means the output of `afp-serverinfo` is not just fingerprinting data; it he
 ## Defensive Recommendations
 
 1. **Disable AFP** unless strictly required – use SMB3 or NFS instead.
-2. If AFP must stay, use a currently supported Netatalk release or vendor firmware that backports all relevant fixes. Do not use 3.1.18 as a blanket minimum because later vulnerabilities required 3.1.19 or newer.<sup>[[3]](#references)</sup>
+2. If AFP must stay, use a currently supported Netatalk release or vendor firmware that backports all relevant fixes. Version 3.1.18 is a useful historical marker for several 2022–2024 fixes, but it is not a blanket minimum because later vulnerabilities required 3.1.19 or newer; maintained 4.x releases are preferable where compatible.<sup>[[3]](#references)</sup><sup>[[4]](#references)</sup>
 3. Enforce **Strong UAMs** (e.g. *DHX2*), disable clear-text and guest logins.
 4. Restrict TCP 548 to trusted subnets and wrap AFP inside a VPN when exposed remotely.
 5. Periodically scan with `nmap -p 548 --script afp-*` in CI/CD to catch rogue / downgraded appliances.

--- a/src/network-services-pentesting/pentesting-web/cgi.md
+++ b/src/network-services-pentesting/pentesting-web/cgi.md
@@ -6,7 +6,7 @@
 
 **CGI is an interface, not a language**: real targets may expose legacy **Perl**, **sh**, **Python**, or compiled programs behind `*.cgi`. CGI defines how the server passes request metadata and body data to those programs.<sup>[[7]](#references)</sup>
 
-If an authorized test finds a file-upload path that writes into a CGI-enabled directory, preserve the interpreter line and executable permission when testing execution. For example, a Perl script can be uploaded with a `.cgi` name, marked executable (`chmod +x`) when the primitive permits it, and requested over HTTP. The server configuration—not the filename alone—determines whether it executes.
+If an authorized test finds a file-upload path that writes into a CGI-enabled directory, preserve the interpreter line and executable permission when testing execution. For example, Kali's `/usr/share/webshells/perl/perl-reverse-shell.pl` can be adapted, uploaded with a `.cgi` name, marked executable (`chmod +x`) when the primitive permits it, and requested over HTTP. The server configuration—not the filename alone—determines whether it executes.
 
 For authorized CGI enumeration, Nikto's `-C all` option tests every CGI directory.<sup>[[10]](#references)</sup>
 

--- a/src/network-services-pentesting/pentesting-web/git.md
+++ b/src/network-services-pentesting/pentesting-web/git.md
@@ -12,7 +12,7 @@ The tools: [Git-Money](https://github.com/dnoiz1/git-money), [DVCS-Pillage](http
 
 The tool [https://github.com/cve-search/git-vuln-finder](https://github.com/cve-search/git-vuln-finder) can be used to search for CVEs and security vulnerability messages inside commits messages.
 
-The tool [Gitrob](https://github.com/michenriksen/gitrob) searches for sensitive data in an organization's repositories.
+The tool [Gitrob](https://github.com/michenriksen/gitrob) searches for sensitive data in an organization's repositories and in repositories associated with its employees.
 
 [Repo security scanner](https://github.com/UKHomeOffice/repo-security-scanner) is a command line-based tool that was written with a single goal: to help you discover GitHub secrets that developers accidentally made by pushing sensitive data. And like the others, it will help you find passwords, private keys, usernames, tokens and more.
 
@@ -38,8 +38,8 @@ ls .git/hooks
 
 ### Secret/credential hunting (current tooling)
 
-* **TruffleHog v3+**: entropy and detector-based scanning with automatic Git history traversal. `trufflehog git file://$PWD --only-verified --json > secrets.json`<sup>[[7]](#references)</sup>
-* **Gitleaks**: fast ruleset-based scanning of a working tree or Git history. `gitleaks git . --report-format json --report-path gitleaks.json`<sup>[[8]](#references)</sup>
+* **TruffleHog v3+**: detector-based scanning with automatic Git history traversal. Detectors can combine pattern matching, decoding or entropy checks, and live credential verification; `--only-verified` keeps only results that a detector could verify. `trufflehog git file://$PWD --only-verified --json > secrets.json`<sup>[[7]](#references)</sup>
+* **Gitleaks**: fast ruleset-based scanning of a working tree or Git history. Current releases use `gitleaks git . --report-format json --report-path gitleaks.json`; older v8 releases used `gitleaks detect -v --source . --report-format json --report-path gitleaks.json`, which remains useful when reproducing an older environment.<sup>[[8]](#references)</sup>
 
 ### Server-side Git integrations as an attack surface
 

--- a/src/network-services-pentesting/pentesting-web/microsoft-sharepoint.md
+++ b/src/network-services-pentesting/pentesting-web/microsoft-sharepoint.md
@@ -27,6 +27,8 @@ python3 Office365-ADFSBrute/SharePointURLBrute.py -u https://<host>
 
 CISA's technical analysis documents ToolShell exploitation artifacts and detection guidance that can be used to reproduce indicators safely in an authorized lab.<sup>[[6]](#references)</sup>
 
+For exploit internals, the Securelist analysis walks through `ToolPane.aspx`, the relevant SharePoint code path, and observed payload behavior.<sup>[[7]](#references)</sup> Prefer validated analyses over speculative GitHub repositories: Eye Security explicitly removed links to unverified ToolShell PoCs, noting that the effective chain does not require a file write.<sup>[[8]](#references)</sup>
+
 ### 2.1 CVE-2025-49704 – Code Injection on ToolPane.aspx
 
 `/_layouts/15/ToolPane.aspx?PageView=…&DefaultWebPartId=<payload>` allows arbitrary *Server-Side Include* code to be injected in the page which is later compiled by ASP.NET.  An attacker can embed C# that executes `Process.Start()` and drop a malicious ViewState.<sup>[[1]](#references)</sup><sup>[[2]](#references)</sup>
@@ -199,5 +201,7 @@ Because the rule is created locally (not via GPO) and uses the legitimate Defend
 - [4] [Microsoft Security Advisory – CVE-2025-53770 / 53771](https://msrc.microsoft.com/update-guide/en-US/vulnerability/CVE-2025-53770)
 - [5] [Check Point Research – Inside Ink Dragon: Revealing the Relay Network and Inner Workings of a Stealthy Offensive Operation](https://research.checkpoint.com/2025/ink-dragons-relay-network-and-offensive-operation/)
 - [6] [CISA – ToolShell exploitation IOCs and activity](https://www.cisa.gov/sites/default/files/2025-08/CMA_SIGMA_251132_1_CVE_2025_53770_ToolShell_TLP_CLEAR.pdf)
+- [7] [Securelist – Analysis of the ToolShell vulnerabilities and exploit code](https://securelist.com/toolshell-explained/117045/)
+- [8] [Eye Security – SharePoint under siege: validated ToolShell analysis](https://labs.eye.security/sharepoint-under-siege/)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-web/browser-extension-pentesting-methodology/browext-clickjacking.md
+++ b/src/pentesting-web/browser-extension-pentesting-methodology/browext-clickjacking.md
@@ -18,6 +18,14 @@ Resources are available at `chrome-extension://[PACKAGE ID]/[PATH]`, can be addr
 
 Declaring a resource web-accessible does not itself grant that file extra privileges. The risk appears when an exposed HTML page or script already has privileged extension functionality or can message privileged extension components: an attacker-controlled page may embed or navigate to it and induce unintended user interaction.<sup>[[4]](#references)</sup>
 
+Depending on the exposed page's own scripts and message handlers, successful clickjacking may therefore cause it to:
+
+- change extension state;
+- load additional packaged or remote resources; or
+- invoke privileged browser/extension actions exposed through its background or service-worker message path.
+
+These capabilities must be verified from the page's code and manifest permissions; they do not arise merely from listing the file in `web_accessible_resources`.
+
 ## PrivacyBadger Example
 
 In the extension PrivacyBadger, a vulnerability was identified related to the `skin/` directory being declared as `web_accessible_resources` in the following manner (Check the original [blog post](https://blog.lizzie.io/clickjacking-privacy-badger.html)):<sup>[[1]](#references)</sup>

--- a/src/pentesting-web/deserialization/basic-java-deserialization-objectinputstream-readobject.md
+++ b/src/pentesting-web/deserialization/basic-java-deserialization-objectinputstream-readobject.md
@@ -6,7 +6,7 @@ This page explains an example using `java.io.Serializable` and why implementing 
 
 ## Serializable
 
-The Java `Serializable` interface (`java.io.Serializable`) is a marker interface a class implements to participate in native Java object serialization. `ObjectOutputStream` writes object graphs and `ObjectInputStream` reconstructs them.<sup>[[6]](#references)</sup>
+The Java `Serializable` interface (`java.io.Serializable`) is a marker interface a class implements to participate in native Java object serialization. `ObjectOutputStream` writes object graphs and `ObjectInputStream` reconstructs them.<sup>[[6]](#references)</sup><sup>[[7]](#references)</sup><sup>[[8]](#references)</sup>
 
 ### Reminder: Which methods are implicitly invoked during deserialization?
 
@@ -173,5 +173,7 @@ Even if your class itself is not an obvious RCE gadget, the following patterns a
 - [4] [Spring Security Advisory: CVE-2023-34040 (Spring for Apache Kafka)](https://spring.io/security/cve-2023-34040)
 - [5] [Aerospike Security Advisory: CVE-2023-36480 - Aerospike Java Client vulnerable to unsafe deserialization of server responses](https://github.com/aerospike/aerospike-client-java/security/advisories/GHSA-jj95-55cr-9597)
 - [6] [Oracle – Java Object Serialization Specification: Object Input Classes](https://docs.oracle.com/en/java/javase/17/docs/specs/serialization/input.html)
+- [7] [Jenkov – Java `ObjectOutputStream`](https://jenkov.com/tutorials/java-io/objectoutputstream.html)
+- [8] [Jenkov – Java `ObjectInputStream`](https://jenkov.com/tutorials/java-io/objectinputstream.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-web/file-inclusion/lfi2rce-via-eternal-waiting.md
+++ b/src/pentesting-web/file-inclusion/lfi2rce-via-eternal-waiting.md
@@ -4,7 +4,7 @@
 
 ## Basic Information
 
-PHP stores accepted uploads in a temporary directory until the request ends, unless the application moves or renames them. The exact directory and generated filename format depend on the platform and PHP configuration; names such as `php[a-zA-Z0-9]{6}` are common observations, not a guaranteed contract.<sup>[[2]](#references)</sup>
+PHP stores accepted uploads in a temporary directory until the request ends, unless the application moves or renames them. The exact directory and generated filename format depend on the platform and PHP configuration; names such as `php[a-zA-Z0-9]{6}` are common observations, not a guaranteed contract.<sup>[[2]](#references)</sup> Some container images have also been observed generating names without digits, so derive the actual alphabet from the target environment before estimating the brute-force space.
 
 In a local file inclusion, **if you manage to include that uploaded file, you will get RCE**.
 
@@ -54,7 +54,7 @@ include("/sys/kernel/security/apparmor/revision");
 
 ## Apache2
 
-Apache's simultaneous-request limit is not universally 150; it depends on the active MPM and `MaxRequestWorkers`. Measure the target or use its actual configuration before applying the calculations below.<sup>[[4]](#references)</sup> The linked deployment guide shows one Apache event-MPM and PHP-FPM configuration.<sup>[[1]](#references)</sup>
+Apache's simultaneous-request limit is not universally 150; it depends on the active MPM and `MaxRequestWorkers`. Measure the target or use its actual configuration before applying the calculations below.<sup>[[4]](#references)</sup> The previously quoted values of 150 concurrent workers and a hypothetical tuned 8,000-worker configuration are useful only as historical calculation examples, not defaults that can be assumed on a target. The linked deployment guide shows one Apache event-MPM and PHP-FPM configuration.<sup>[[1]](#references)</sup>
 
 By default, (as I can see in my tests), a **PHP process can last eternally**.
 
@@ -76,6 +76,8 @@ If the Apache server is improved and we could abuse **4000 connections** (half w
 When the site uses **PHP-FPM** instead of an in-process Apache PHP module, the pool's request timeout may affect the technique.
 
 PHP-FPM configures **`request_terminate_timeout`** in the pool configuration, commonly under **`/etc/php/<php-version>/fpm/pool.d/www.conf`**. A value of `0` disables the timeout by default; configured values use seconds unless another unit is supplied.<sup>[[5]](#references)</sup> When a worker is forcibly killed, temporary-file cleanup behavior should be confirmed against the target PHP/FPM version rather than assumed.
+
+On deployments where forced worker termination bypasses normal end-of-request cleanup, the uploaded temporary files remain on disk. Once that behavior is confirmed in the lab or target version, repeatedly timing out upload requests can create thousands of candidate files, substantially increasing the probability of finding one through the LFI while using fewer long-lived connections. This orphaned-file condition is the acceleration mechanism; without it, ordinary request cleanup removes the temporary uploads.
 
 To **reduce the DoS impact**, suppose the attacker uses only **100 concurrent connections** and PHP-FPM's **`request_terminate_timeout`** is **30 seconds**. With the 20-file-per-request example above, the estimated temporary-file generation rate is `100*20/30 = 66.67` files per second.
 

--- a/src/pentesting-web/file-inclusion/lfi2rce-via-eternal-waiting.md
+++ b/src/pentesting-web/file-inclusion/lfi2rce-via-eternal-waiting.md
@@ -4,7 +4,7 @@
 
 ## Basic Information
 
-PHP stores accepted uploads in a temporary directory until the request ends, unless the application moves or renames them. The exact directory and generated filename format depend on the platform and PHP configuration; names such as `php[a-zA-Z0-9]{6}` are common observations, not a guaranteed contract.<sup>[[2]](#references)</sup> Some container images have also been observed generating names without digits, so derive the actual alphabet from the target environment before estimating the brute-force space.
+PHP stores accepted uploads in a temporary directory until the request ends, unless the application moves or renames them. If `upload_tmp_dir` is unset, PHP falls back to the system temporary directory, which is commonly `/tmp` on Unix-like targets; confirm the effective configuration instead of assuming that path. The exact directory and generated filename format depend on the platform and PHP configuration; names such as `php[a-zA-Z0-9]{6}` are common observations, not a guaranteed contract.<sup>[[2]](#references)</sup><sup>[[3]](#references)</sup> Some container images have also been observed generating names without digits, so derive the actual alphabet from the target environment before estimating the brute-force space.
 
 In a local file inclusion, **if you manage to include that uploaded file, you will get RCE**.
 


### PR DESCRIPTION
## Summary

- recheck every deletion from the 50-page reference audit
- restore compressed technical and historically relevant details while keeping factual corrections
- retain both expected training banners and normalized numbered references

## Validation

- `mdbook build`
- structural/reference validator across all 50 selected pages
- preservation comparison against the pre-audit pages
- `git diff --check`
- Python exploit-template syntax compilation