### PR TITLE
Restore technical details from reference audit

### DIFF
--- a/src/network-services-pentesting/1414-pentesting-ibmmq.md
+++ b/src/network-services-pentesting/1414-pentesting-ibmmq.md
@@ -176,6 +176,8 @@ Once you know a valid `SVRCONN` channel, **punch-q** has a `discover users` mode
 ❯ sudo docker run --rm -ti leonjza/punch-q --host 172.17.0.2 --port 1414 discover users --channel DEV.ADMIN.SVRCONN
 ```
 
+IBM MQ can validate supplied identities against the local operating system or LDAP, and applications may also present service-account credentials. When choosing an explicitly approved candidate set, include documented operating-system, directory, and service-account credentials that may have been reused for MQ; do not assume reuse.<sup>[[12]](#references)</sup>
+
 A TLS error instead of authorization reason code `2035` can indicate that the candidate channel exists but requires a compatible `SSLCIPH` and possibly client-certificate material. Corroborate this because gateways can normalize errors.
 
 If the channel list shows a non-empty **SSL Cipher**, or `punch-q` says a channel "wants SSL", shift to **client-artifact looting** instead of blind spraying. IBM MQ clients can inherit channel and TLS settings from a **CCDT** (`AMQCLCHL.TAB` or JSON), `mqclient.ini`, and a key repository. Hunt for `MQCCDTURL`, `MQCHLLIB`, `MQCHLTAB`, `mqclient.ini`, `*.kdb`, `*.sth`, and `*.p12` files in application servers, CI jobs, containers, or Kubernetes Secrets. Recent IBM MQ versions also support **HTTPS-hosted CCDTs**, so a leaked `MQCCDTURL=https://...` can be enough to recover queue-manager names, channel names, hosts, ports, and TLS requirements without first touching the MQ server itself.
@@ -616,5 +618,6 @@ CONTAINER ID   IMAGE                                COMMAND                  CRE
 - [9] [Starting IBM MQ applications using triggers](https://www.ibm.com/docs/en/ibm-mq/9.4.x?topic=queuing-starting-mq-applications-using-triggers)
 - [10] [Redistributable IBM MQ clients](https://www.ibm.com/docs/en/ibm-mq/9.4.x?topic=overview-redistributable-mq-clients)
 - [11] [SensePost – Punching Messages in the Q](https://sensepost.com/blog/2018/punching-messages-in-the-q/)
+- [12] [IBM MQ - User identities in IBM MQ](https://www.ibm.com/docs/en/ibm-mq/9.4.x?topic=authentication-user-identities-in-mq)
 
 {{#include ../banners/hacktricks-training.md}}

--- a/src/network-services-pentesting/pentesting-web/ruby-tricks.md
+++ b/src/network-services-pentesting/pentesting-web/ruby-tricks.md
@@ -54,7 +54,7 @@ h = {'Content-Type': (' ' * 50_000) + 'a,'}
 requests.post('http://target/', data='x', headers=h)
 PY
   ```
-- The vulnerable parser can be reached through many Rack-based stacks, including Rails and Sinatra, subject to proxy/header-size limits. Use a controlled environment or a single low-impact request during authorized testing.
+- The vulnerable parser can be reached through many Rack-based stacks, including Rails, Sinatra, Hanami, and Grape, subject to proxy/header-size limits in frontends such as nginx or HAProxy. Use a controlled environment or a single low-impact request during authorized testing.
 - The fix makes parsing linear. Look for `rack` versions below `3.0.9.1` or `2.2.8.1`; do not assume a WAF blocks the syntactically valid header.
 
 ## REXML XML parser ReDoS (CVE-2024-49761)

--- a/src/network-services-pentesting/pentesting-web/special-http-headers.md
+++ b/src/network-services-pentesting/pentesting-web/special-http-headers.md
@@ -98,6 +98,7 @@ For more info about HTTP Request Smuggling check:
 
 ## Conditionals
 
+- **`Last-Modified`** is a response validator containing the origin server's selected modification time for the representation. Clients can send that value in `If-Modified-Since` or `If-Unmodified-Since`; coarse or synthetic timestamps and clock behavior can affect its reliability.<sup>[[8]](#references)</sup>
 - **`If-Modified-Since`** asks for the representation only if it changed after the supplied date; otherwise a successful conditional `GET`/`HEAD` normally receives `304`. **`If-Unmodified-Since`** instead requires that the resource has not changed and otherwise normally produces `412` for a state-changing request.<sup>[[8]](#references)</sup>
 - **`If-Match`** requires a current entity-tag match, while **`If-None-Match`** requires no match. For `GET`/`HEAD`, a failed `If-None-Match` condition normally returns `304`; for other methods it returns `412`.<sup>[[8]](#references)</sup>
   - Entity-tag generation is implementation-specific. For example, `W/"37-eL2g8DEyqntYlaLp5XLInBWsjWI"` is a weak validator from a particular framework; its syntax alone does not prove that the value is SHA-1 or that `37` represents a byte count.


### PR DESCRIPTION
## Summary

- restore IBM MQ operating-system, LDAP, and service-account credential-source guidance with an IBM reference
- restore Hanami/Grape and nginx/HAProxy examples in the Rack ReDoS section
- restore explicit `Last-Modified` validator behavior

## Validation

- validated reference structure and banners across all 50 audited pages
- checked substantial duplicate prose across all 50 audited pages
- `git diff --check`
- `mdbook build`