### PR TITLE
Remove duplicate WordPress caution marker

### DIFF
--- a/src/network-services-pentesting/pentesting-web/wordpress.md
+++ b/src/network-services-pentesting/pentesting-web/wordpress.md
@@ -408,7 +408,6 @@ add_action( 'wp_ajax_nopriv_action_name', array(&$this, 'function_name'));
 **Registering the `wp_ajax_nopriv_` hook makes the callback reachable by unauthenticated users.**
 
 > [!CAUTION]
-> [!CAUTION]
 > `wp_verify_nonce()` validates a time-limited CSRF token associated with an action and user context; it does **not** authorize the action or simply prove that a user has a particular role. Pair nonce validation with an appropriate capability check such as `current_user_can()`.<sup>[[27]](#references)</sup>
 
 - **REST API**


### PR DESCRIPTION
Follow-up to #2681 after a fresh preservation audit of all 50 pages. No distinct technical or relevant content was missing. This removes one duplicated CAUTION marker discovered during the recheck.\n\nValidation: full mdBook build plus reference, citation, banner, fence, internal-link, duplicate-reference, duplicate-paragraph, callout, and diff checks.